### PR TITLE
[setup] don't pip install --upgrade fontmake; just pip install

### DIFF
--- a/build
+++ b/build
@@ -42,7 +42,7 @@ function setup() {
     # ensure fontmake submodule is up-to-date
     git submodule update --init
     pip install --upgrade -r scripts/fontmake/requirements.txt
-    pip install --upgrade scripts/fontmake
+    pip install scripts/fontmake
     deactivate
 }
 


### PR DESCRIPTION
The default pip upgrade strategy is "eager", which means dependencies
are upgraded regardless of whether the currently installed version
satisfies the requirements of the upgraded package(s).

This make the setup undeterministic (as it dependes on what is currently
latest available versions on PyPI), and risks failing when newer
versions of the dependencies break the API.

We use requirements.txt to pin down fontmake's dependencies to specific
versions, and use git submodule to pin down fontmake's version itself.

Fixes https://github.com/googlei18n/noto-source/issues/72