### PR TITLE
do not attempt to interpolate Nastaliq Urdu

### DIFF
--- a/src/NotoNastaliqUrdu/NotoNastaliqUrdu-MM.glyphs
+++ b/src/NotoNastaliqUrdu/NotoNastaliqUrdu-MM.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "998";
+.appVersion = "1060";
 copyright = "Copyright 2017 Google Inc. All Rights Reserved.";
 customParameters = (
 {
@@ -1442,6 +1442,14 @@ value = (
 "2",
 "4"
 );
+},
+{
+name = openTypeOS2WeightClass;
+value = 400;
+},
+{
+name = openTypeOS2WidthClass;
+value = 5;
 }
 );
 descender = -596;
@@ -1522,6 +1530,14 @@ value = (
 "2",
 "4"
 );
+},
+{
+name = openTypeOS2WeightClass;
+value = 700;
+},
+{
+name = openTypeOS2WidthClass;
+value = 5;
 }
 );
 descender = -596;

--- a/util.sh
+++ b/util.sh
@@ -40,8 +40,10 @@ function build_plist() {
     else
         fontmake -g "$glyphs" -o "${@:2}" --mti-source "$1"\
             --no-production-names
-        fontmake -g "$glyphs" -o "${@:2}" -i --interpolate-binary-layout\
-            --no-production-names
+        if [ "$(should_interpolate "$1")" == "yes" ]; then
+            fontmake -g "$glyphs" -o "${@:2}" -i --interpolate-binary-layout\
+                --no-production-names
+        fi
     fi
 }
 
@@ -117,6 +119,17 @@ function family_from_plist() {
             ;;
         *)
             echo ''
+            ;;
+    esac
+}
+
+function should_interpolate() {
+    case "$1" in
+        */NotoNastaliqUrdu-MM.plist)
+            echo 'no'
+            ;;
+        *)
+            echo 'yes'
             ;;
     esac
 }

--- a/util.sh
+++ b/util.sh
@@ -40,7 +40,7 @@ function build_plist() {
     else
         fontmake -g "$glyphs" -o "${@:2}" --mti-source "$1"\
             --no-production-names
-        if [ "$(should_interpolate "$1")" == "yes" ]; then
+        if should_interpolate "$1"; then
             fontmake -g "$glyphs" -o "${@:2}" -i --interpolate-binary-layout\
                 --no-production-names
         fi
@@ -126,10 +126,10 @@ function family_from_plist() {
 function should_interpolate() {
     case "$1" in
         */NotoNastaliqUrdu-MM.plist)
-            echo 'no'
+            false
             ;;
         *)
-            echo 'yes'
+            true
             ;;
     esac
 }


### PR DESCRIPTION
Fixes a compilation issue reported at https://github.com/googlei18n/fontmake/issues/352

NotoNastaliqUrdu-MM.glyphs does not have interpolatable outlines or GPOS, so it doesn't make sense to call fontmake with -i or --interpolate-binary-layout options in that case.
We can build static OTFs and TTFs straight from the master UFOs.

The only thing that distinguishes the instances in NotoNastaliqUrdu-MM.glyphs from the respective masters is that in Glyphs.app only the instances have OS/2 Weight and Width clearly defined, whereas masters do not.

We work around this by setting `openTypeOS2WeightClass` and `openTypeOS2WidthClass` custom parameters ourselves directly on the _masters_. Even though in Glyphs.app these will appear greyed out (as they are not normally assigned to masters but to instances), glyphsLib will read and apply correctly to the generated UFO masters.

/cc @brawer 