### PR TITLE
Update Armenian version numbers for release.

### DIFF
--- a/src/NotoSansAdlamUnjoined/NotoSansAdlamUnjoined-MM.glyphs
+++ b/src/NotoSansAdlamUnjoined/NotoSansAdlamUnjoined-MM.glyphs
@@ -359,7 +359,7 @@ zal_adlam.medi
 },
 {
 name = versionString;
-value = "Version 1.900\012";
+value = "Version 1.900";
 },
 {
 name = unicodeRanges;

--- a/src/NotoSansArmenian-MM.glyphs
+++ b/src/NotoSansArmenian-MM.glyphs
@@ -133,7 +133,7 @@ value = "This Font Software is licensed under the SIL Open Font License, Version
 },
 {
 name = versionString;
-value = "Version 1.902";
+value = "Version 2.040";
 },
 {
 name = "Has WWS Names";
@@ -43394,5 +43394,5 @@ GSDimensionPlugin.Dimensions = {
 };
 };
 versionMajor = 2;
-versionMinor = 902;
+versionMinor = 40;
 }

--- a/src/NotoSerifArmenian-MM.glyphs
+++ b/src/NotoSerifArmenian-MM.glyphs
@@ -133,7 +133,7 @@ value = "This Font Software is licensed under the SIL Open Font License, Version
 },
 {
 name = versionString;
-value = "Version 1.901";
+value = "Version 2.040";
 },
 {
 name = "Has WWS Names";
@@ -52780,5 +52780,5 @@ manufacturer = "Monotype Imaging Inc.";
 manufacturerURL = "http://www.google.com/get/noto/";
 unitsPerEm = 1000;
 versionMajor = 2;
-versionMinor = 901;
+versionMinor = 40;
 }


### PR DESCRIPTION
Previously these were 2.900+, because the phase 2 versions had major
versions of 2.

This seems like a good time to unify the major version numbering to be
consistent across the noto phase, so we will keep the major version at
2 but bump the minor.  The minor of 040 was chosen so there's a bump
in the second digit, since we're also converting to a three-digit minor
with this phase of Noto.