### PR TITLE
temporarily bootstrap virtualenv instead of installing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 GlyphData.xml
-env
+venv

--- a/build.sh
+++ b/build.sh
@@ -12,21 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# stop script execution if any command returns an error
+set -e
+
 source util.sh
 
+# local folder containing the python virtual environment (default: ./venv)
+VENV="${VENV:-venv}"
+
+# Set the $PYTHON_EXE env variable to override the default "python"
+# interpreter that is used to create the virtual environment
+PYTHON_EXE="${PYTHON_EXE:-python}"
+
 setup() {
-    if [[ ! $(python -m pip) ]]; then
-        if [[ ! $(sudo python -m ensurepip) ]]; then
-            echo 'You need to manually install pip.'
-            exit 1
-        fi
+    # create virtual environment if it does not exist yet
+    if [ ! -d "$VENV" ]; then
+        bootstrap_virtualenv $PYTHON_EXE $VENV
     fi
-    pip install --user virtualenv
-    python -m virtualenv env
-    source env/bin/activate
-    pip install --upgrade -r Lib/fontmake/requirements.txt
-    cd Lib/fontmake
-    pip install .
+
+    # install/update fontmake and it dependencies inside the virtual env
+    source ${VENV}/bin/activate
+    pip install --upgrade -r Lib/fontmake/requirements.txt Lib/fontmake
     deactivate
 }
 
@@ -39,7 +45,7 @@ build_all() {
 }
 
 build_one() {
-    source env/bin/activate
+    source ${VENV}/bin/activate
     case "$1" in
         *.plist)
             build_plist "$1" 'otf' 'ttf'

--- a/util.sh
+++ b/util.sh
@@ -13,6 +13,41 @@
 # limitations under the License.
 
 ################################################################################
+# Temporarily download virtualenv package from PyPI and run with arguments.
+# Arguments:
+#     The Python interpreter to use to create the new virtual environment.
+#     The destination folder for the new virtual environment.
+#     Extra arguments to pass on to virtualenv script.
+################################################################################
+function bootstrap_virtualenv() {
+    if [ $# -lt 2 ]; then
+        echo "usage: bootstrap_virtualenv PYTHON_EXE DEST_DIR [OPTIONS]"
+        exit 2
+    fi
+
+    venv_version="15.1.0"
+    venv_package_dir="virtualenv-${venv_version}"
+    venv_tarball="${venv_package_dir}.tar.gz"
+
+    python_exe="$1"
+    dest_dir="$2"
+    shift 2
+    options="$@"
+
+    # print commands as they are executed
+    set -x
+    # download the virtualenv package from PyPI
+    curl -LO "https://pypi.org/packages/source/v/virtualenv/${venv_tarball}"
+    tar xzf $venv_tarball
+    # create a new virtual environment
+    "$python_exe" ${venv_package_dir}/virtualenv.py $options "$dest_dir"
+    # clean up temporary files
+    rm -rf $venv_package_dir $venv_tarball
+    # turn off commands echoing
+    { set +x; } 2> /dev/null
+}
+
+################################################################################
 # Build from Glyphs source.
 # Arguments:
 #     Path to Glyphs source.


### PR DESCRIPTION
The `virtualenv` module is also a standalone script which can be run as is directly from its source distribution.

Instead of calling `ensurepip` (which is not guaranteed to be present, e.g. see Debian/Ubuntu), or forcing users to install `virtualenv` to their global/user site-packages, we can simply `curl` the virtualenv package from PyPI, untar it locally and run it from there, and clean it up once the new virtual environment is generated.

This method will work on any python interpreter, whether or not a user has `sudo` access or pip/virtualenv are already installed or not.

I also modified the make setup target so that one can override the default "python" executable through the `$PYTHON_EXE` environment variable. E.g. to use `python3`:

`make PYTHON_EXE=python3 ...`

The destination of the virtual environment can also be changed though the $VENV variable. This defaults to `venv` instead of `env`, to avoid confusing it with the `/usr/bin/env`.

@jamesgk PTAL, thanks.