### PR TITLE
Add Noto Sans Syriac

### DIFF
--- a/src/NotoSansSyriac-MM.glyphs
+++ b/src/NotoSansSyriac-MM.glyphs
@@ -1,0 +1,54393 @@
+{
+.appVersion = "1060";
+classes = (
+{
+code = "uni0710 uni0710.Fina1 uni0710.Medi2 uni0712 uni0713 uni0713.Fina uni0713.Medi uni0714 uni0714.Fina uni0714.Medi uni071A uni071B uni071C uni071D uni071F uni0720 uni0721 uni0722 uni0723 uni0724 uni0725 uni0726 uni0727 uni0729 uni072B uni072D uni072E uni072E.Fina uni072E.Medi uni074E uni074F";
+name = aalt1;
+},
+{
+code = "uni0713.Init uni0714.Init uni0715 uni0716 uni0717 uni0718 uni0719 uni071B.Medi uni071B.Init uni071C.Medi uni071C.Init uni071D.Medi uni071D.Init uni0720.Medi uni0720.Init uni0722.Fina uni0722.Medi uni0722.Init uni0723.Fina uni0728 uni072A uni072C uni072E.Init uni072F uni074D uni074F.Medi uni074F.Init uni070F uni0741 uni0742 parenleft parenright SAM4xout SAM12xout SAM18xout";
+name = aalt2;
+},
+{
+code = "uni0713.InitLong uni0714.InitLong uni0715.Fina uni0716.Fina uni0717.Fina uni0718.Fina uni0719.Fina uni071B.MediLongG uni071B.InitLongG uni071C.MediLongG uni071C.InitLongG uni071D.MediB uni071D.InitB uni0720.MediB uni0720.InitB uni0722.FinaSoft uni0722.MediB uni0722.InitB uni0724.Fina uni0728.Fina uni072A.Fina uni072C.Fina uni072E.InitLong uni072F.Fina uni074D.Fina uni074F.MediB uni074F.InitB uni070F.blank uni030A uni0325 parenleft.alt parenright.alt SAM4out SAM12out SAM18out";
+name = aalt3;
+},
+{
+code = "uni0712.Medi uni0712.Init uni0713.Medi uni0713.Init uni0714.Medi uni0714.Init uni0721.Medi uni0721.Init uni0722.Medi uni0722.Init uni0726.Medi uni0726.Init uni072B.Medi uni072B.Init uni072D.Medi uni072D.Init uni072E.Medi uni072E.Init uni0713.MediWide uni0714.MediWide uni072E.MediWide uni0713.MediWide2 uni0714.MediWide2 uni072E.MediWide2 uni0713.MediLong uni0713.InitLong uni0714.MediLong uni0714.InitLong uni072E.MediLong uni072E.InitLong";
+name = calt10;
+},
+{
+code = "uni0711 uni0730 uni0733 uni0735 uni0736 uni073A uni073D uni073F uni0740 uni0743 uni0745 uni0747 uni0749 uni074A uni0303 uni0304 uni0307 uni0308 uni064B uni064C uni064E uni064F uni0651 uni0652 uni0653 uni0654 uni0670 FC5E FC5F uni064B0651 FC60 FC61 FC62 FC63 uni0654064B uni0654064E uni0654064C uni0654064F uni06540652 uni0732.above";
+name = calt11;
+},
+{
+code = "uni0711 uni0730 uni0731 uni0733 uni0734 uni0735 uni0736 uni0737 uni0738 uni0739 uni073A uni073B uni073C uni073D uni073E uni073F uni0740 uni0743 uni0744 uni0745 uni0746 uni0747 uni0748 uni0749 uni074A uni0303 uni0304 uni0307 uni0308 uni0323 uni0324 uni032D uni032E uni0330 uni0331 uni064B uni064C uni064D uni064E uni064F uni0650 uni0651 uni0652 uni0653 uni0654 uni0655 uni0670 FC5E FC5F uni064B0651 FC60 FC61 FC62 FC63 uni0654064B uni0654064E uni0654064C uni0654064F uni06540652 uni06550650 uni0655064D uni0732.above uni0732.below";
+name = calt12;
+},
+{
+code = "uni0710 uni0710.Fina3 uni0710.Fina2 uni0710.Fina1 uni0710.Medi2 uni0712 uni0712.Fina uni0712.Medi uni0712.Init uni0713 uni0713.Fina uni0713.Medi uni0713.Init uni0714 uni0714.Fina uni0714.Medi uni0714.Init uni0715 uni0715.Fina uni0716 uni0716.Fina uni0717 uni0717.Fina uni0718 uni0718.Fina uni0719 uni0719.Fina uni071A uni071A.Fina uni071A.Medi uni071A.Init uni071B uni071B.Fina uni071B.Medi uni071B.Init uni071C uni071C.Fina uni071C.Medi uni071C.Init uni071D uni071D.Fina uni071D.Medi uni071D.Init uni071E uni071F uni071F.Fina uni071F.Medi uni071F.Init uni0720 uni0720.Fina uni0720.Medi uni0720.Init uni0721 uni0721.Fina uni0721.Medi uni0721.Init uni0722 uni0722.Fina uni0722.Medi uni0722.Init uni0723 uni0723.Fina uni0723.Medi uni0723.Init uni0724 uni0724.Fina uni0724.Medi uni0724.Init uni0725 uni0725.Fina uni0725.Medi uni0725.Init uni0726 uni0726.Fina uni0726.Medi uni0726.Init uni0727 uni0727.Fina uni0727.Medi uni0727.Init uni0728 uni0728.Fina uni0729 uni0729.Fina uni0729.Medi uni0729.Init uni072A uni072A.Fina uni072B uni072B.Fina uni072B.Medi uni072B.Init uni072C uni072C.Fina uni072D uni072D.Fina uni072D.Medi uni072D.Init uni072E uni072E.Fina uni072E.Medi uni072E.Init uni072F uni072F.Fina uni074D uni074D.Fina uni074E uni074E.Fina uni074E.Medi uni074E.Init uni074F uni074F.Fina uni074F.Medi uni074F.Init uni0621 uni0640 uni072Auni0308.Isol uni072Auni0308.Fina uni0713.FinaWide uni0713.MediWide uni0714.FinaWide uni0714.MediWide uni072E.FinaWide uni072E.MediWide uni0713.FinaWide2 uni0713.MediWide2 uni0714.FinaWide2 uni0714.MediWide2 uni072E.FinaWide2 uni072E.MediWide2 uni0710.Fina1wideY uni0710.Fina1wideX uni0710.Medi2wideY uni0710.Medi2wideX uni071B.MediLongG uni071B.InitLongG uni071C.MediLongG uni071C.InitLongG uni0713.MediLong uni0713.InitLong uni0714.MediLong uni0714.InitLong uni072E.MediLong uni072E.InitLong uni0720.MediB uni0720.InitB uni0722.InitB uni0722.MediB uni071D.InitB uni071D.MediB uni074F.MediB uni074F.InitB uni0722.FinaSoft";
+name = calt13;
+},
+{
+code = "uni071D.Medi uni071D.Init uni0722.Medi uni0722.Init uni074F.Medi uni074F.Init";
+name = calt1;
+},
+{
+code = "uni071B.Medi uni071B.Init uni071C.Medi uni071C.Init uni0720.Medi uni0720.Init";
+name = calt2;
+},
+{
+code = "uni071B.Medi uni071B.Init uni071C.Medi uni071C.Init uni0720.Medi uni0720.Init uni074F.Medi uni074F.Init";
+name = calt3;
+},
+{
+code = "uni071D.Medi uni071D.Init uni0720.Medi uni0720.Init uni0722.Medi uni0722.Init uni074F.Medi uni074F.Init";
+name = calt4;
+},
+{
+code = "uni0713.Fina uni0713.Medi uni0714.Fina uni0714.Medi uni072E.Fina uni072E.Medi uni0713.MediLong uni0714.MediLong uni072E.MediLong";
+name = calt5;
+},
+{
+code = "uni0719.Fina uni071B.Fina uni071B.Medi uni071C.Fina uni071C.Medi uni071F.Fina uni0722.Fina uni071B.MediLongG uni071C.MediLongG";
+name = calt6;
+},
+{
+code = "uni0713.Medi uni0713.Init uni0714.Medi uni0714.Init uni072E.Medi uni072E.Init uni0713.MediWide uni0714.MediWide uni072E.MediWide uni0713.MediWide2 uni0714.MediWide2 uni072E.MediWide2 uni0713.MediLong uni0713.InitLong uni0714.MediLong uni0714.InitLong uni072E.MediLong uni072E.InitLong";
+name = calt7;
+},
+{
+code = "uni0712.Medi uni0712.Init uni071A.Medi uni071A.Init uni071F.Medi uni071F.Init uni0725.Medi uni0725.Init uni0726.Medi uni0726.Init uni0727.Medi uni0727.Init uni0729.Medi uni0729.Init uni072B.Medi uni072B.Init uni072D.Medi uni072D.Init uni074E.Medi uni074E.Init";
+name = calt8;
+},
+{
+code = "uni0731 uni0734 uni0737 uni0738 uni0739 uni073B uni073C uni073E uni0744 uni0746 uni0748 uni0323 uni0324 uni032D uni032E uni0330 uni0331 uni064D uni0650 uni0655 uni0732.below";
+name = calt9;
+},
+{
+code = "uni0715 uni0715.Fina uni0716 uni0716.Fina uni0726.Medi uni0726.Init uni072A uni072A.Fina uni072Auni0308.Isol uni072Auni0308.Fina";
+name = class151;
+},
+{
+code = "uni0731 uni0734 uni0737 uni073B uni073E uni0744 uni0746 uni0748";
+name = class162;
+},
+{
+code = "uni0710 uni0710.Fina3 uni0710.Fina2 uni0710.Fina1 uni0710.Medi2 uni0717 uni0717.Fina uni0710.Fina1wideY uni0710.Fina1wideX uni0710.Medi2wideY uni0710.Medi2wideX";
+name = class174;
+},
+{
+code = "uni0710 uni0710.Fina3 uni0710.Fina2 uni0710.Fina1 uni0710.Medi2 uni0712 uni0712.Fina uni0712.Medi uni0712.Init uni0713 uni0713.Fina uni0713.Medi uni0713.Init uni0714 uni0714.Fina uni0714.Medi uni0714.Init uni0715 uni0715.Fina uni0716 uni0716.Fina uni0717 uni0717.Fina uni0718 uni0718.Fina uni0719 uni0719.Fina uni071A uni071A.Fina uni071A.Medi uni071A.Init uni071B uni071B.Fina uni071B.Medi uni071B.Init uni071C uni071C.Fina uni071C.Medi uni071C.Init uni071D uni071D.Fina uni071D.Medi uni071D.Init uni071F uni071F.Fina uni071F.Medi uni071F.Init uni0720 uni0720.Fina uni0720.Medi uni0720.Init uni0721 uni0721.Fina uni0721.Medi uni0721.Init uni0722 uni0722.Fina uni0722.Medi uni0722.Init uni0723 uni0723.Fina uni0723.Medi uni0723.Init uni0724 uni0724.Fina uni0724.Medi uni0724.Init uni0725 uni0725.Fina uni0725.Medi uni0725.Init uni0726 uni0726.Fina uni0726.Medi uni0726.Init uni0727 uni0727.Fina uni0727.Medi uni0727.Init uni0728 uni0728.Fina uni0729 uni0729.Fina uni0729.Medi uni0729.Init uni072A uni072A.Fina uni072B uni072B.Fina uni072B.Medi uni072B.Init uni072C uni072C.Fina uni072D uni072D.Fina uni072D.Medi uni072D.Init uni072E uni072E.Fina uni072E.Medi uni072E.Init uni072F uni072F.Fina uni074D uni074D.Fina uni074E uni074E.Fina uni074E.Medi uni074E.Init uni074F uni074F.Fina uni074F.Medi uni074F.Init uni0621 uni0640 uni072Auni0308.Isol uni072Auni0308.Fina uni0713.FinaWide uni0713.MediWide uni0714.FinaWide uni0714.MediWide uni072E.FinaWide uni072E.MediWide uni0713.FinaWide2 uni0713.MediWide2 uni0714.FinaWide2 uni0714.MediWide2 uni072E.FinaWide2 uni072E.MediWide2 uni0710.Fina1wideY uni0710.Fina1wideX uni0710.Medi2wideY uni0710.Medi2wideX uni071B.MediLongG uni071B.InitLongG uni071C.MediLongG uni071C.InitLongG uni0713.MediLong uni0713.InitLong uni0714.MediLong uni0714.InitLong uni072E.MediLong uni072E.InitLong uni0720.MediB uni0720.InitB uni0722.InitB uni0722.MediB uni071D.InitB uni071D.MediB uni074F.MediB uni074F.InitB uni0722.FinaSoft";
+name = class1;
+},
+{
+code = "uni0710 uni0710.Fina3 uni0710.Fina2 uni0710.Fina1 uni0710.Medi2 uni0712 uni0712.Fina uni0712.Medi uni0712.Init uni0713.Fina uni0713.Medi uni0713.Init uni0714.Fina uni0714.Medi uni0714.Init uni0715 uni0715.Fina uni0716 uni0716.Fina uni0717 uni0717.Fina uni0718 uni0718.Fina uni0719 uni0719.Fina uni071A uni071A.Fina uni071A.Medi uni071A.Init uni071B.Medi uni071B.Init uni071C.Medi uni071C.Init uni071D uni071D.Fina uni071D.Medi uni071D.Init uni071F uni071F.Fina uni071F.Medi uni071F.Init uni0720 uni0720.Fina uni0720.Medi uni0720.Init uni0721 uni0721.Fina uni0721.Medi uni0721.Init uni0722 uni0722.Fina uni0722.Medi uni0722.Init uni0723 uni0723.Fina uni0723.Medi uni0723.Init uni0724 uni0724.Fina uni0724.Medi uni0724.Init uni0725 uni0725.Fina uni0725.Medi uni0725.Init uni0726 uni0726.Fina uni0726.Medi uni0726.Init uni0727 uni0727.Fina uni0727.Medi uni0727.Init uni0728 uni0728.Fina uni0729 uni0729.Fina uni0729.Medi uni0729.Init uni072A uni072A.Fina uni072B uni072B.Fina uni072B.Medi uni072B.Init uni072C uni072C.Fina uni072D uni072D.Fina uni072D.Medi uni072D.Init uni072E.Fina uni072E.Medi uni072E.Init uni072F uni072F.Fina uni074D uni074D.Fina uni074E uni074E.Fina uni074E.Medi uni074E.Init uni074F uni074F.Fina uni074F.Medi uni074F.Init uni0621 uni0640 uni072Auni0308.Isol uni072Auni0308.Fina uni0713.MediWide uni0714.MediWide uni072E.MediWide uni0713.MediWide2 uni0714.MediWide2 uni072E.MediWide2 uni071B.MediLongG uni071B.InitLongG uni071C.MediLongG uni071C.InitLongG uni0713.MediLong uni0713.InitLong uni0714.MediLong uni0714.InitLong uni072E.MediLong uni072E.InitLong uni0720.MediB uni0720.InitB uni0722.InitB uni0722.MediB uni071D.InitB uni071D.MediB uni074F.MediB uni074F.InitB uni0722.FinaSoft";
+name = class220;
+},
+{
+code = "uni0731 uni0734 uni0737 uni0738 uni0739 uni073B uni073C uni073E uni0744 uni0746 uni0748 uni0323 uni0324 uni032D uni032E uni0330 uni0331 uni064D uni0650 uni0655 uni06550650 uni0655064D uni0732.below";
+name = class2;
+},
+{
+code = "uni0712 uni0712.Fina uni0712.Medi uni0712.Init uni0713 uni0713.Fina uni0713.Medi uni0713.Init uni0715 uni0715.Fina uni0716 uni0716.Fina uni071F uni071F.Fina uni071F.Medi uni071F.Init uni0726 uni0726.Fina uni0726.Medi uni0726.Init uni072C uni072C.Fina uni0713.FinaWide uni0713.MediWide uni0713.FinaWide2 uni0713.MediWide2 uni0713.MediLong uni0713.InitLong";
+name = class5;
+},
+{
+code = "uni0710.Fina1 uni0710.Medi2 uni0713.Medi uni0713.Init uni0714.Medi uni0714.Init uni071B.Medi uni071B.Init uni071C.Medi uni071C.Init uni0720.Medi uni0720.Init uni072E.Medi uni072E.Init";
+name = class834;
+},
+{
+code = "uni0710.Fina1wideX uni0710.Medi2wideX uni0713.MediLong uni0713.InitLong uni0714.MediLong uni0714.InitLong uni071B.MediLongG uni071B.InitLongG uni071C.MediLongG uni071C.InitLongG uni0720.MediB uni0720.InitB uni072E.MediLong uni072E.InitLong";
+name = class835;
+},
+{
+code = "uni0710.Fina1 uni0710.Medi2 uni0713.Fina uni0713.Medi uni0714.Fina uni0714.Medi uni071B.Medi uni071B.Init uni071C.Medi uni071C.Init uni071D.Medi uni071D.Init uni0720.Medi uni0720.Init uni0722.Fina uni0722.Medi uni0722.Init uni072E.Fina uni072E.Medi uni074F.Medi uni074F.Init";
+name = class838;
+},
+{
+code = "uni0710.Fina1wideX uni0710.Medi2wideX uni0713.FinaWide uni0713.MediWide uni0714.FinaWide uni0714.MediWide uni071B.MediLongG uni071B.InitLongG uni071C.MediLongG uni071C.InitLongG uni071D.MediB uni071D.InitB uni0720.MediB uni0720.InitB uni0722.FinaSoft uni0722.MediB uni0722.InitB uni072E.FinaWide uni072E.MediWide uni074F.MediB uni074F.InitB";
+name = class839;
+},
+{
+code = "uni0713.Fina uni0713.Medi uni0714.Fina uni0714.Medi uni071D.Medi uni071D.Init uni0720.Medi uni0720.Init uni0722.Medi uni0722.Init uni072E.Fina uni072E.Medi uni074F.Medi uni074F.Init uni070F SAM4xout SAM12xout SAM18xout";
+name = class840;
+},
+{
+code = "uni0713.FinaWide2 uni0713.MediWide2 uni0714.FinaWide2 uni0714.MediWide2 uni071D.MediB uni071D.InitB uni0720.MediB uni0720.InitB uni0722.MediB uni0722.InitB uni072E.FinaWide2 uni072E.MediWide2 uni074F.MediB uni074F.InitB uni070F.blank SAM4out SAM12out SAM18out";
+name = class841;
+},
+{
+code = "uni0710 uni0712 uni0713 uni0714 uni0715 uni0716 uni0717 uni0718 uni0719 uni071A uni071B uni071C uni071D uni071F uni0720 uni0721 uni0722 uni0723 uni0724 uni0725 uni0726 uni0727 uni0728 uni0729 uni072A uni072B uni072C uni072D uni072E uni072F uni074D uni074E uni074F uni0710.loclSYRN uni0712.loclSYRN uni0713.loclSYRN uni0714.loclSYRN uni0715.loclSYRN uni0716.loclSYRN uni0717.loclSYRN uni0718.loclSYRN uni0719.loclSYRN uni071A.loclSYRN uni071B.loclSYRN uni071C.loclSYRN uni071D.loclSYRN uni071F.loclSYRN uni0720.loclSYRN uni0721.loclSYRN uni0722.loclSYRN uni0723.loclSYRN uni0724.loclSYRN uni0725.loclSYRN uni0726.loclSYRN uni0727.loclSYRN uni0728.loclSYRN uni0729.loclSYRN uni072A.loclSYRN uni072B.loclSYRN uni072C.loclSYRN uni072D.loclSYRN uni072E.loclSYRN uni072F.loclSYRN uni074D uni074E.loclSYRN uni074F.loclSYRN uni0710.loclSYRJ uni0712.loclSYRJ uni0713.loclSYRJ uni0714.loclSYRJ uni0715.loclSYRJ uni0716.loclSYRJ uni0717.loclSYRJ uni0718.loclSYRJ uni0719.loclSYRJ uni071A.loclSYRJ uni071B.loclSYRJ uni071C.loclSYRJ uni071D.loclSYRJ uni071F.loclSYRJ uni0720.loclSYRJ uni0721.loclSYRJ uni0722.loclSYRJ uni0723.loclSYRJ uni0724.loclSYRJ uni0725.loclSYRJ uni0726.loclSYRJ uni0728.loclSYRJ uni0729.loclSYRJ uni072A.loclSYRJ uni072B.loclSYRJ uni072C.loclSYRJ";
+name = fina1;
+},
+{
+code = "uni0710.Fina1 uni0712.Fina uni0713.Fina uni0714.Fina uni0715.Fina uni0716.Fina uni0717.Fina uni0718.Fina uni0719.Fina uni071A.Fina uni071B.Fina uni071C.Fina uni071D.Fina uni071F.Fina uni0720.Fina uni0721.Fina uni0722.Fina uni0723.Fina uni0724.Fina uni0725.Fina uni0726.Fina uni0727.Fina uni0728.Fina uni0729.Fina uni072A.Fina uni072B.Fina uni072C.Fina uni072D.Fina uni072E.Fina uni072F.Fina uni074D.Fina uni074E.Fina uni074F.Fina uni0710.loclSYRN.Fina1 uni0712.loclSYRN.Fina uni0713.loclSYRN.Fina uni0714.loclSYRN.Fina uni0715.loclSYRN.Fina uni0716.loclSYRN.Fina uni0717.loclSYRN.Fina uni0718.loclSYRN.Fina uni0719.loclSYRN.Fina uni071A.loclSYRN.Fina uni071B.loclSYRN.Fina uni071C.loclSYRN.Fina uni071D.loclSYRN.Fina uni071F.loclSYRN.Fina uni0720.loclSYRN.Fina uni0721.loclSYRN.Fina uni0722.loclSYRN.Fina uni0723.loclSYRN.Fina uni0724.loclSYRN.Fina uni0725.loclSYRN.Fina uni0726.loclSYRN.Fina uni0727.loclSYRN.Fina uni0728.loclSYRN.Fina uni0729.loclSYRN.Fina uni072A.loclSYRN.Fina uni072B.loclSYRN.Fina uni072C.loclSYRN.Fina uni072D.loclSYRN.Fina uni072E.loclSYRN.Fina uni072F.loclSYRN.Fina uni074D.Fina uni074E.loclSYRN.Fina uni074F.loclSYRN.Fina uni0710.loclSYRJ.Fina1 uni0712.loclSYRJ.Fina uni0713.loclSYRJ.Fina uni0714.loclSYRJ.Fina uni0715.loclSYRJ.Fina uni0716.loclSYRJ.Fina uni0717.loclSYRJ.Fina uni0718.loclSYRJ.Fina uni0719.loclSYRJ.Fina uni071A.loclSYRJ.Fina uni071B.loclSYRJ.Fina uni071C.loclSYRJ.Fina uni071D.loclSYRJ.Fina uni071F.loclSYRJ.Fina uni0720.loclSYRJ.Fina uni0721.loclSYRJ.Fina uni0722.loclSYRJ.Fina uni0723.loclSYRJ.Fina uni0724.loclSYRJ.Fina uni0725.loclSYRJ.Fina uni0726.loclSYRJ.Fina uni0728.loclSYRJ.Fina uni0729.loclSYRJ.Fina uni072A.loclSYRJ.Fina uni072B.loclSYRJ.Fina uni072C.loclSYRJ.Fina";
+name = fina2;
+},
+{
+code = "uni0712 uni0713 uni0714 uni071A uni071B uni071C uni071D uni071F uni0720 uni0721 uni0722 uni0723 uni0724 uni0725 uni0726 uni0727 uni0729 uni072B uni072D uni072E uni074E uni074F uni0712.loclSYRN uni0713.loclSYRN uni0714.loclSYRN uni071A.loclSYRN uni071B.loclSYRN uni071C.loclSYRN uni071D.loclSYRN uni071F.loclSYRN uni0720.loclSYRN uni0721.loclSYRN uni0722.loclSYRN uni0723.loclSYRN uni0724.loclSYRN uni0725.loclSYRN uni0726.loclSYRN uni0727.loclSYRN uni0729.loclSYRN uni072B.loclSYRN uni072D.loclSYRN uni072E.loclSYRN uni074E.loclSYRN uni074F.loclSYRN uni0712.loclSYRJ uni0713.loclSYRJ uni0714.loclSYRJ uni071A.loclSYRJ uni071B.loclSYRJ uni071C.loclSYRJ uni071D.loclSYRJ uni071F.loclSYRJ uni0720.loclSYRJ uni0721.loclSYRJ uni0722.loclSYRJ uni0723.loclSYRJ uni0724.loclSYRJ uni0725.loclSYRJ uni0726.loclSYRJ uni0729.loclSYRJ uni072B.loclSYRJ";
+name = init1;
+},
+{
+code = "uni0712.Init uni0713.Init uni0714.Init uni071A.Init uni071B.Init uni071C.Init uni071D.Init uni071F.Init uni0720.Init uni0721.Init uni0722.Init uni0723.Init uni0724.Init uni0725.Init uni0726.Init uni0727.Init uni0729.Init uni072B.Init uni072D.Init uni072E.Init uni074E.Init uni074F.Init uni0712.loclSYRN.Init uni0713.loclSYRN.Init uni0714.loclSYRN.Init uni071A.loclSYRN.Init uni071B.loclSYRN.Init uni071C.loclSYRN.Init uni071D.loclSYRN.Init uni071F.loclSYRN.Init uni0720.loclSYRN.Init uni0721.loclSYRN.Init uni0722.loclSYRN.Init uni0723.loclSYRN.Init uni0724.loclSYRN.Init uni0725.loclSYRN.Init uni0726.loclSYRN.Init uni0727.loclSYRN.Init uni0729.loclSYRN.Init uni072B.loclSYRN.Init uni072D.loclSYRN.Init uni072E.loclSYRN.Init uni074E.loclSYRN.Init uni074F.loclSYRN.Init uni0712.loclSYRJ.Init uni0713.loclSYRJ.Init uni0714.loclSYRJ.Init uni071A.loclSYRJ.Init uni071B.loclSYRJ.Init uni071C.loclSYRJ.Init uni071D.loclSYRJ.Init uni071F.loclSYRJ.Init uni0720.loclSYRJ.Init uni0721.loclSYRJ.Init uni0722.loclSYRJ.Init uni0723.loclSYRJ.Init uni0724.loclSYRJ.Init uni0725.loclSYRJ.Init uni0726.loclSYRJ.Init uni0729.loclSYRJ.Init uni072B.loclSYRJ.Init";
+name = init2;
+},
+{
+code = "uni0712.Medi uni0713.Medi uni0714.Medi uni071A.Medi uni071B.Medi uni071C.Medi uni071D.Medi uni071F.Medi uni0720.Medi uni0721.Medi uni0722.Medi uni0723.Medi uni0724.Medi uni0725.Medi uni0726.Medi uni0727.Medi uni0729.Medi uni072B.Medi uni072D.Medi uni072E.Medi uni074E.Medi uni074F.Medi uni0712.loclSYRN.Medi uni0713.loclSYRN.Medi uni0714.loclSYRN.Medi uni071A.loclSYRN.Medi uni071B.loclSYRN.Medi uni071C.loclSYRN.Medi uni071D.loclSYRN.Medi uni071F.loclSYRN.Medi uni0720.loclSYRN.Medi uni0721.loclSYRN.Medi uni0722.loclSYRN.Medi uni0723.loclSYRN.Medi uni0724.loclSYRN.Medi uni0725.loclSYRN.Medi uni0726.loclSYRN.Medi uni0727.loclSYRN.Medi uni0729.loclSYRN.Medi uni072B.loclSYRN.Medi uni072D.loclSYRN.Medi uni072E.loclSYRN.Medi uni074E.loclSYRN.Medi uni074F.loclSYRN.Medi uni0712.loclSYRJ.Medi uni0713.loclSYRJ.Medi uni0714.loclSYRJ.Medi uni071A.loclSYRJ.Medi uni071B.loclSYRJ.Medi uni071C.loclSYRJ.Medi uni071D.loclSYRJ.Medi uni071F.loclSYRJ.Medi uni0720.loclSYRJ.Medi uni0721.loclSYRJ.Medi uni0722.loclSYRJ.Medi uni0723.loclSYRJ.Medi uni0724.loclSYRJ.Medi uni0725.loclSYRJ.Medi uni0726.loclSYRJ.Medi uni0729.loclSYRJ.Medi uni072B.loclSYRJ.Medi";
+name = medi1;
+},
+{
+code = "colon exclam period uni0304 uni0307 uni0308 uni030A uni0320 uni0323 uni0324 uni0325 uni061B uni061F uni0621 uni0660 uni066A uni0700 uni0701 uni0702 uni0703 uni0704 uni0705 uni0706 uni0707 uni0708 uni0709 uni070A uni070B uni070D uni0710 uni0711 uni0712 uni0713 uni0714 uni0715 uni0716 uni0717 uni0718 uni0719 uni071A uni071B uni071C uni071D uni071E uni071F uni0720 uni0721 uni0722 uni0723 uni0724 uni0725 uni0726 uni0727 uni0728 uni0729 uni072A uni072B uni072C uni072D uni072E uni072F uni0730 uni0731 uni0732 uni0733 uni0734 uni0735 uni0738 uni0739 uni073C uni073D uni073E uni073F uni0740 uni0741 uni0742 uni0743 uni0744 uni0745 uni0746 uni0747 uni0748 uni074A uni074E uni074F";
+name = SYREencoded;
+},
+{
+code = "colon.loclSYRN exclam.loclSYRN period.loclSYRN uni0304.loclSYRN uni0307.loclSYRN uni0308.loclSYRN uni030A.loclSYRN uni0320.loclSYRN uni0323.loclSYRN uni0324.loclSYRN uni0325.loclSYRN uni061B.loclSYRN uni061F.loclSYRN uni0621.loclSYRN uni0660.loclSYRN uni066A.loclSYRN uni0700.loclSYRN uni0701.loclSYRN uni0702.loclSYRN uni0703.loclSYRN uni0704.loclSYRN uni0705.loclSYRN uni0706.loclSYRN uni0707.loclSYRN uni0708.loclSYRN uni0709.loclSYRN uni070A.loclSYRN uni070B.loclSYRN uni070D.loclSYRN uni0710.loclSYRN uni0711.loclSYRN uni0712.loclSYRN uni0713.loclSYRN uni0714.loclSYRN uni0715.loclSYRN uni0716.loclSYRN uni0717.loclSYRN uni0718.loclSYRN uni0719.loclSYRN uni071A.loclSYRN uni071B.loclSYRN uni071C.loclSYRN uni071D.loclSYRN uni071E.loclSYRN uni071F.loclSYRN uni0720.loclSYRN uni0721.loclSYRN uni0722.loclSYRN uni0723.loclSYRN uni0724.loclSYRN uni0725.loclSYRN uni0726.loclSYRN uni0727.loclSYRN uni0728.loclSYRN uni0729.loclSYRN uni072A.loclSYRN uni072B.loclSYRN uni072C.loclSYRN uni072D.loclSYRN uni072E.loclSYRN uni072F.loclSYRN uni0730.loclSYRN uni0731.loclSYRN uni0732.loclSYRN uni0733.loclSYRN uni0734.loclSYRN uni0735.loclSYRN uni0738.loclSYRN uni0739.loclSYRN uni073C.loclSYRN uni073D.loclSYRN uni073E.loclSYRN uni073F.loclSYRN uni0740.loclSYRN uni0741.loclSYRN uni0742.loclSYRN uni0743.loclSYRN uni0744.loclSYRN uni0745.loclSYRN uni0746.loclSYRN uni0747.loclSYRN uni0748.loclSYRN uni074A.loclSYRN uni074E.loclSYRN uni074F.loclSYRN ";
+name = SYRNencoded;
+},
+{
+code = "colon.loclSYRJ exclam.loclSYRJ period.loclSYRJ uni0304.loclSYRJ uni0307.loclSYRJ uni0308.loclSYRJ uni030A.loclSYRJ uni0320.loclSYRJ uni0323.loclSYRJ uni0324.loclSYRJ uni0325.loclSYRJ uni061B.loclSYRJ uni061F.loclSYRJ uni0621.loclSYRJ uni0660.loclSYRJ uni066A.loclSYRJ uni0700.loclSYRJ uni0701.loclSYRJ uni0702.loclSYRJ uni0703.loclSYRJ uni0704.loclSYRJ uni0705.loclSYRJ uni0706.loclSYRJ uni0707.loclSYRJ uni0708.loclSYRJ uni0709.loclSYRJ uni070A.loclSYRJ uni070B.loclSYRJ uni070D.loclSYRJ uni0710.loclSYRJ uni0711.loclSYRJ uni0712.loclSYRJ uni0713.loclSYRJ uni0714.loclSYRJ uni0715.loclSYRJ uni0716.loclSYRJ uni0717.loclSYRJ uni0718.loclSYRJ uni0719.loclSYRJ uni071A.loclSYRJ uni071B.loclSYRJ uni071C.loclSYRJ uni071D.loclSYRJ uni071E.loclSYRJ uni071F.loclSYRJ uni0720.loclSYRJ uni0721.loclSYRJ uni0722.loclSYRJ uni0723.loclSYRJ uni0724.loclSYRJ uni0725.loclSYRJ uni0726.loclSYRJ uni0727.loclSYRJ uni0728.loclSYRJ uni0729.loclSYRJ uni072A.loclSYRJ uni072B.loclSYRJ uni072C.loclSYRJ uni072D.loclSYRJ uni072E.loclSYRJ uni072F.loclSYRJ uni0730.loclSYRJ uni0731.loclSYRJ uni0732.loclSYRJ uni0733.loclSYRJ uni0734.loclSYRJ uni0735.loclSYRJ uni0738.loclSYRJ uni0739.loclSYRJ uni073C.loclSYRJ uni073D.loclSYRJ uni073E.loclSYRJ uni073F.loclSYRJ uni0740.loclSYRJ uni0741.loclSYRJ uni0742.loclSYRJ uni0743.loclSYRJ uni0744.loclSYRJ uni0745.loclSYRJ uni0746.loclSYRJ uni0747.loclSYRJ uni0748.loclSYRJ uni074A.loclSYRJ uni074E.loclSYRJ uni074F.loclSYRJ ";
+name = SYRJencoded;
+},
+{
+code = "uni0731.loclSYRN uni0734.loclSYRN uni0737 uni0738.loclSYRN uni0739.loclSYRN uni073B uni073C.loclSYRN uni073E.loclSYRN uni0742.loclSYRN uni0744.loclSYRN uni0746.loclSYRN uni0748.loclSYRN uni0323.loclSYRN uni0324.loclSYRN uni0325.loclSYRN uni032D uni032E uni0330 uni0331 uni064D uni0650 uni0655 uni0732.loclSYRN.below";
+name = calt11.loclSYRN;
+},
+{
+code = "uni0713.loclSYRN uni0713.loclSYRN.Fina uni0713.loclSYRN.Medi uni0713.loclSYRN.Init uni0714.loclSYRN uni0714.loclSYRN.Fina uni0714.loclSYRN.Medi uni0714.loclSYRN.Init uni071B.loclSYRN uni071B.loclSYRN.Fina uni071B.loclSYRN.Medi uni071B.loclSYRN.Init uni071C.loclSYRN uni071C.loclSYRN.Fina uni071C.loclSYRN.Medi uni071C.loclSYRN.Init uni0720.loclSYRN uni0720.loclSYRN.Fina uni0720.loclSYRN.Medi uni0720.loclSYRN.Init uni072E.loclSYRN uni072E.loclSYRN.Fina uni072E.loclSYRN.Medi uni072E.loclSYRN.Init uni0713.loclSYRN.FinaW uni0713.loclSYRN.MediW uni0714.loclSYRN.FinaW uni0714.loclSYRN.MediW uni072E.loclSYRN.FinaW uni072E.loclSYRN.MediW";
+name = calt14.loclSYRN;
+},
+{
+code = "uni0712.loclSYRN uni0712.loclSYRN.Fina uni0712.loclSYRN.Medi uni0712.loclSYRN.Init uni0713.loclSYRN uni0713.loclSYRN.Fina uni0713.loclSYRN.Medi uni0713.loclSYRN.Init uni0715.loclSYRN uni0715.loclSYRN.Fina uni0716.loclSYRN uni0716.loclSYRN.Fina uni071F.loclSYRN uni071F.loclSYRN.Fina uni071F.loclSYRN.Medi uni071F.loclSYRN.Init uni0726.loclSYRN uni0726.loclSYRN.Fina uni0726.loclSYRN.Medi uni0726.loclSYRN.Init uni072C.loclSYRN uni072C.loclSYRN.Fina uni072C.loclSYRN.MediLiga2 uni0712.loclSYRN.MediN uni0712.loclSYRN.InitN uni0713.loclSYRN.MediN uni0713.loclSYRN.InitN uni0713.loclSYRN.FinaW uni0713.loclSYRN.MediW uni0713.loclSYRN.MediWN uni0715.loclSYRN.FinaQR uni0716.loclSYRN.FinaQR uni0712.loclSYRN.FinaQR uni0712.loclSYRN.MediQR uni0726.loclSYRN.FinaQR uni0726.loclSYRN.MediQR";
+name = calt16.loclSYRN;
+},
+{
+code = "uni0711.loclSYRN uni0730.loclSYRN uni0733.loclSYRN uni0735.loclSYRN uni0736 uni073A uni073D.loclSYRN uni073F.loclSYRN uni0740.loclSYRN uni0743.loclSYRN uni0745.loclSYRN uni0747.loclSYRN uni0749 uni074A.loclSYRN uni0303 uni0304.loclSYRN uni0307.loclSYRN uni0308.loclSYRN uni064B uni064C uni064E uni064F uni0651 uni0652 uni0653 uni0654 uni0670 FC5E FC5F uni064B0651 FC60 FC61 FC62 FC63 uni0654064B uni0654064E uni0654064C uni0654064F uni06540652 uni0732.loclSYRN.above uni0735.loclSYRN.alt uni0735.loclSYRN.altC";
+name = calt17.loclSYRN;
+},
+{
+code = "uni0711.loclSYRN uni0730.loclSYRN uni0733.loclSYRN uni0735.loclSYRN uni0736 uni073A uni073D.loclSYRN uni073F.loclSYRN uni0740.loclSYRN uni0741.loclSYRN uni0743.loclSYRN uni0745.loclSYRN uni0747.loclSYRN uni0749 uni074A.loclSYRN uni0303 uni0304.loclSYRN uni0307.loclSYRN uni0308.loclSYRN uni030A.loclSYRN uni064B uni064C uni064E uni064F uni0651 uni0652 uni0653 uni0654 uni0670 FC5E FC5F uni064B0651 FC60 FC61 FC62 FC63 uni0654064B uni0654064E uni0654064C uni0654064F uni06540652 uni0732.loclSYRN.above uni0735.loclSYRN.alt uni0735.loclSYRN.altC";
+name = calt18.loclSYRN;
+},
+{
+code = "uni0725.loclSYRN uni0725.loclSYRN.Fina uni0725.loclSYRN.Medi uni0725.loclSYRN.Init uni0725.loclSYRN.MediN uni0725.loclSYRN.InitN";
+name = calt1.loclSYRN;
+},
+{
+code = "uni0713.loclSYRN.MediN uni0713.loclSYRN.InitN uni072E.loclSYRN.MediN uni072E.loclSYRN.InitN uni071B.loclSYRN.MediN uni071B.loclSYRN.InitN uni071C.loclSYRN.MediN uni071C.loclSYRN.InitN uni0720.loclSYRN.MediN uni0720.loclSYRN.InitN uni0713.loclSYRN.MediWN uni072E.loclSYRN.MediWN";
+name = calt6.loclSYRN;
+}
+);
+copyright = "Copyright (c) 2014 by Monotype Imaging Inc.. All rights reserved.";
+customParameters = (
+{
+name = licenseURL;
+value = "http://www.apache.org/licenses/LICENSE-2.0";
+},
+{
+name = description;
+value = "Designed by Monotype design team";
+},
+{
+name = trademark;
+value = "NotoSansEstrangelaKamal is a trademark of Monotype Imaging Inc..";
+},
+{
+name = license;
+value = "Licensed under the Apache License, Version 2.0";
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = openTypeOS2VendorID;
+value = GOOG;
+},
+{
+name = glyphOrder;
+value = (
+space,
+uni200C,
+uni200D,
+uni200E,
+uni200F,
+uni0710,
+uni0710.Fina3,
+uni0710.Fina2,
+uni0710.Fina1,
+uni0710.Medi2,
+uni0711,
+uni0712,
+uni0712.Fina,
+uni0712.Medi,
+uni0712.Init,
+uni0713,
+uni0713.Fina,
+uni0713.Medi,
+uni0713.Init,
+uni0714,
+uni0714.Fina,
+uni0714.Medi,
+uni0714.Init,
+uni0715,
+uni0715.Fina,
+uni0716,
+uni0716.Fina,
+uni0717,
+uni0717.Fina,
+uni0718,
+uni0718.Fina,
+uni0719,
+uni0719.Fina,
+uni071A,
+uni071A.Fina,
+uni071A.Medi,
+uni071A.Init,
+uni071B,
+uni071B.Fina,
+uni071B.Medi,
+uni071B.Init,
+uni071C,
+uni071C.Fina,
+uni071C.Medi,
+uni071C.Init,
+uni071D,
+uni071D.Fina,
+uni071D.Medi,
+uni071D.Init,
+uni071E,
+uni071F,
+uni071F.Fina,
+uni071F.Medi,
+uni071F.Init,
+uni0720,
+uni0720.Fina,
+uni0720.Medi,
+uni0720.Init,
+uni0721,
+uni0721.Fina,
+uni0721.Medi,
+uni0721.Init,
+uni0722,
+uni0722.Fina,
+uni0722.Medi,
+uni0722.Init,
+uni0723,
+uni0723.Fina,
+uni0723.Medi,
+uni0723.Init,
+uni0724,
+uni0724.Fina,
+uni0724.Medi,
+uni0724.Init,
+uni0725,
+uni0725.Fina,
+uni0725.Medi,
+uni0725.Init,
+uni0726,
+uni0726.Fina,
+uni0726.Medi,
+uni0726.Init,
+uni0727,
+uni0727.Fina,
+uni0727.Medi,
+uni0727.Init,
+uni0728,
+uni0728.Fina,
+uni0729,
+uni0729.Fina,
+uni0729.Medi,
+uni0729.Init,
+uni072A,
+uni072A.Fina,
+uni072B,
+uni072B.Fina,
+uni072B.Medi,
+uni072B.Init,
+uni072C,
+uni072C.Fina,
+uni072D,
+uni072D.Fina,
+uni072D.Medi,
+uni072D.Init,
+uni072E,
+uni072E.Fina,
+uni072E.Medi,
+uni072E.Init,
+uni072F,
+uni072F.Fina,
+uni074D,
+uni074D.Fina,
+uni074E,
+uni074E.Fina,
+uni074E.Medi,
+uni074E.Init,
+uni074F,
+uni074F.Fina,
+uni074F.Medi,
+uni074F.Init,
+uni0621,
+uni0640,
+uni0700,
+uni0701,
+uni0702,
+uni0703,
+uni0704,
+uni0705,
+uni0706,
+uni0707,
+uni0708,
+uni0709,
+uni070A,
+uni070B,
+uni070C,
+uni070D,
+uni070F,
+uni0730,
+uni0731,
+uni0732,
+uni0733,
+uni0734,
+uni0735,
+uni0736,
+uni0737,
+uni0738,
+uni0739,
+uni073A,
+uni073B,
+uni073C,
+uni073D,
+uni073E,
+uni073F,
+uni0740,
+uni0741,
+uni0742,
+uni0743,
+uni0744,
+uni0745,
+uni0746,
+uni0747,
+uni0748,
+uni0749,
+uni074A,
+uni0303,
+uni0304,
+uni0307,
+uni0308,
+uni030A,
+uni0320,
+uni0323,
+uni0324,
+uni0325,
+uni032D,
+uni032E,
+uni0330,
+uni0331,
+uni064B,
+uni064C,
+uni064D,
+uni064E,
+uni064F,
+uni0650,
+uni0651,
+uni0652,
+uni0653,
+uni0654,
+uni0655,
+uni0670,
+Wasla,
+FC5E,
+FC5F,
+uni064B0651,
+FC60,
+FC61,
+FC62,
+FC63,
+uni0654064B,
+uni0654064E,
+uni0654064C,
+uni0654064F,
+uni06540652,
+uni06550650,
+uni0655064D,
+uni0660,
+uni0661,
+uni0662,
+uni0663,
+uni0664,
+uni0665,
+uni0666,
+uni0667,
+uni0668,
+uni0669,
+uni066A,
+uni066B,
+uni066C,
+period,
+uni060C,
+uni061B,
+colon,
+uni061F,
+exclam,
+parenleft,
+parenright,
+bracketleft,
+bracketright,
+parenleft.alt,
+parenright.alt,
+guillemotleft,
+guillemotright,
+asterisk,
+plus,
+equal,
+slash,
+backslash,
+hyphen,
+degree,
+uni25CC,
+uni2670,
+uni2671,
+uni072Auni0308.Isol,
+uni072Auni0308.Fina,
+uni0713.FinaWide,
+uni0713.MediWide,
+uni0714.FinaWide,
+uni0714.MediWide,
+uni072E.FinaWide,
+uni072E.MediWide,
+uni0713.FinaWide2,
+uni0713.MediWide2,
+uni0714.FinaWide2,
+uni0714.MediWide2,
+uni072E.FinaWide2,
+uni072E.MediWide2,
+uni0710.Fina1wideY,
+uni0710.Fina1wideX,
+uni0710.Medi2wideY,
+uni0710.Medi2wideX,
+uni071B.MediLongG,
+uni071B.InitLongG,
+uni071C.MediLongG,
+uni071C.InitLongG,
+uni0713.MediLong,
+uni0713.InitLong,
+uni0714.MediLong,
+uni0714.InitLong,
+uni072E.MediLong,
+uni072E.InitLong,
+uni0720.MediB,
+uni0720.InitB,
+uni0722.InitB,
+uni0722.MediB,
+uni071D.InitB,
+uni071D.MediB,
+uni074F.MediB,
+uni074F.InitB,
+uni0722.FinaSoft,
+uni0732.above,
+uni0732.below,
+Dot1,
+Dot2slant,
+Dot3,
+DotEncl,
+Stretch,
+Stretch2,
+Stretch3,
+Stretch4,
+Stretch5,
+uni070F.blank,
+SAM4in,
+SAM8in,
+SAM4out,
+SAM12out,
+SAM18out,
+SAM4xin,
+SAM8xin,
+SAM4xout,
+SAM12xout,
+SAM18xout,
+nbspace
+);
+},
+{
+name = versionString;
+value = "Version 0.900";
+}
+);
+date = "2017-08-15 12:59:45 +0000";
+designer = "Monotype Design team";
+designerURL = "http://www.monotype.com/studio";
+disablesAutomaticAlignment = 1;
+disablesNiceNames = 1;
+familyName = "Noto Sans Syriac";
+featurePrefixes = (
+{
+code = "languagesystem DFLT dflt;\012languagesystem syrc dflt;\012languagesystem syrc SYR;\012languagesystem syrc SYRE;\012languagesystem syrc SYRN;\012languagesystem syrc SYRJ;\012";
+name = Languagesystems;
+}
+);
+features = (
+{
+code = "# default local is Estrangelo: SYRE\012script syrc;\012language SYRN; #Eastern\012sub @SYREencoded by @SYRNencoded;\012language SYRJ; #Western\012sub @SYREencoded by @SYRJencoded;\012	";
+name = locl;
+},
+{
+code = "feature init;\012  feature medi;\012  feature med2;\012  feature fina;\012  feature fin2;\012  feature fin3;\012  feature calt;\012";
+name = aalt;
+},
+{
+code = "# Glyph Composition / Decomposition\012 # DEFAULT\012lookup ccmp55 {\012    sub uni0732 by uni0732.above uni0732.below;\012    sub uni0732.loclSYRJ by uni0732.loclSYRJ.above uni0732.loclSYRJ.below;\012    sub uni0732.loclSYRN by uni0732.loclSYRN.above uni0732.loclSYRN.below;\012} ccmp55;\012lookup ccmp56 {\012lookupflag RightToLeft;\012    sub uni064E' uni0651' by FC60;\012    sub uni064B' uni0651' by uni064B0651;\012    sub uni0650' uni0651' by FC62;\012    sub uni064D' uni0651' by FC5F;\012    sub uni064F' uni0651' by FC61;\012    sub uni064C' uni0651' by FC5E;\012    sub uni0670' uni0651' by FC63;\012    sub uni064B' uni0654' by uni0654064B;\012    sub uni064E' uni0654' by uni0654064E;\012    sub uni064C' uni0654' by uni0654064C;\012    sub uni064F' uni0654' by uni0654064F;\012    sub uni0652' uni0654' by uni06540652;\012    sub uni0650' uni0655' by uni06550650;\012    sub uni064D' uni0655' by uni0655064D;\012    sub uni0651' uni064E' by FC60;\012    sub uni0651' uni064B' by uni064B0651;\012    sub uni0651' uni0650' by FC62;\012    sub uni0651' uni064D' by FC5F;\012    sub uni0651' uni064F' by FC61;\012    sub uni0651' uni064C' by FC5E;\012    sub uni0651' uni0670' by FC63;\012    sub uni0654' uni064B' by uni0654064B;\012    sub uni0654' uni064E' by uni0654064E;\012    sub uni0654' uni064C' by uni0654064C;\012    sub uni0654' uni064F' by uni0654064F;\012    sub uni0654' uni0652' by uni06540652;\012    sub uni0655' uni0650' by uni06550650;\012    sub uni0655' uni064D' by uni0655064D;\012} ccmp56;\012 script syrc; # Syriac\012lookup ccmp55;\012lookup ccmp56;\012";
+name = ccmp;
+},
+{
+code = "# Initial Forms\012 # DEFAULT\012lookupflag IgnoreMarks RightToLeft;\012    sub @init1 by @init2;\012 script syrc; # Syriac\012    sub @init1 by @init2;\012";
+name = init;
+},
+{
+code = "# Medial Forms\012 # DEFAULT\012lookupflag IgnoreMarks RightToLeft;\012    sub @init1 by @medi1;\012 script syrc; # Syriac\012    sub @init1 by @medi1;\012";
+name = medi;
+},
+{
+code = "# Medial Forms #2\012 # DEFAULT\012lookupflag IgnoreMarks RightToLeft;\012    sub uni0710 by uni0710.Medi2;\012    sub uni0710.loclSYRN by uni0710.loclSYRN.Medi2;\012    sub uni0710.loclSYRJ by uni0710.loclSYRJ.Medi2;\012 script syrc; # Syriac\012    sub uni0710 by uni0710.Medi2;\012    sub uni0710.loclSYRN by uni0710.loclSYRN.Medi2;\012    sub uni0710.loclSYRJ by uni0710.loclSYRJ.Medi2;\012";
+name = med2;
+},
+{
+code = "# Terminal Forms\012 # DEFAULT\012lookupflag IgnoreMarks RightToLeft;\012    sub @fina1 by @fina2;\012 script syrc; # Syriac\012    sub @fina1 by @fina2;\012";
+name = fina;
+},
+{
+code = "# Terminal Forms #2\012 # DEFAULT\012lookupflag IgnoreMarks RightToLeft;\012    sub uni0710 by uni0710.Fina2;\012    sub uni0710.loclSYRN by uni0710.loclSYRN.Fina2;\012    sub uni0710.loclSYRJ by uni0710.loclSYRJ.Fina2;\012 script syrc; # Syriac\012    sub uni0710 by uni0710.Fina2;\012    sub uni0710.loclSYRN by uni0710.loclSYRN.Fina2;\012    sub uni0710.loclSYRJ by uni0710.loclSYRJ.Fina2;\012";
+name = fin2;
+},
+{
+code = "# Terminal Forms #3\012 # DEFAULT\012lookupflag IgnoreMarks RightToLeft;\012    sub uni0710 by uni0710.Fina3;\012    sub uni0710.loclSYRN by uni0710.loclSYRN.Fina3;\012    sub uni0710.loclSYRJ by uni0710.loclSYRJ.Fina3;\012 script syrc; # Syriac\012    sub uni0710 by uni0710.Fina3;\012    sub uni0710.loclSYRN by uni0710.loclSYRN.Fina3;\012    sub uni0710.loclSYRJ by uni0710.loclSYRJ.Fina3;\012";
+name = fin3;
+},
+{
+code = "# Required Ligatures\012 # DEFAULT\012lookupflag RightToLeft;\012    sub uni072A uni0308 by uni072Auni0308.Isol;\012    sub uni072A.Fina uni0308 by uni072Auni0308.Fina;\012    sub uni072A.loclSYRN uni0308.loclSYRN by uni072Auni0308.loclSYRN.Isol;\012    sub uni072A.loclSYRN.Fina uni0308.loclSYRN by uni072Auni0308.loclSYRN.Fina;\012    sub uni072A.loclSYRJ uni0308.loclSYRJ by uni072Auni0308.loclSYRJ.Isol;\012    sub uni072A.loclSYRJ.Fina uni0308.loclSYRJ by uni072Auni0308.loclSYRJ.Fina;\012 script syrc; # Syriac\012    sub uni072A uni0308 by uni072Auni0308.Isol;\012    sub uni072A.Fina uni0308 by uni072Auni0308.Fina;\012    sub uni072A.loclSYRN uni0308.loclSYRN by uni072Auni0308.loclSYRN.Isol;\012    sub uni072A.loclSYRN.Fina uni0308.loclSYRN by uni072Auni0308.loclSYRN.Fina;\012    sub uni072A.loclSYRJ uni0308.loclSYRJ by uni072Auni0308.loclSYRJ.Isol;\012    sub uni072A.loclSYRJ.Fina uni0308.loclSYRJ by uni072Auni0308.loclSYRJ.Fina;\012";
+name = rlig;
+},
+{
+code = "# Contextual Alternates\012 # DEFAULT\012lookup calt66 {\012lookupflag IgnoreMarks RightToLeft;\012    sub [uni0713.Medi uni0713.Init uni0714.Medi uni0714.Init uni072E.Medi uni072E.Init]' [uni0713.Fina uni0713.Medi uni0714.Fina uni0714.Medi uni072E.Fina uni072E.Medi] by [uni0713.MediLong uni0713.InitLong uni0714.MediLong uni0714.InitLong uni072E.MediLong uni072E.InitLong];\012} calt66;\012lookup calt67 {\012    sub [uni0713.MediLong uni0714.MediLong uni072E.MediLong] [uni0713.Medi uni0714.Medi uni072E.Medi]' by [uni0713.MediLong uni0714.MediLong uni072E.MediLong];\012} calt67;\012lookup calt68 {\012    sub uni0720.Init' uni074E.Medi by uni0720.InitB;\012    sub uni0720.Init' uni074E.Fina by uni0720.InitB;\012    sub uni0720.Medi' uni074E.Medi by uni0720.MediB;\012    sub uni0720.Medi' uni074E.Fina by uni0720.MediB;\012    sub uni071B.Init' uni074E.Medi by uni071B.InitLongG;\012    sub uni071B.Init' uni074E.Fina by uni071B.InitLongG;\012    sub uni071B.Medi' uni074E.Medi by uni071B.MediLongG;\012    sub uni071B.Medi' uni074E.Fina by uni071B.MediLongG;\012    sub uni071C.Init' uni074E.Medi by uni071C.InitLongG;\012    sub uni071C.Init' uni074E.Fina by uni071C.InitLongG;\012    sub uni071C.Medi' uni074E.Medi by uni071C.MediLongG;\012    sub uni071C.Medi' uni074E.Fina by uni071C.MediLongG;\012} calt68;\012\012# SYRJ\012lookup calt54 {\012    sub uni0720.loclSYRJ.Init' [uni0710.loclSYRJ.Fina1 uni0710.loclSYRJ.Medi2] by uni0720.loclSYRJ.InitLiga;\012    sub uni0720.loclSYRJ.Medi' [uni0710.loclSYRJ.Fina1 uni0710.loclSYRJ.Medi2] by uni0720.loclSYRJ.MediLiga;\012\012} calt54;\012lookup calt55 {\012    sub [uni0720.loclSYRJ.InitLiga uni0720.loclSYRJ.MediLiga] uni0710.loclSYRJ.Fina1' by uni0710.loclSYRJ.FinaLiga;\012    sub [uni0720.loclSYRJ.InitLiga uni0720.loclSYRJ.MediLiga] uni0710.loclSYRJ.Medi2' by uni0710.loclSYRJ.MediLiga;\012} calt55;\012\012lookup calt57 {\012lookupflag RightToLeft;\012    sub @calt14.loclSYRN @calt18.loclSYRN uni0735.loclSYRN' by uni0735.loclSYRN.alt;\012    sub @calt14.loclSYRN uni0735.loclSYRN' by uni0735.loclSYRN.alt;\012    sub @calt6.loclSYRN @calt18.loclSYRN uni0735.loclSYRN' by uni0735.loclSYRN.altB;\012    sub @calt6.loclSYRN uni0735.loclSYRN' by uni0735.loclSYRN.altB;\012    sub @calt1.loclSYRN @calt18.loclSYRN uni0735.loclSYRN' by uni0735.loclSYRN.altC;\012    sub @calt1.loclSYRN uni0735.loclSYRN' by uni0735.loclSYRN.altC;\012} calt57;\012lookup calt58 {\012lookupflag RightToLeft;\012    sub @calt16.loclSYRN @calt17.loclSYRN @calt17.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN @calt17.loclSYRN @calt11.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN @calt11.loclSYRN @calt17.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN @calt17.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' @calt17.loclSYRN by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN @calt17.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' @calt11.loclSYRN by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN @calt11.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' @calt17.loclSYRN by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' @calt17.loclSYRN @calt17.loclSYRN by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' @calt17.loclSYRN @calt11.loclSYRN by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' @calt11.loclSYRN @calt17.loclSYRN by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN @calt17.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012    sub @calt16.loclSYRN [uni0741.loclSYRN uni030A.loclSYRN]' @calt17.loclSYRN by [uni0741.loclSYRN.alt uni030A.loclSYRN.alt];\012} calt58;\012lookup calt59 {\012lookupflag IgnoreMarks RightToLeft;\012    sub [uni0720.loclSYRN.Medi uni0720.loclSYRN.Init] uni0710.loclSYRN.Fina1' by uni0710.loclSYRN.FinaLiga;\012    sub [uni0720.loclSYRN.Medi uni0720.loclSYRN.Init] uni0710.loclSYRN.Medi2' by uni0710.loclSYRN.MediLiga;\012} calt59;\012lookup calt60 {\012    sub uni072C.loclSYRN.Fina uni0710.loclSYRN.Fina2' by uni0710.loclSYRN.FinaLiga2;\012} calt60;\012lookup calt61 {\012    sub uni072C.loclSYRN.Fina' uni0710.loclSYRN.FinaLiga2 by uni072C.loclSYRN.MediLiga2;\012} calt61;\012\012 script syrc; # Syriac\012lookup calt54;\012lookup calt55;\012\012lookup calt57;\012lookup calt58;\012lookup calt59;\012lookup calt60;\012lookup calt61;\012\012lookup calt66;\012lookup calt67;\012lookup calt68;\012\012";
+name = calt;
+}
+);
+fontMaster = (
+{
+ascender = 1069;
+capHeight = 714;
+customParameters = (
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = winDescent;
+value = 293;
+},
+{
+name = winAscent;
+value = 1069;
+}
+);
+descender = -293;
+id = UUID0;
+xHeight = 553;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 260;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = uni200C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-18 714 LINE",
+"-18 0 LINE",
+"18 0 LINE",
+"18 714 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 200C;
+},
+{
+glyphname = uni200D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"18 579 LINE",
+"83 512 LINE",
+"107 536 LINE",
+"23 619 LINE",
+"107 701 LINE",
+"83 725 LINE",
+"0 641 LINE",
+"-83 725 LINE",
+"-107 701 LINE",
+"-23 619 LINE",
+"-107 536 LINE",
+"-83 512 LINE",
+"-18 579 LINE",
+"-18 0 LINE",
+"18 0 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 200D;
+},
+{
+glyphname = uni200E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"104 725 LINE",
+"80 701 LINE",
+"147 637 LINE",
+"-18 637 LINE",
+"-18 0 LINE",
+"17 0 LINE",
+"17 603 LINE",
+"147 603 LINE",
+"80 539 LINE",
+"104 515 LINE",
+"210 620 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 200E;
+},
+{
+glyphname = uni200F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"17 637 LINE",
+"-147 637 LINE",
+"-81 701 LINE",
+"-104 725 LINE",
+"-210 620 LINE",
+"-104 515 LINE",
+"-81 539 LINE",
+"-147 603 LINE",
+"-18 603 LINE",
+"-18 0 LINE",
+"17 0 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 200F;
+},
+{
+glyphname = uni0710;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{429, -49}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"390 307 LINE",
+"482 310 OFFCURVE",
+"581 336 OFFCURVE",
+"686 384 CURVE SMOOTH",
+"791 433 OFFCURVE",
+"870 487 OFFCURVE",
+"922 547 CURVE",
+"869 595 LINE",
+"801 531 OFFCURVE",
+"713 477 OFFCURVE",
+"605 432 CURVE SMOOTH",
+"498 388 OFFCURVE",
+"399 366 OFFCURVE",
+"310 366 CURVE SMOOTH",
+"272 366 LINE SMOOTH",
+"246 366 OFFCURVE",
+"216 367 OFFCURVE",
+"183 369 CURVE SMOOTH",
+"150 371 OFFCURVE",
+"123 374 OFFCURVE",
+"102 377 CURVE",
+"81 370 OFFCURVE",
+"73 355 OFFCURVE",
+"73 326 CURVE SMOOTH",
+"73 317 OFFCURVE",
+"80 279 OFFCURVE",
+"95 213 CURVE SMOOTH",
+"110 148 OFFCURVE",
+"123 77 OFFCURVE",
+"134 0 CURVE",
+"208 0 LINE",
+"201 52 OFFCURVE",
+"191 108 OFFCURVE",
+"179 167 CURVE SMOOTH",
+"167 227 OFFCURVE",
+"157 272 OFFCURVE",
+"148 303 CURVE",
+"156 303 LINE SMOOTH",
+"265 303 OFFCURVE",
+"374 254 OFFCURVE",
+"484 156 CURVE SMOOTH",
+"594 58 OFFCURVE",
+"681 3 OFFCURVE",
+"746 -8 CURVE",
+"780 58 LINE",
+"744 69 OFFCURVE",
+"708 85 OFFCURVE",
+"671 107 CURVE",
+"635 130 OFFCURVE",
+"590 164 OFFCURVE",
+"535 209 CURVE",
+"481 255 OFFCURVE",
+"433 286 OFFCURVE",
+"390 302 CURVE"
+);
+}
+);
+width = 930;
+}
+);
+leftKerningGroup = uni0710;
+rightKerningGroup = uni0710;
+unicode = 0710;
+},
+{
+glyphname = uni0710.Fina3;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{429, -49}";
+}
+);
+components = (
+{
+name = uni0710;
+}
+);
+layerId = UUID0;
+width = 930;
+}
+);
+leftKerningGroup = uni0710;
+rightKerningGroup = uni0710;
+},
+{
+glyphname = uni0710.Fina2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{429, -49}";
+}
+);
+components = (
+{
+name = uni0710;
+}
+);
+layerId = UUID0;
+width = 930;
+}
+);
+leftKerningGroup = uni0710;
+rightKerningGroup = uni0710;
+},
+{
+glyphname = uni0710.Fina1;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{429, -49}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"870 76 LINE",
+"837 76 LINE SMOOTH",
+"780 76 OFFCURVE",
+"729 86 OFFCURVE",
+"684 107 CURVE SMOOTH",
+"639 128 OFFCURVE",
+"589 162 OFFCURVE",
+"532 209 CURVE SMOOTH",
+"475 256 OFFCURVE",
+"427 287 OFFCURVE",
+"388 302 CURVE",
+"388 306 LINE",
+"481 310 OFFCURVE",
+"581 336 OFFCURVE",
+"686 384 CURVE SMOOTH",
+"791 432 OFFCURVE",
+"870 486 OFFCURVE",
+"922 547 CURVE",
+"869 595 LINE",
+"801 531 OFFCURVE",
+"713 477 OFFCURVE",
+"605 432 CURVE SMOOTH",
+"498 388 OFFCURVE",
+"399 366 OFFCURVE",
+"310 366 CURVE SMOOTH",
+"272 366 LINE SMOOTH",
+"246 366 OFFCURVE",
+"216 367 OFFCURVE",
+"183 369 CURVE SMOOTH",
+"150 371 OFFCURVE",
+"123 374 OFFCURVE",
+"102 377 CURVE",
+"81 370 OFFCURVE",
+"73 356 OFFCURVE",
+"73 327 CURVE SMOOTH",
+"73 317 OFFCURVE",
+"80 279 OFFCURVE",
+"95 213 CURVE SMOOTH",
+"110 148 OFFCURVE",
+"123 77 OFFCURVE",
+"134 0 CURVE",
+"208 0 LINE",
+"201 47 OFFCURVE",
+"192 101 OFFCURVE",
+"180 160 CURVE SMOOTH",
+"169 219 OFFCURVE",
+"158 267 OFFCURVE",
+"149 303 CURVE",
+"156 303 LINE SMOOTH",
+"219 303 OFFCURVE",
+"275 290 OFFCURVE",
+"324 265 CURVE SMOOTH",
+"374 240 OFFCURVE",
+"430 200 OFFCURVE",
+"491 145 CURVE SMOOTH",
+"553 90 OFFCURVE",
+"609 52 OFFCURVE",
+"659 31 CURVE SMOOTH",
+"709 10 OFFCURVE",
+"764 0 OFFCURVE",
+"825 0 CURVE SMOOTH",
+"870 0 LINE"
+);
+}
+);
+width = 870;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+glyphname = uni0710.Medi2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{430, -49}";
+}
+);
+components = (
+{
+name = uni0710.Fina1;
+}
+);
+layerId = UUID0;
+width = 870;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+glyphname = uni0711;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"104 578 LINE",
+"84 585 OFFCURVE",
+"63 597 OFFCURVE",
+"42 615 CURVE SMOOTH",
+"21 633 OFFCURVE",
+"4 645 OFFCURVE",
+"-8 652 CURVE",
+"-8 654 LINE",
+"55 665 OFFCURVE",
+"103 691 OFFCURVE",
+"132 730 CURVE",
+"105 755 LINE",
+"62 711 OFFCURVE",
+"8 684 OFFCURVE",
+"-48 684 CURVE SMOOTH",
+"-57 684 OFFCURVE",
+"-80 684 OFFCURVE",
+"-103 688 CURVE",
+"-114 685 OFFCURVE",
+"-121 677 OFFCURVE",
+"-121 662 CURVE SMOOTH",
+"-121 651 OFFCURVE",
+"-113 619 OFFCURVE",
+"-108 594 CURVE",
+"-105 571 LINE",
+"-102 546 LINE",
+"-62 546 LINE",
+"-63 561 OFFCURVE",
+"-66 579 OFFCURVE",
+"-70 600 CURVE SMOOTH",
+"-74 622 OFFCURVE",
+"-78 639 OFFCURVE",
+"-81 650 CURVE",
+"-62 650 OFFCURVE",
+"-47 644 OFFCURVE",
+"-35 633 CURVE SMOOTH",
+"14 586 LINE SMOOTH",
+"35 567 OFFCURVE",
+"59 552 OFFCURVE",
+"86 542 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0711;
+},
+{
+glyphname = uni0712;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{812, -81}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"708 0 LINE SMOOTH",
+"837 0 OFFCURVE",
+"889 50 OFFCURVE",
+"889 175 CURVE SMOOTH",
+"889 195 OFFCURVE",
+"886 225 OFFCURVE",
+"883 253 CURVE",
+"879 275 LINE SMOOTH",
+"862 376 OFFCURVE",
+"809 426 OFFCURVE",
+"705 426 CURVE SMOOTH",
+"628 426 OFFCURVE",
+"551 421 OFFCURVE",
+"474 421 CURVE SMOOTH",
+"391 421 OFFCURVE",
+"347 424 OFFCURVE",
+"326 429 CURVE",
+"326 357 LINE",
+"347 352 OFFCURVE",
+"394 348 OFFCURVE",
+"479 348 CURVE SMOOTH",
+"548 348 OFFCURVE",
+"621 353 OFFCURVE",
+"690 353 CURVE SMOOTH",
+"759 353 OFFCURVE",
+"789 334 OFFCURVE",
+"805 270 CURVE SMOOTH",
+"813 239 OFFCURVE",
+"817 207 OFFCURVE",
+"817 175 CURVE SMOOTH",
+"817 100 OFFCURVE",
+"793 76 OFFCURVE",
+"729 76 CURVE SMOOTH",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH"
+);
+}
+);
+width = 958;
+}
+);
+unicode = 0712;
+},
+{
+glyphname = uni0712.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{813, -83}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"708 0 LINE SMOOTH",
+"773 0 OFFCURVE",
+"814 14 OFFCURVE",
+"841 42 CURVE",
+"846 42 LINE",
+"874 7 OFFCURVE",
+"908 0 OFFCURVE",
+"968 0 CURVE",
+"968 76 LINE",
+"907 76 OFFCURVE",
+"887 85 OFFCURVE",
+"880 104 CURVE",
+"887 124 OFFCURVE",
+"889 148 OFFCURVE",
+"889 175 CURVE SMOOTH",
+"889 195 OFFCURVE",
+"886 225 OFFCURVE",
+"883 253 CURVE",
+"879 275 LINE SMOOTH",
+"862 376 OFFCURVE",
+"809 426 OFFCURVE",
+"705 426 CURVE SMOOTH",
+"628 426 OFFCURVE",
+"551 421 OFFCURVE",
+"474 421 CURVE SMOOTH",
+"391 421 OFFCURVE",
+"347 424 OFFCURVE",
+"326 429 CURVE",
+"326 357 LINE",
+"347 352 OFFCURVE",
+"394 348 OFFCURVE",
+"479 348 CURVE SMOOTH",
+"548 348 OFFCURVE",
+"621 353 OFFCURVE",
+"690 353 CURVE SMOOTH",
+"759 353 OFFCURVE",
+"789 334 OFFCURVE",
+"805 270 CURVE SMOOTH",
+"813 239 OFFCURVE",
+"817 207 OFFCURVE",
+"817 175 CURVE SMOOTH",
+"817 100 OFFCURVE",
+"793 76 OFFCURVE",
+"729 76 CURVE SMOOTH",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH"
+);
+}
+);
+width = 968;
+}
+);
+},
+{
+glyphname = uni0712.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{585, -81}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"480 0 LINE SMOOTH",
+"545 0 OFFCURVE",
+"586 14 OFFCURVE",
+"613 42 CURVE",
+"618 42 LINE",
+"646 7 OFFCURVE",
+"680 0 OFFCURVE",
+"740 0 CURVE",
+"740 76 LINE",
+"679 76 OFFCURVE",
+"659 85 OFFCURVE",
+"652 104 CURVE",
+"659 124 OFFCURVE",
+"661 148 OFFCURVE",
+"661 175 CURVE SMOOTH",
+"661 195 OFFCURVE",
+"658 225 OFFCURVE",
+"655 253 CURVE",
+"651 275 LINE SMOOTH",
+"634 376 OFFCURVE",
+"581 426 OFFCURVE",
+"477 426 CURVE SMOOTH",
+"400 426 OFFCURVE",
+"323 421 OFFCURVE",
+"246 421 CURVE SMOOTH",
+"163 421 OFFCURVE",
+"119 424 OFFCURVE",
+"98 429 CURVE",
+"98 357 LINE",
+"119 352 OFFCURVE",
+"166 348 OFFCURVE",
+"251 348 CURVE SMOOTH",
+"320 348 OFFCURVE",
+"393 353 OFFCURVE",
+"462 353 CURVE SMOOTH",
+"531 353 OFFCURVE",
+"561 334 OFFCURVE",
+"577 270 CURVE SMOOTH",
+"585 239 OFFCURVE",
+"589 207 OFFCURVE",
+"589 175 CURVE SMOOTH",
+"589 100 OFFCURVE",
+"565 76 OFFCURVE",
+"501 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 740;
+}
+);
+},
+{
+glyphname = uni0712.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{585, -81}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"480 0 LINE SMOOTH",
+"609 0 OFFCURVE",
+"661 50 OFFCURVE",
+"661 175 CURVE SMOOTH",
+"661 195 OFFCURVE",
+"658 225 OFFCURVE",
+"655 253 CURVE",
+"651 275 LINE SMOOTH",
+"634 376 OFFCURVE",
+"581 426 OFFCURVE",
+"477 426 CURVE SMOOTH",
+"400 426 OFFCURVE",
+"323 421 OFFCURVE",
+"246 421 CURVE SMOOTH",
+"163 421 OFFCURVE",
+"119 424 OFFCURVE",
+"98 429 CURVE",
+"98 357 LINE",
+"119 352 OFFCURVE",
+"166 348 OFFCURVE",
+"251 348 CURVE SMOOTH",
+"320 348 OFFCURVE",
+"393 353 OFFCURVE",
+"462 353 CURVE SMOOTH",
+"531 353 OFFCURVE",
+"561 334 OFFCURVE",
+"577 270 CURVE SMOOTH",
+"585 239 OFFCURVE",
+"589 207 OFFCURVE",
+"589 175 CURVE SMOOTH",
+"589 100 OFFCURVE",
+"565 76 OFFCURVE",
+"501 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 730;
+}
+);
+},
+{
+glyphname = uni0713;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{880, -232}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"955 -100 LINE",
+"877 -52 OFFCURVE",
+"804 -17 OFFCURVE",
+"737 5 CURVE SMOOTH",
+"670 28 OFFCURVE",
+"600 45 OFFCURVE",
+"529 57 CURVE SMOOTH",
+"458 70 OFFCURVE",
+"375 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"246 76 OFFCURVE",
+"207 74 OFFCURVE",
+"160 71 CURVE SMOOTH",
+"114 68 OFFCURVE",
+"77 63 OFFCURVE",
+"49 58 CURVE",
+"63 -12 LINE",
+"87 -9 OFFCURVE",
+"120 -7 OFFCURVE",
+"163 -4 CURVE SMOOTH",
+"206 -1 OFFCURVE",
+"250 0 OFFCURVE",
+"293 0 CURVE SMOOTH",
+"440 0 OFFCURVE",
+"587 -24 OFFCURVE",
+"743 -77 CURVE SMOOTH",
+"822 -104 OFFCURVE",
+"895 -136 OFFCURVE",
+"962 -171 CURVE SMOOTH",
+"1029 -206 OFFCURVE",
+"1116 -261 OFFCURVE",
+"1222 -335 CURVE SMOOTH",
+"1278 -375 LINE",
+"1324 -316 LINE",
+"1249 -267 OFFCURVE",
+"1161 -197 OFFCURVE",
+"1061 -107 CURVE SMOOTH",
+"961 -17 OFFCURVE",
+"863 84 OFFCURVE",
+"767 195 CURVE SMOOTH",
+"672 306 OFFCURVE",
+"582 420 OFFCURVE",
+"497 536 CURVE",
+"427 496 LINE",
+"518 368 OFFCURVE",
+"612 250 OFFCURVE",
+"708 141 CURVE SMOOTH",
+"805 32 OFFCURVE",
+"888 -47 OFFCURVE",
+"958 -97 CURVE"
+);
+}
+);
+width = 1091;
+}
+);
+leftKerningGroup = uni0713;
+unicode = 0713;
+},
+{
+glyphname = uni0713.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{881, -232}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"955 -100 LINE",
+"877 -52 OFFCURVE",
+"804 -17 OFFCURVE",
+"737 5 CURVE SMOOTH",
+"670 28 OFFCURVE",
+"600 45 OFFCURVE",
+"529 57 CURVE SMOOTH",
+"458 70 OFFCURVE",
+"375 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"246 76 OFFCURVE",
+"207 74 OFFCURVE",
+"160 71 CURVE SMOOTH",
+"114 68 OFFCURVE",
+"77 63 OFFCURVE",
+"49 58 CURVE",
+"63 -12 LINE",
+"87 -9 OFFCURVE",
+"120 -7 OFFCURVE",
+"163 -4 CURVE SMOOTH",
+"206 -1 OFFCURVE",
+"250 0 OFFCURVE",
+"293 0 CURVE SMOOTH",
+"440 0 OFFCURVE",
+"587 -24 OFFCURVE",
+"743 -77 CURVE SMOOTH",
+"822 -104 OFFCURVE",
+"895 -136 OFFCURVE",
+"962 -171 CURVE SMOOTH",
+"1029 -206 OFFCURVE",
+"1116 -261 OFFCURVE",
+"1222 -335 CURVE SMOOTH",
+"1278 -375 LINE",
+"1324 -316 LINE",
+"1263 -277 OFFCURVE",
+"1198 -226 OFFCURVE",
+"1127 -165 CURVE SMOOTH",
+"1057 -104 OFFCURVE",
+"996 -48 OFFCURVE",
+"945 3 CURVE",
+"945 76 LINE",
+"875 76 LINE",
+"754 204 OFFCURVE",
+"624 361 OFFCURVE",
+"497 536 CURVE",
+"427 496 LINE",
+"518 368 OFFCURVE",
+"612 250 OFFCURVE",
+"708 141 CURVE SMOOTH",
+"805 32 OFFCURVE",
+"888 -47 OFFCURVE",
+"958 -97 CURVE"
+);
+}
+);
+width = 945;
+}
+);
+},
+{
+glyphname = uni0713.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{508, -230}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"535 -61 LINE",
+"438 -8 OFFCURVE",
+"349 28 OFFCURVE",
+"270 47 CURVE SMOOTH",
+"191 66 OFFCURVE",
+"101 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"151 0 OFFCURVE",
+"282 -25 OFFCURVE",
+"399 -69 CURVE SMOOTH",
+"518 -114 OFFCURVE",
+"619 -174 OFFCURVE",
+"750 -266 CURVE SMOOTH",
+"870 -351 LINE",
+"905 -375 LINE",
+"951 -316 LINE",
+"892 -278 OFFCURVE",
+"829 -229 OFFCURVE",
+"760 -170 CURVE SMOOTH",
+"691 -111 OFFCURVE",
+"628 -53 OFFCURVE",
+"571 4 CURVE",
+"571 76 LINE",
+"501 76 LINE",
+"386 199 OFFCURVE",
+"253 357 OFFCURVE",
+"124 536 CURVE",
+"54 496 LINE",
+"221 261 OFFCURVE",
+"385 73 OFFCURVE",
+"538 -58 CURVE"
+);
+}
+);
+width = 571;
+}
+);
+},
+{
+glyphname = uni0713.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{508, -232}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"535 -61 LINE",
+"438 -8 OFFCURVE",
+"349 28 OFFCURVE",
+"270 47 CURVE SMOOTH",
+"191 66 OFFCURVE",
+"101 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"151 0 OFFCURVE",
+"282 -25 OFFCURVE",
+"399 -69 CURVE SMOOTH",
+"518 -114 OFFCURVE",
+"619 -174 OFFCURVE",
+"750 -266 CURVE SMOOTH",
+"870 -351 LINE",
+"905 -375 LINE",
+"951 -316 LINE",
+"876 -267 OFFCURVE",
+"789 -198 OFFCURVE",
+"690 -109 CURVE SMOOTH",
+"591 -20 OFFCURVE",
+"494 79 OFFCURVE",
+"399 188 CURVE SMOOTH",
+"304 298 OFFCURVE",
+"213 414 OFFCURVE",
+"124 536 CURVE",
+"54 496 LINE",
+"221 261 OFFCURVE",
+"385 73 OFFCURVE",
+"538 -58 CURVE"
+);
+}
+);
+width = 718;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+glyphname = uni0714;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{605, -146}";
+}
+);
+components = (
+{
+name = uni0713;
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 458, 145}";
+}
+);
+layerId = UUID0;
+width = 1091;
+}
+);
+leftKerningGroup = uni0713;
+unicode = 0714;
+},
+{
+glyphname = uni0714.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{600, -146}";
+}
+);
+components = (
+{
+name = uni0713.Fina;
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 458, 145}";
+}
+);
+layerId = UUID0;
+width = 945;
+}
+);
+},
+{
+glyphname = uni0714.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{248, -157}";
+}
+);
+components = (
+{
+name = uni0713.Medi;
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 83, 145}";
+}
+);
+layerId = UUID0;
+width = 571;
+}
+);
+},
+{
+glyphname = uni0714.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{239, -157}";
+}
+);
+components = (
+{
+name = uni0713.Init;
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 83, 145}";
+}
+);
+layerId = UUID0;
+width = 718;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+glyphname = uni0715;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{443, -106}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 206, 102}";
+},
+{
+name = uni0716;
+}
+);
+layerId = UUID0;
+width = 539;
+}
+);
+rightKerningGroup = uni0715;
+unicode = 0715;
+},
+{
+glyphname = uni0715.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{443, -106}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 206, 102}";
+},
+{
+name = uni0716.Fina;
+}
+);
+layerId = UUID0;
+width = 531;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+glyphname = uni0716;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{443, -106}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"44 353 LINE",
+"341 353 LINE",
+"349 328 OFFCURVE",
+"359 274 OFFCURVE",
+"371 190 CURVE",
+"384 107 OFFCURVE",
+"393 37 OFFCURVE",
+"398 -18 CURVE",
+"471 -18 LINE",
+"464 48 OFFCURVE",
+"455 122 OFFCURVE",
+"442 203 CURVE SMOOTH",
+"429 285 OFFCURVE",
+"418 343 OFFCURVE",
+"409 376 CURVE SMOOTH",
+"400 409 OFFCURVE",
+"374 426 OFFCURVE",
+"330 426 CURVE SMOOTH",
+"44 426 LINE"
+);
+}
+);
+width = 539;
+}
+);
+rightKerningGroup = uni0715;
+unicode = 0716;
+},
+{
+glyphname = uni0716.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{443, -106}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"44 353 LINE",
+"341 353 LINE",
+"349 328 OFFCURVE",
+"359 274 OFFCURVE",
+"371 190 CURVE",
+"384 107 OFFCURVE",
+"393 37 OFFCURVE",
+"398 -18 CURVE",
+"470 -18 LINE",
+"466 18 LINE",
+"470 18 LINE",
+"482 6 OFFCURVE",
+"503 0 OFFCURVE",
+"527 0 CURVE SMOOTH",
+"531 0 LINE",
+"531 76 LINE",
+"519 76 LINE SMOOTH",
+"483 76 OFFCURVE",
+"459 87 OFFCURVE",
+"456 111 CURVE SMOOTH",
+"445 186 LINE SMOOTH",
+"430 284 OFFCURVE",
+"418 348 OFFCURVE",
+"408 379 CURVE SMOOTH",
+"399 410 OFFCURVE",
+"373 426 OFFCURVE",
+"330 426 CURVE SMOOTH",
+"44 426 LINE"
+);
+}
+);
+width = 531;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+glyphname = uni0717;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{474, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"426 -6 LINE",
+"535 353 LINE",
+"563 357 OFFCURVE",
+"600 362 OFFCURVE",
+"643 362 CURVE SMOOTH",
+"748 362 OFFCURVE",
+"788 314 OFFCURVE",
+"788 198 CURVE SMOOTH",
+"788 101 OFFCURVE",
+"744 76 OFFCURVE",
+"656 76 CURVE SMOOTH",
+"646 76 LINE",
+"643 2 LINE",
+"648 1 OFFCURVE",
+"653 0 OFFCURVE",
+"658 0 CURVE SMOOTH",
+"667 0 LINE SMOOTH",
+"794 0 OFFCURVE",
+"861 63 OFFCURVE",
+"861 195 CURVE SMOOTH",
+"861 356 OFFCURVE",
+"789 436 OFFCURVE",
+"649 436 CURVE SMOOTH",
+"609 436 OFFCURVE",
+"559 426 OFFCURVE",
+"498 426 CURVE SMOOTH",
+"453 426 OFFCURVE",
+"377 437 OFFCURVE",
+"312 437 CURVE SMOOTH",
+"161 437 OFFCURVE",
+"68 356 OFFCURVE",
+"68 225 CURVE SMOOTH",
+"68 108 OFFCURVE",
+"119 35 OFFCURVE",
+"231 -8 CURVE",
+"264 57 LINE",
+"176 93 OFFCURVE",
+"142 140 OFFCURVE",
+"142 216 CURVE SMOOTH",
+"142 313 OFFCURVE",
+"201 365 OFFCURVE",
+"333 365 CURVE SMOOTH",
+"386 365 OFFCURVE",
+"429 359 OFFCURVE",
+"458 354 CURVE",
+"355 5 LINE"
+);
+}
+);
+width = 930;
+}
+);
+rightKerningGroup = uni0717;
+unicode = 0717;
+},
+{
+glyphname = uni0717.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{474, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"942 0 LINE",
+"942 76 LINE",
+"933 76 LINE SMOOTH",
+"878 76 OFFCURVE",
+"854 83 OFFCURVE",
+"846 102 CURVE",
+"858 133 OFFCURVE",
+"861 166 OFFCURVE",
+"861 195 CURVE SMOOTH",
+"861 356 OFFCURVE",
+"789 436 OFFCURVE",
+"649 436 CURVE SMOOTH",
+"609 436 OFFCURVE",
+"559 426 OFFCURVE",
+"498 426 CURVE SMOOTH",
+"453 426 OFFCURVE",
+"377 437 OFFCURVE",
+"312 437 CURVE SMOOTH",
+"161 437 OFFCURVE",
+"68 356 OFFCURVE",
+"68 225 CURVE SMOOTH",
+"68 108 OFFCURVE",
+"119 35 OFFCURVE",
+"231 -8 CURVE",
+"264 57 LINE",
+"176 93 OFFCURVE",
+"142 140 OFFCURVE",
+"142 216 CURVE SMOOTH",
+"142 313 OFFCURVE",
+"201 365 OFFCURVE",
+"333 365 CURVE SMOOTH",
+"386 365 OFFCURVE",
+"429 359 OFFCURVE",
+"458 354 CURVE",
+"355 5 LINE",
+"426 -6 LINE",
+"535 353 LINE",
+"563 357 OFFCURVE",
+"600 362 OFFCURVE",
+"643 362 CURVE SMOOTH",
+"748 362 OFFCURVE",
+"788 314 OFFCURVE",
+"788 198 CURVE SMOOTH",
+"788 101 OFFCURVE",
+"744 76 OFFCURVE",
+"656 76 CURVE SMOOTH",
+"646 76 LINE",
+"643 2 LINE",
+"648 1 OFFCURVE",
+"653 0 OFFCURVE",
+"658 0 CURVE SMOOTH",
+"667 0 LINE SMOOTH",
+"734 0 OFFCURVE",
+"776 18 OFFCURVE",
+"805 43 CURVE",
+"810 43 LINE",
+"841 7 OFFCURVE",
+"877 0 OFFCURVE",
+"933 0 CURVE SMOOTH"
+);
+}
+);
+width = 942;
+}
+);
+rightKerningGroup = uni0717;
+},
+{
+glyphname = uni0718;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{316, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"545 -9 LINE",
+"519 176 OFFCURVE",
+"490 297 OFFCURVE",
+"458 352 CURVE SMOOTH",
+"426 408 OFFCURVE",
+"371 436 OFFCURVE",
+"294 436 CURVE SMOOTH",
+"233 436 OFFCURVE",
+"180 412 OFFCURVE",
+"135 363 CURVE SMOOTH",
+"90 314 OFFCURVE",
+"68 258 OFFCURVE",
+"68 195 CURVE SMOOTH",
+"68 68 OFFCURVE",
+"150 -9 OFFCURVE",
+"283 -9 CURVE SMOOTH",
+"326 -9 OFFCURVE",
+"363 -6 OFFCURVE",
+"396 9 CURVE",
+"375 74 LINE",
+"347 66 OFFCURVE",
+"325 64 OFFCURVE",
+"292 64 CURVE SMOOTH",
+"196 64 OFFCURVE",
+"142 110 OFFCURVE",
+"142 197 CURVE SMOOTH",
+"142 242 OFFCURVE",
+"157 280 OFFCURVE",
+"186 313 CURVE SMOOTH",
+"215 346 OFFCURVE",
+"252 362 OFFCURVE",
+"297 362 CURVE SMOOTH",
+"334 362 OFFCURVE",
+"362 352 OFFCURVE",
+"381 331 CURVE SMOOTH",
+"400 311 OFFCURVE",
+"416 274 OFFCURVE",
+"429 219 CURVE SMOOTH",
+"442 164 OFFCURVE",
+"454 107 OFFCURVE",
+"463 48 CURVE",
+"473 -9 LINE"
+);
+}
+);
+width = 610;
+}
+);
+rightKerningGroup = uni0718;
+unicode = 0718;
+},
+{
+glyphname = uni0718.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{316, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"542 -9 LINE",
+"538 23 LINE",
+"542 23 LINE",
+"555 8 OFFCURVE",
+"571 0 OFFCURVE",
+"598 0 CURVE",
+"598 76 LINE",
+"562 76 OFFCURVE",
+"529 89 OFFCURVE",
+"526 112 CURVE SMOOTH",
+"525 123 OFFCURVE",
+"521 144 OFFCURVE",
+"514 175 CURVE SMOOTH",
+"501 230 LINE SMOOTH",
+"483 309 OFFCURVE",
+"458 363 OFFCURVE",
+"426 392 CURVE SMOOTH",
+"395 421 OFFCURVE",
+"351 436 OFFCURVE",
+"294 436 CURVE SMOOTH",
+"233 436 OFFCURVE",
+"180 412 OFFCURVE",
+"135 363 CURVE SMOOTH",
+"90 314 OFFCURVE",
+"68 258 OFFCURVE",
+"68 195 CURVE SMOOTH",
+"68 68 OFFCURVE",
+"150 -9 OFFCURVE",
+"283 -9 CURVE SMOOTH",
+"326 -9 OFFCURVE",
+"363 -6 OFFCURVE",
+"396 9 CURVE",
+"375 74 LINE",
+"347 66 OFFCURVE",
+"325 64 OFFCURVE",
+"292 64 CURVE SMOOTH",
+"196 64 OFFCURVE",
+"142 110 OFFCURVE",
+"142 197 CURVE SMOOTH",
+"142 242 OFFCURVE",
+"157 280 OFFCURVE",
+"186 313 CURVE SMOOTH",
+"215 346 OFFCURVE",
+"252 362 OFFCURVE",
+"297 362 CURVE SMOOTH",
+"334 362 OFFCURVE",
+"362 352 OFFCURVE",
+"381 331 CURVE SMOOTH",
+"400 311 OFFCURVE",
+"416 274 OFFCURVE",
+"429 219 CURVE SMOOTH",
+"442 164 OFFCURVE",
+"454 107 OFFCURVE",
+"463 48 CURVE",
+"473 -9 LINE"
+);
+}
+);
+width = 598;
+}
+);
+rightKerningGroup = uni0718;
+},
+{
+glyphname = uni0719;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{152, -138}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"68 417 LINE",
+"79 359 LINE",
+"90 294 OFFCURVE",
+"101 224 OFFCURVE",
+"112 150 CURVE SMOOTH",
+"123 76 OFFCURVE",
+"132 14 OFFCURVE",
+"137 -37 CURVE",
+"209 -37 LINE",
+"206 -6 OFFCURVE",
+"202 33 OFFCURVE",
+"195 80 CURVE SMOOTH",
+"189 127 OFFCURVE",
+"183 170 OFFCURVE",
+"177 208 CURVE SMOOTH",
+"152 364 LINE",
+"141 426 LINE"
+);
+}
+);
+width = 275;
+}
+);
+rightKerningGroup = uni0719;
+unicode = 0719;
+},
+{
+glyphname = uni0719.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{151, -137}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"68 417 LINE",
+"79 359 LINE SMOOTH",
+"88 308 OFFCURVE",
+"98 243 OFFCURVE",
+"110 162 CURVE SMOOTH",
+"123 81 OFFCURVE",
+"132 13 OFFCURVE",
+"138 -42 CURVE",
+"208 -42 LINE",
+"207 -23 OFFCURVE",
+"205 -3 OFFCURVE",
+"201 18 CURVE",
+"206 18 LINE",
+"218 6 OFFCURVE",
+"239 0 OFFCURVE",
+"263 0 CURVE SMOOTH",
+"277 0 LINE",
+"277 76 LINE",
+"255 76 LINE SMOOTH",
+"215 76 OFFCURVE",
+"194 88 OFFCURVE",
+"191 112 CURVE SMOOTH",
+"188 137 OFFCURVE",
+"180 194 OFFCURVE",
+"165 285 CURVE SMOOTH",
+"152 362 LINE",
+"141 426 LINE"
+);
+}
+);
+width = 277;
+}
+);
+rightKerningGroup = uni0719;
+},
+{
+glyphname = uni071A;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{481, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"49 89 LINE",
+"69 38 OFFCURVE",
+"140 0 OFFCURVE",
+"219 0 CURVE SMOOTH",
+"294 0 OFFCURVE",
+"339 27 OFFCURVE",
+"362 62 CURVE",
+"387 26 OFFCURVE",
+"438 0 OFFCURVE",
+"489 0 CURVE SMOOTH",
+"576 0 OFFCURVE",
+"633 58 OFFCURVE",
+"633 150 CURVE SMOOTH",
+"633 184 OFFCURVE",
+"629 218 OFFCURVE",
+"622 251 CURVE SMOOTH",
+"615 284 OFFCURVE",
+"609 309 OFFCURVE",
+"602 324 CURVE SMOOTH",
+"595 340 OFFCURVE",
+"585 348 OFFCURVE",
+"570 348 CURVE SMOOTH",
+"550 348 OFFCURVE",
+"531 338 OFFCURVE",
+"531 310 CURVE SMOOTH",
+"531 290 OFFCURVE",
+"535 261 OFFCURVE",
+"543 223 CURVE SMOOTH",
+"551 186 OFFCURVE",
+"560 151 OFFCURVE",
+"570 119 CURVE",
+"562 90 OFFCURVE",
+"535 76 OFFCURVE",
+"492 76 CURVE SMOOTH",
+"447 76 OFFCURVE",
+"409 99 OFFCURVE",
+"390 140 CURVE",
+"390 165 OFFCURVE",
+"387 197 OFFCURVE",
+"380 236 CURVE SMOOTH",
+"374 275 OFFCURVE",
+"368 303 OFFCURVE",
+"361 320 CURVE SMOOTH",
+"355 337 OFFCURVE",
+"345 346 OFFCURVE",
+"331 346 CURVE SMOOTH",
+"307 346 OFFCURVE",
+"289 336 OFFCURVE",
+"289 304 CURVE SMOOTH",
+"289 280 OFFCURVE",
+"292 250 OFFCURVE",
+"299 215 CURVE SMOOTH",
+"306 180 OFFCURVE",
+"314 150 OFFCURVE",
+"325 123 CURVE",
+"314 92 OFFCURVE",
+"275 76 OFFCURVE",
+"222 76 CURVE SMOOTH",
+"162 76 OFFCURVE",
+"119 95 OFFCURVE",
+"94 132 CURVE",
+"49 89 LINE"
+);
+}
+);
+width = 701;
+}
+);
+unicode = 071A;
+},
+{
+glyphname = uni071A.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{480, -99}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"49 89 LINE",
+"69 38 OFFCURVE",
+"140 0 OFFCURVE",
+"219 0 CURVE SMOOTH",
+"292 0 OFFCURVE",
+"338 26 OFFCURVE",
+"361 62 CURVE",
+"386 26 OFFCURVE",
+"436 0 OFFCURVE",
+"488 0 CURVE SMOOTH",
+"539 0 OFFCURVE",
+"579 19 OFFCURVE",
+"604 55 CURVE",
+"631 23 OFFCURVE",
+"671 0 OFFCURVE",
+"727 0 CURVE",
+"727 76 LINE",
+"682 76 OFFCURVE",
+"643 102 OFFCURVE",
+"631 139 CURVE",
+"632 141 OFFCURVE",
+"632 144 OFFCURVE",
+"632 147 CURVE SMOOTH",
+"632 219 OFFCURVE",
+"614 293 OFFCURVE",
+"601 324 CURVE SMOOTH",
+"594 340 OFFCURVE",
+"584 348 OFFCURVE",
+"569 348 CURVE SMOOTH",
+"549 348 OFFCURVE",
+"530 338 OFFCURVE",
+"530 310 CURVE SMOOTH",
+"530 286 OFFCURVE",
+"534 254 OFFCURVE",
+"541 215 CURVE SMOOTH",
+"549 176 OFFCURVE",
+"558 143 OFFCURVE",
+"569 116 CURVE",
+"560 85 OFFCURVE",
+"528 76 OFFCURVE",
+"491 76 CURVE SMOOTH",
+"446 76 OFFCURVE",
+"408 99 OFFCURVE",
+"389 140 CURVE",
+"389 165 OFFCURVE",
+"386 197 OFFCURVE",
+"379 236 CURVE SMOOTH",
+"373 275 OFFCURVE",
+"367 303 OFFCURVE",
+"360 320 CURVE SMOOTH",
+"354 337 OFFCURVE",
+"344 346 OFFCURVE",
+"330 346 CURVE SMOOTH",
+"306 346 OFFCURVE",
+"288 336 OFFCURVE",
+"288 304 CURVE SMOOTH",
+"288 281 OFFCURVE",
+"291 252 OFFCURVE",
+"298 215 CURVE SMOOTH",
+"305 179 OFFCURVE",
+"314 148 OFFCURVE",
+"325 122 CURVE",
+"313 93 OFFCURVE",
+"273 76 OFFCURVE",
+"222 76 CURVE SMOOTH",
+"162 76 OFFCURVE",
+"119 95 OFFCURVE",
+"94 132 CURVE",
+"49 89 LINE"
+);
+}
+);
+width = 727;
+}
+);
+},
+{
+glyphname = uni071A.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{302, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"126 92 OFFCURVE",
+"81 76 OFFCURVE",
+"25 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"17 0 LINE SMOOTH",
+"92 0 OFFCURVE",
+"143 20 OFFCURVE",
+"175 61 CURVE",
+"200 25 OFFCURVE",
+"250 0 OFFCURVE",
+"302 0 CURVE SMOOTH",
+"351 0 OFFCURVE",
+"393 19 OFFCURVE",
+"418 55 CURVE",
+"443 23 OFFCURVE",
+"484 0 OFFCURVE",
+"541 0 CURVE",
+"541 76 LINE",
+"496 76 OFFCURVE",
+"457 102 OFFCURVE",
+"445 139 CURVE",
+"445 147 LINE SMOOTH",
+"445 219 OFFCURVE",
+"427 293 OFFCURVE",
+"414 324 CURVE SMOOTH",
+"408 340 OFFCURVE",
+"397 348 OFFCURVE",
+"382 348 CURVE SMOOTH",
+"362 348 OFFCURVE",
+"344 338 OFFCURVE",
+"344 310 CURVE SMOOTH",
+"344 286 OFFCURVE",
+"348 254 OFFCURVE",
+"355 215 CURVE SMOOTH",
+"363 176 OFFCURVE",
+"372 143 OFFCURVE",
+"382 116 CURVE",
+"373 85 OFFCURVE",
+"341 76 OFFCURVE",
+"304 76 CURVE SMOOTH",
+"260 76 OFFCURVE",
+"221 99 OFFCURVE",
+"202 140 CURVE",
+"202 165 OFFCURVE",
+"199 197 OFFCURVE",
+"192 236 CURVE SMOOTH",
+"186 275 OFFCURVE",
+"180 303 OFFCURVE",
+"174 320 CURVE SMOOTH",
+"168 337 OFFCURVE",
+"158 346 OFFCURVE",
+"143 346 CURVE SMOOTH",
+"119 346 OFFCURVE",
+"102 336 OFFCURVE",
+"102 304 CURVE SMOOTH",
+"102 281 OFFCURVE",
+"105 252 OFFCURVE",
+"112 216 CURVE SMOOTH",
+"119 181 OFFCURVE",
+"127 150 OFFCURVE",
+"138 123 CURVE"
+);
+}
+);
+width = 541;
+}
+);
+},
+{
+glyphname = uni071A.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{303, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"126 92 OFFCURVE",
+"81 76 OFFCURVE",
+"25 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"17 0 LINE SMOOTH",
+"92 0 OFFCURVE",
+"143 20 OFFCURVE",
+"175 61 CURVE",
+"200 25 OFFCURVE",
+"250 0 OFFCURVE",
+"302 0 CURVE SMOOTH",
+"387 0 OFFCURVE",
+"445 58 OFFCURVE",
+"445 150 CURVE SMOOTH",
+"445 184 OFFCURVE",
+"441 218 OFFCURVE",
+"434 251 CURVE SMOOTH",
+"427 284 OFFCURVE",
+"421 309 OFFCURVE",
+"414 324 CURVE",
+"408 340 OFFCURVE",
+"397 348 OFFCURVE",
+"382 348 CURVE SMOOTH",
+"362 348 OFFCURVE",
+"344 338 OFFCURVE",
+"344 310 CURVE SMOOTH",
+"344 290 OFFCURVE",
+"348 261 OFFCURVE",
+"355 223 CURVE",
+"363 186 OFFCURVE",
+"372 151 OFFCURVE",
+"383 119 CURVE",
+"374 90 OFFCURVE",
+"348 76 OFFCURVE",
+"304 76 CURVE SMOOTH",
+"260 76 OFFCURVE",
+"221 99 OFFCURVE",
+"202 140 CURVE",
+"202 165 OFFCURVE",
+"199 197 OFFCURVE",
+"192 236 CURVE SMOOTH",
+"186 275 OFFCURVE",
+"180 303 OFFCURVE",
+"174 320 CURVE SMOOTH",
+"168 337 OFFCURVE",
+"158 346 OFFCURVE",
+"143 346 CURVE SMOOTH",
+"119 346 OFFCURVE",
+"102 336 OFFCURVE",
+"102 304 CURVE SMOOTH",
+"102 281 OFFCURVE",
+"105 252 OFFCURVE",
+"112 216 CURVE SMOOTH",
+"119 181 OFFCURVE",
+"127 150 OFFCURVE",
+"138 123 CURVE"
+);
+}
+);
+width = 514;
+}
+);
+},
+{
+glyphname = uni071B;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{564, -418}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"630 -238 LINE SMOOTH",
+"659 -310 OFFCURVE",
+"687 -353 OFFCURVE",
+"731 -353 CURVE SMOOTH",
+"750 -353 OFFCURVE",
+"766 -348 OFFCURVE",
+"781 -337 CURVE SMOOTH",
+"796 -326 OFFCURVE",
+"818 -296 OFFCURVE",
+"849 -245 CURVE SMOOTH",
+"880 -195 OFFCURVE",
+"905 -144 OFFCURVE",
+"923 -92 CURVE SMOOTH",
+"941 -40 OFFCURVE",
+"950 1 OFFCURVE",
+"950 32 CURVE SMOOTH",
+"950 60 OFFCURVE",
+"927 76 OFFCURVE",
+"894 76 CURVE SMOOTH",
+"595 76 LINE",
+"344 720 LINE",
+"273 693 LINE",
+"513 76 LINE",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"739 -279 LINE",
+"730 -276 OFFCURVE",
+"713 -241 OFFCURVE",
+"702 -214 CURVE SMOOTH",
+"618 0 LINE",
+"876 0 LINE",
+"871 -35 OFFCURVE",
+"853 -85 OFFCURVE",
+"821 -150 CURVE SMOOTH",
+"789 -216 OFFCURVE",
+"763 -259 OFFCURVE",
+"743 -279 CURVE"
+);
+}
+);
+width = 999;
+}
+);
+leftKerningGroup = uni071B;
+unicode = 071B;
+},
+{
+glyphname = uni071B.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{564, -418}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"536 0 LINE",
+"630 -238 LINE SMOOTH",
+"659 -310 OFFCURVE",
+"687 -353 OFFCURVE",
+"731 -353 CURVE SMOOTH",
+"750 -353 OFFCURVE",
+"766 -348 OFFCURVE",
+"781 -337 CURVE SMOOTH",
+"796 -326 OFFCURVE",
+"818 -296 OFFCURVE",
+"849 -245 CURVE SMOOTH",
+"880 -195 OFFCURVE",
+"905 -144 OFFCURVE",
+"923 -92 CURVE SMOOTH",
+"941 -40 OFFCURVE",
+"950 1 OFFCURVE",
+"950 32 CURVE SMOOTH",
+"950 68 OFFCURVE",
+"947 76 OFFCURVE",
+"922 76 CURVE SMOOTH",
+"595 76 LINE",
+"344 720 LINE",
+"273 693 LINE",
+"513 76 LINE",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"739 -279 LINE",
+"730 -276 OFFCURVE",
+"713 -241 OFFCURVE",
+"702 -214 CURVE SMOOTH",
+"618 0 LINE",
+"876 0 LINE",
+"871 -35 OFFCURVE",
+"853 -85 OFFCURVE",
+"821 -150 CURVE SMOOTH",
+"789 -216 OFFCURVE",
+"763 -259 OFFCURVE",
+"743 -279 CURVE"
+);
+}
+);
+width = 922;
+}
+);
+},
+{
+glyphname = uni071B.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{253, -418}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-38 693 LINE",
+"202 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"225 0 LINE",
+"319 -238 LINE SMOOTH",
+"348 -310 OFFCURVE",
+"376 -353 OFFCURVE",
+"420 -353 CURVE SMOOTH",
+"439 -353 OFFCURVE",
+"455 -348 OFFCURVE",
+"470 -337 CURVE SMOOTH",
+"485 -326 OFFCURVE",
+"507 -296 OFFCURVE",
+"538 -245 CURVE SMOOTH",
+"569 -195 OFFCURVE",
+"594 -144 OFFCURVE",
+"612 -92 CURVE SMOOTH",
+"630 -40 OFFCURVE",
+"639 1 OFFCURVE",
+"639 32 CURVE SMOOTH",
+"639 68 OFFCURVE",
+"636 76 OFFCURVE",
+"611 76 CURVE SMOOTH",
+"284 76 LINE",
+"33 720 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 -279 LINE",
+"419 -276 OFFCURVE",
+"402 -241 OFFCURVE",
+"391 -214 CURVE SMOOTH",
+"307 0 LINE",
+"565 0 LINE",
+"560 -35 OFFCURVE",
+"542 -85 OFFCURVE",
+"510 -150 CURVE SMOOTH",
+"478 -216 OFFCURVE",
+"452 -259 OFFCURVE",
+"432 -279 CURVE"
+);
+}
+);
+width = 611;
+}
+);
+},
+{
+glyphname = uni071B.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{253, -419}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-38 693 LINE",
+"202 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"225 0 LINE",
+"319 -238 LINE SMOOTH",
+"348 -310 OFFCURVE",
+"376 -353 OFFCURVE",
+"420 -353 CURVE SMOOTH",
+"439 -353 OFFCURVE",
+"455 -348 OFFCURVE",
+"470 -337 CURVE SMOOTH",
+"485 -326 OFFCURVE",
+"507 -296 OFFCURVE",
+"538 -245 CURVE SMOOTH",
+"569 -195 OFFCURVE",
+"594 -144 OFFCURVE",
+"612 -92 CURVE SMOOTH",
+"630 -40 OFFCURVE",
+"639 1 OFFCURVE",
+"639 32 CURVE SMOOTH",
+"639 60 OFFCURVE",
+"616 76 OFFCURVE",
+"583 76 CURVE SMOOTH",
+"284 76 LINE",
+"33 720 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 -279 LINE",
+"419 -276 OFFCURVE",
+"402 -241 OFFCURVE",
+"391 -214 CURVE SMOOTH",
+"307 0 LINE",
+"565 0 LINE",
+"560 -35 OFFCURVE",
+"542 -85 OFFCURVE",
+"510 -150 CURVE SMOOTH",
+"478 -216 OFFCURVE",
+"452 -259 OFFCURVE",
+"432 -279 CURVE"
+);
+}
+);
+width = 687;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+glyphname = uni071C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{563, -418}";
+}
+);
+components = (
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, 502, 33}";
+},
+{
+name = uni071B;
+}
+);
+layerId = UUID0;
+width = 999;
+}
+);
+leftKerningGroup = uni071B;
+unicode = 071C;
+},
+{
+glyphname = uni071C.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{564, -418}";
+}
+);
+components = (
+{
+name = uni071B.Fina;
+},
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, 502, 33}";
+}
+);
+layerId = UUID0;
+width = 922;
+}
+);
+},
+{
+glyphname = uni071C.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{253, -418}";
+}
+);
+components = (
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, 191, 33}";
+},
+{
+name = uni071B.Medi;
+}
+);
+layerId = UUID0;
+width = 611;
+}
+);
+},
+{
+glyphname = uni071C.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{253, -418}";
+}
+);
+components = (
+{
+name = uni071B.Init;
+},
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, 191, 33}";
+}
+);
+layerId = UUID0;
+width = 687;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+glyphname = uni071D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{120, -226}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"62 -124 OFFCURVE",
+"80 -140 OFFCURVE",
+"100 -140 CURVE SMOOTH",
+"119 -140 OFFCURVE",
+"140 -121 OFFCURVE",
+"161 -84 CURVE SMOOTH",
+"183 -47 OFFCURVE",
+"194 -8 OFFCURVE",
+"194 33 CURVE SMOOTH",
+"194 75 OFFCURVE",
+"183 116 OFFCURVE",
+"162 156 CURVE SMOOTH",
+"141 196 OFFCURVE",
+"120 216 OFFCURVE",
+"99 216 CURVE SMOOTH",
+"78 216 OFFCURVE",
+"59 199 OFFCURVE",
+"59 179 CURVE SMOOTH",
+"59 155 OFFCURVE",
+"95 117 OFFCURVE",
+"115 74 CURVE SMOOTH",
+"125 53 OFFCURVE",
+"130 38 OFFCURVE",
+"130 30 CURVE SMOOTH",
+"130 14 OFFCURVE",
+"110 -28 OFFCURVE",
+"82 -60 CURVE",
+"69 -77 OFFCURVE",
+"62 -91 OFFCURVE",
+"62 -104 CURVE SMOOTH"
+);
+}
+);
+width = 243;
+}
+);
+unicode = 071D;
+},
+{
+glyphname = uni071D.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{119, -226}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"203 0 OFFCURVE",
+"215 0 OFFCURVE",
+"227 0 CURVE SMOOTH",
+"257 0 LINE",
+"257 76 LINE",
+"240 76 OFFCURVE",
+"214 77 OFFCURVE",
+"190 78 CURVE",
+"183 113 OFFCURVE",
+"171 144 OFFCURVE",
+"152 173 CURVE SMOOTH",
+"134 202 OFFCURVE",
+"116 216 OFFCURVE",
+"99 216 CURVE SMOOTH",
+"78 216 OFFCURVE",
+"59 199 OFFCURVE",
+"59 179 CURVE SMOOTH",
+"59 155 OFFCURVE",
+"95 117 OFFCURVE",
+"115 74 CURVE SMOOTH",
+"125 53 OFFCURVE",
+"130 38 OFFCURVE",
+"130 30 CURVE SMOOTH",
+"130 14 OFFCURVE",
+"110 -28 OFFCURVE",
+"82 -60 CURVE",
+"69 -77 OFFCURVE",
+"62 -91 OFFCURVE",
+"62 -104 CURVE SMOOTH",
+"62 -124 OFFCURVE",
+"80 -140 OFFCURVE",
+"100 -140 CURVE SMOOTH",
+"117 -140 OFFCURVE",
+"135 -125 OFFCURVE",
+"154 -96 CURVE SMOOTH",
+"173 -67 OFFCURVE",
+"186 -36 OFFCURVE",
+"191 -1 CURVE"
+);
+}
+);
+width = 257;
+}
+);
+},
+{
+glyphname = uni071D.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{152, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"208 120 LINE SMOOTH",
+"208 168 OFFCURVE",
+"200 227 OFFCURVE",
+"187 254 CURVE SMOOTH",
+"181 268 OFFCURVE",
+"171 275 OFFCURVE",
+"156 275 CURVE SMOOTH",
+"133 275 OFFCURVE",
+"113 261 OFFCURVE",
+"113 238 CURVE SMOOTH",
+"113 218 OFFCURVE",
+"116 194 OFFCURVE",
+"121 166 CURVE SMOOTH",
+"126 138 OFFCURVE",
+"133 115 OFFCURVE",
+"140 98 CURVE",
+"127 83 OFFCURVE",
+"92 76 OFFCURVE",
+"29 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"29 0 LINE SMOOTH",
+"98 0 OFFCURVE",
+"146 16 OFFCURVE",
+"173 40 CURVE",
+"196 15 OFFCURVE",
+"237 0 OFFCURVE",
+"310 0 CURVE",
+"310 76 LINE",
+"245 76 OFFCURVE",
+"215 84 OFFCURVE",
+"208 100 CURVE",
+"208 110 LINE"
+);
+}
+);
+width = 310;
+}
+);
+},
+{
+glyphname = uni071D.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{135, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"136 83 OFFCURVE",
+"106 76 OFFCURVE",
+"29 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"29 0 LINE SMOOTH",
+"158 0 OFFCURVE",
+"209 46 OFFCURVE",
+"209 138 CURVE",
+"205 203 OFFCURVE",
+"192 277 OFFCURVE",
+"153 275 CURVE",
+"129 275 OFFCURVE",
+"110 262 OFFCURVE",
+"110 234 CURVE SMOOTH",
+"110 217 OFFCURVE",
+"113 194 OFFCURVE",
+"119 166 CURVE",
+"126 139 OFFCURVE",
+"133 116 OFFCURVE",
+"141 99 CURVE"
+);
+}
+);
+width = 278;
+}
+);
+},
+{
+glyphname = uni071E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = uni0717.Fina;
+},
+{
+name = uni071D.Init;
+transform = "{1, 0, 0, 1, 942, 0}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 432, 551}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 580, 551}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 506, 690}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 453, -213}";
+}
+);
+layerId = UUID0;
+width = 1220;
+}
+);
+unicode = 071E;
+},
+{
+glyphname = uni071F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{667, -156}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"458 375 OFFCURVE",
+"410 315 OFFCURVE",
+"398 207 CURVE SMOOTH",
+"386 100 OFFCURVE",
+"368 55 OFFCURVE",
+"296 55 CURVE SMOOTH",
+"251 55 OFFCURVE",
+"214 76 OFFCURVE",
+"185 119 CURVE SMOOTH",
+"156 162 OFFCURVE",
+"142 216 OFFCURVE",
+"142 280 CURVE SMOOTH",
+"142 313 OFFCURVE",
+"148 349 OFFCURVE",
+"156 366 CURVE",
+"91 392 LINE",
+"76 364 OFFCURVE",
+"68 312 OFFCURVE",
+"68 277 CURVE SMOOTH",
+"68 194 OFFCURVE",
+"89 123 OFFCURVE",
+"132 65 CURVE SMOOTH",
+"175 8 OFFCURVE",
+"230 -21 OFFCURVE",
+"299 -21 CURVE",
+"413 -17 OFFCURVE",
+"449 46 OFFCURVE",
+"465 179 CURVE SMOOTH",
+"476 271 OFFCURVE",
+"496 300 OFFCURVE",
+"541 300 CURVE SMOOTH",
+"556 300 OFFCURVE",
+"571 295 OFFCURVE",
+"584 284 CURVE SMOOTH",
+"598 273 OFFCURVE",
+"619 244 OFFCURVE",
+"646 195 CURVE SMOOTH",
+"673 147 OFFCURVE",
+"705 81 OFFCURVE",
+"742 -4 CURVE SMOOTH",
+"779 -89 OFFCURVE",
+"826 -209 OFFCURVE",
+"882 -364 CURVE",
+"950 -344 LINE",
+"899 -197 OFFCURVE",
+"854 -80 OFFCURVE",
+"817 9 CURVE SMOOTH",
+"780 98 OFFCURVE",
+"747 167 OFFCURVE",
+"720 218 CURVE SMOOTH",
+"665 319 OFFCURVE",
+"618 375 OFFCURVE",
+"543 375 CURVE SMOOTH"
+);
+}
+);
+width = 889;
+}
+);
+unicode = 071F;
+},
+{
+glyphname = uni071F.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{667, -160}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"458 375 OFFCURVE",
+"410 315 OFFCURVE",
+"398 207 CURVE SMOOTH",
+"386 100 OFFCURVE",
+"368 55 OFFCURVE",
+"296 55 CURVE SMOOTH",
+"251 55 OFFCURVE",
+"214 76 OFFCURVE",
+"185 119 CURVE SMOOTH",
+"156 162 OFFCURVE",
+"142 216 OFFCURVE",
+"142 280 CURVE SMOOTH",
+"142 313 OFFCURVE",
+"148 349 OFFCURVE",
+"156 366 CURVE",
+"91 392 LINE",
+"76 364 OFFCURVE",
+"68 312 OFFCURVE",
+"68 277 CURVE SMOOTH",
+"68 194 OFFCURVE",
+"89 123 OFFCURVE",
+"132 65 CURVE SMOOTH",
+"175 8 OFFCURVE",
+"230 -21 OFFCURVE",
+"299 -21 CURVE",
+"413 -17 OFFCURVE",
+"449 46 OFFCURVE",
+"465 179 CURVE SMOOTH",
+"476 271 OFFCURVE",
+"496 300 OFFCURVE",
+"541 300 CURVE SMOOTH",
+"556 300 OFFCURVE",
+"571 295 OFFCURVE",
+"584 284 CURVE SMOOTH",
+"598 273 OFFCURVE",
+"619 244 OFFCURVE",
+"646 195 CURVE SMOOTH",
+"673 147 OFFCURVE",
+"705 81 OFFCURVE",
+"742 -4 CURVE SMOOTH",
+"779 -89 OFFCURVE",
+"826 -209 OFFCURVE",
+"882 -364 CURVE",
+"950 -344 LINE",
+"901 -204 OFFCURVE",
+"859 -92 OFFCURVE",
+"820 0 CURVE",
+"886 0 LINE",
+"886 76 LINE",
+"788 76 LINE",
+"697 271 OFFCURVE",
+"650 372 OFFCURVE",
+"543 375 CURVE"
+);
+}
+);
+width = 886;
+}
+);
+},
+{
+glyphname = uni071F.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{546, -93}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"643 0 LINE",
+"643 76 LINE",
+"611 76 LINE",
+"596 104 OFFCURVE",
+"561 156 OFFCURVE",
+"528 207 CURVE",
+"503 242 LINE SMOOTH",
+"453 314 OFFCURVE",
+"408 363 OFFCURVE",
+"368 389 CURVE SMOOTH",
+"329 415 OFFCURVE",
+"284 428 OFFCURVE",
+"233 428 CURVE SMOOTH",
+"177 428 OFFCURVE",
+"126 408 OFFCURVE",
+"75 352 CURVE",
+"120 305 LINE",
+"155 338 OFFCURVE",
+"194 353 OFFCURVE",
+"223 353 CURVE SMOOTH",
+"264 353 OFFCURVE",
+"302 339 OFFCURVE",
+"338 312 CURVE SMOOTH",
+"375 285 OFFCURVE",
+"417 236 OFFCURVE",
+"466 164 CURVE SMOOTH",
+"496 120 LINE",
+"524 76 LINE",
+"0 76 LINE"
+);
+}
+);
+width = 643;
+}
+);
+},
+{
+glyphname = uni071F.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{546, -92}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"120 305 LINE",
+"155 338 OFFCURVE",
+"194 353 OFFCURVE",
+"223 353 CURVE SMOOTH",
+"264 353 OFFCURVE",
+"302 339 OFFCURVE",
+"338 312 CURVE SMOOTH",
+"375 285 OFFCURVE",
+"417 236 OFFCURVE",
+"466 164 CURVE SMOOTH",
+"496 120 LINE",
+"524 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"569 0 LINE SMOOTH",
+"598 0 OFFCURVE",
+"614 21 OFFCURVE",
+"614 57 CURVE SMOOTH",
+"614 66 OFFCURVE",
+"612 75 OFFCURVE",
+"608 82 CURVE SMOOTH",
+"576 133 LINE SMOOTH",
+"559 160 OFFCURVE",
+"543 185 OFFCURVE",
+"526 209 CURVE SMOOTH",
+"503 242 LINE SMOOTH",
+"453 314 OFFCURVE",
+"408 363 OFFCURVE",
+"368 389 CURVE SMOOTH",
+"329 415 OFFCURVE",
+"284 428 OFFCURVE",
+"233 428 CURVE SMOOTH",
+"177 428 OFFCURVE",
+"126 408 OFFCURVE",
+"75 352 CURVE"
+);
+}
+);
+width = 673;
+}
+);
+},
+{
+glyphname = uni0720;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{318, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"284 725 LINE",
+"293 702 OFFCURVE",
+"314 651 OFFCURVE",
+"327 616 CURVE SMOOTH",
+"360 526 LINE SMOOTH",
+"393 438 OFFCURVE",
+"426 349 OFFCURVE",
+"457 260 CURVE SMOOTH",
+"488 171 OFFCURVE",
+"509 109 OFFCURVE",
+"518 76 CURVE",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH",
+"543 0 LINE SMOOTH",
+"575 0 OFFCURVE",
+"592 24 OFFCURVE",
+"592 59 CURVE SMOOTH",
+"592 73 OFFCURVE",
+"590 86 OFFCURVE",
+"587 99 CURVE SMOOTH",
+"584 112 OFFCURVE",
+"573 151 OFFCURVE",
+"552 215 CURVE SMOOTH",
+"531 280 OFFCURVE",
+"497 378 OFFCURVE",
+"448 510 CURVE SMOOTH",
+"399 643 OFFCURVE",
+"368 724 OFFCURVE",
+"355 753 CURVE"
+);
+}
+);
+width = 656;
+}
+);
+leftKerningGroup = uni0720;
+unicode = 0720;
+},
+{
+glyphname = uni0720.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{318, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"546 229 LINE",
+"514 316 LINE",
+"479 410 LINE",
+"444 503 LINE",
+"382 666 LINE",
+"373 694 OFFCURVE",
+"355 736 OFFCURVE",
+"348 753 CURVE",
+"276 725 LINE",
+"290 690 LINE",
+"344 554 LINE",
+"378 464 LINE",
+"415 370 LINE",
+"482 191 LINE",
+"508 120 LINE",
+"496 91 OFFCURVE",
+"454 76 OFFCURVE",
+"403 76 CURVE SMOOTH",
+"267 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"48 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH",
+"392 0 LINE SMOOTH",
+"465 0 OFFCURVE",
+"516 21 OFFCURVE",
+"541 52 CURVE",
+"544 52 LINE",
+"568 19 OFFCURVE",
+"605 0 OFFCURVE",
+"652 0 CURVE",
+"652 76 LINE",
+"620 76 OFFCURVE",
+"592 101 OFFCURVE",
+"572 156 CURVE SMOOTH"
+);
+}
+);
+width = 652;
+}
+);
+},
+{
+glyphname = uni0720.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{193, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"232 229 LINE",
+"200 316 LINE",
+"166 410 LINE",
+"130 503 LINE",
+"68 666 LINE",
+"59 694 OFFCURVE",
+"41 736 OFFCURVE",
+"34 753 CURVE",
+"-38 725 LINE",
+"-24 690 LINE",
+"30 554 LINE",
+"87 405 LINE SMOOTH",
+"112 340 OFFCURVE",
+"129 297 OFFCURVE",
+"136 276 CURVE",
+"168 191 LINE",
+"194 120 LINE",
+"182 91 OFFCURVE",
+"140 76 OFFCURVE",
+"89 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"78 0 LINE SMOOTH",
+"151 0 OFFCURVE",
+"202 21 OFFCURVE",
+"227 52 CURVE",
+"230 52 LINE",
+"254 19 OFFCURVE",
+"291 0 OFFCURVE",
+"338 0 CURVE",
+"338 76 LINE",
+"306 76 OFFCURVE",
+"278 101 OFFCURVE",
+"258 156 CURVE SMOOTH"
+);
+}
+);
+width = 338;
+}
+);
+},
+{
+glyphname = uni0720.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{169, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"229 0 LINE SMOOTH",
+"261 0 OFFCURVE",
+"277 24 OFFCURVE",
+"277 59 CURVE SMOOTH",
+"277 73 OFFCURVE",
+"276 86 OFFCURVE",
+"273 99 CURVE SMOOTH",
+"270 112 OFFCURVE",
+"258 151 OFFCURVE",
+"237 215 CURVE SMOOTH",
+"216 280 OFFCURVE",
+"182 378 OFFCURVE",
+"133 510 CURVE",
+"85 643 OFFCURVE",
+"54 724 OFFCURVE",
+"41 753 CURVE",
+"-31 725 LINE",
+"-20 702 OFFCURVE",
+"-1 651 OFFCURVE",
+"12 616 CURVE SMOOTH",
+"46 526 LINE SMOOTH",
+"79 438 OFFCURVE",
+"111 349 OFFCURVE",
+"142 260 CURVE SMOOTH",
+"173 171 OFFCURVE",
+"194 109 OFFCURVE",
+"204 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 341;
+}
+);
+leftKerningGroup = uni0720;
+},
+{
+glyphname = uni0721;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{607, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"635 0 LINE",
+"759 0 OFFCURVE",
+"816 51 OFFCURVE",
+"816 182 CURVE SMOOTH",
+"816 275 OFFCURVE",
+"800 339 OFFCURVE",
+"769 374 CURVE SMOOTH",
+"738 409 OFFCURVE",
+"690 427 OFFCURVE",
+"625 427 CURVE SMOOTH",
+"616 427 OFFCURVE",
+"604 426 OFFCURVE",
+"589 425 CURVE SMOOTH",
+"538 421 LINE",
+"501 417 OFFCURVE",
+"460 415 OFFCURVE",
+"429 415 CURVE SMOOTH",
+"310 415 OFFCURVE",
+"186 436 OFFCURVE",
+"85 475 CURVE",
+"59 411 LINE",
+"86 396 OFFCURVE",
+"135 381 OFFCURVE",
+"206 366 CURVE SMOOTH",
+"278 351 OFFCURVE",
+"347 344 OFFCURVE",
+"414 343 CURVE",
+"411 313 LINE SMOOTH",
+"408 292 OFFCURVE",
+"407 269 OFFCURVE",
+"406 248 CURVE",
+"403 217 LINE SMOOTH",
+"396 150 OFFCURVE",
+"379 89 OFFCURVE",
+"352 35 CURVE SMOOTH",
+"326 -19 OFFCURVE",
+"284 -78 OFFCURVE",
+"226 -141 CURVE",
+"270 -185 LINE",
+"359 -100 OFFCURVE",
+"423 0 OFFCURVE",
+"443 97 CURVE",
+"447 97 LINE",
+"464 40 OFFCURVE",
+"527 0 OFFCURVE",
+"604 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 347 OFFCURVE",
+"589 354 OFFCURVE",
+"630 354 CURVE SMOOTH",
+"673 354 OFFCURVE",
+"702 341 OFFCURVE",
+"718 316 CURVE SMOOTH",
+"735 291 OFFCURVE",
+"743 247 OFFCURVE",
+"743 182 CURVE SMOOTH",
+"743 105 OFFCURVE",
+"718 76 OFFCURVE",
+"655 76 CURVE SMOOTH",
+"611 76 LINE SMOOTH",
+"538 76 OFFCURVE",
+"503 113 OFFCURVE",
+"487 153 CURVE",
+"480 174 OFFCURVE",
+"476 209 OFFCURVE",
+"476 260 CURVE SMOOTH",
+"476 279 OFFCURVE",
+"479 323 OFFCURVE",
+"483 343 CURVE"
+);
+}
+);
+width = 885;
+}
+);
+unicode = 0721;
+},
+{
+glyphname = uni0721.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{606, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"635 0 LINE",
+"698 0 OFFCURVE",
+"740 13 OFFCURVE",
+"767 42 CURVE",
+"772 42 LINE",
+"800 7 OFFCURVE",
+"835 0 OFFCURVE",
+"894 0 CURVE",
+"894 76 LINE",
+"833 76 OFFCURVE",
+"812 85 OFFCURVE",
+"807 104 CURVE",
+"814 125 OFFCURVE",
+"816 153 OFFCURVE",
+"816 182 CURVE SMOOTH",
+"816 275 OFFCURVE",
+"800 339 OFFCURVE",
+"769 374 CURVE SMOOTH",
+"738 409 OFFCURVE",
+"690 427 OFFCURVE",
+"625 427 CURVE SMOOTH",
+"616 427 OFFCURVE",
+"604 426 OFFCURVE",
+"589 425 CURVE SMOOTH",
+"538 421 LINE",
+"501 417 OFFCURVE",
+"460 415 OFFCURVE",
+"429 415 CURVE SMOOTH",
+"310 415 OFFCURVE",
+"186 436 OFFCURVE",
+"85 475 CURVE",
+"59 411 LINE",
+"86 396 OFFCURVE",
+"135 381 OFFCURVE",
+"206 366 CURVE SMOOTH",
+"278 351 OFFCURVE",
+"347 344 OFFCURVE",
+"414 343 CURVE",
+"411 313 LINE SMOOTH",
+"408 292 OFFCURVE",
+"407 269 OFFCURVE",
+"406 248 CURVE",
+"403 217 LINE SMOOTH",
+"396 150 OFFCURVE",
+"379 89 OFFCURVE",
+"352 35 CURVE SMOOTH",
+"326 -19 OFFCURVE",
+"284 -78 OFFCURVE",
+"226 -141 CURVE",
+"270 -185 LINE",
+"359 -100 OFFCURVE",
+"423 0 OFFCURVE",
+"443 97 CURVE",
+"447 97 LINE",
+"464 40 OFFCURVE",
+"527 0 OFFCURVE",
+"604 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 347 OFFCURVE",
+"589 354 OFFCURVE",
+"630 354 CURVE SMOOTH",
+"673 354 OFFCURVE",
+"702 341 OFFCURVE",
+"718 316 CURVE SMOOTH",
+"735 291 OFFCURVE",
+"743 247 OFFCURVE",
+"743 182 CURVE SMOOTH",
+"743 105 OFFCURVE",
+"718 76 OFFCURVE",
+"655 76 CURVE SMOOTH",
+"611 76 LINE SMOOTH",
+"538 76 OFFCURVE",
+"503 113 OFFCURVE",
+"487 153 CURVE",
+"480 174 OFFCURVE",
+"476 209 OFFCURVE",
+"476 260 CURVE SMOOTH",
+"476 279 OFFCURVE",
+"479 323 OFFCURVE",
+"483 343 CURVE"
+);
+}
+);
+width = 894;
+}
+);
+},
+{
+glyphname = uni0721.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{465, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"172 0 LINE SMOOTH",
+"305 0 OFFCURVE",
+"395 42 OFFCURVE",
+"454 135 CURVE SMOOTH",
+"484 182 OFFCURVE",
+"508 252 OFFCURVE",
+"526 346 CURVE",
+"554 351 OFFCURVE",
+"585 354 OFFCURVE",
+"625 354 CURVE SMOOTH",
+"660 354 OFFCURVE",
+"688 343 OFFCURVE",
+"709 320 CURVE SMOOTH",
+"730 298 OFFCURVE",
+"741 247 OFFCURVE",
+"741 167 CURVE SMOOTH",
+"741 98 OFFCURVE",
+"710 57 OFFCURVE",
+"646 57 CURVE SMOOTH",
+"607 57 OFFCURVE",
+"560 74 OFFCURVE",
+"512 102 CURVE",
+"479 46 LINE",
+"523 13 OFFCURVE",
+"589 -14 OFFCURVE",
+"644 -14 CURVE SMOOTH",
+"703 -14 OFFCURVE",
+"744 5 OFFCURVE",
+"772 38 CURVE",
+"776 38 LINE",
+"801 11 OFFCURVE",
+"835 0 OFFCURVE",
+"896 0 CURVE",
+"896 76 LINE",
+"832 76 OFFCURVE",
+"809 88 OFFCURVE",
+"809 112 CURVE",
+"812 137 OFFCURVE",
+"814 158 OFFCURVE",
+"814 178 CURVE SMOOTH",
+"814 361 OFFCURVE",
+"748 428 OFFCURVE",
+"620 428 CURVE SMOOTH",
+"605 428 OFFCURVE",
+"590 427 OFFCURVE",
+"573 425 CURVE SMOOTH",
+"520 419 LINE SMOOTH",
+"481 415 OFFCURVE",
+"438 411 OFFCURVE",
+"389 411 CURVE SMOOTH",
+"330 411 OFFCURVE",
+"278 415 OFFCURVE",
+"234 422 CURVE SMOOTH",
+"190 429 OFFCURVE",
+"143 445 OFFCURVE",
+"93 470 CURVE",
+"63 406 LINE",
+"118 366 OFFCURVE",
+"230 337 OFFCURVE",
+"370 337 CURVE SMOOTH",
+"383 337 OFFCURVE",
+"397 337 OFFCURVE",
+"412 338 CURVE SMOOTH",
+"453 340 LINE",
+"436 266 OFFCURVE",
+"416 211 OFFCURVE",
+"393 176 CURVE SMOOTH",
+"370 141 OFFCURVE",
+"342 116 OFFCURVE",
+"307 100 CURVE SMOOTH",
+"273 84 OFFCURVE",
+"231 76 OFFCURVE",
+"180 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 896;
+}
+);
+},
+{
+glyphname = uni0721.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{465, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"172 0 LINE SMOOTH",
+"304 0 OFFCURVE",
+"394 41 OFFCURVE",
+"454 134 CURVE SMOOTH",
+"484 181 OFFCURVE",
+"508 251 OFFCURVE",
+"526 345 CURVE",
+"555 350 OFFCURVE",
+"586 354 OFFCURVE",
+"625 354 CURVE SMOOTH",
+"660 354 OFFCURVE",
+"688 343 OFFCURVE",
+"709 320 CURVE SMOOTH",
+"730 298 OFFCURVE",
+"741 247 OFFCURVE",
+"741 167 CURVE SMOOTH",
+"741 98 OFFCURVE",
+"710 57 OFFCURVE",
+"646 57 CURVE SMOOTH",
+"607 57 OFFCURVE",
+"560 74 OFFCURVE",
+"512 102 CURVE",
+"479 46 LINE",
+"523 13 OFFCURVE",
+"589 -14 OFFCURVE",
+"644 -14 CURVE SMOOTH",
+"752 -14 OFFCURVE",
+"814 54 OFFCURVE",
+"814 178 CURVE SMOOTH",
+"814 361 OFFCURVE",
+"748 428 OFFCURVE",
+"620 428 CURVE SMOOTH",
+"605 428 OFFCURVE",
+"590 427 OFFCURVE",
+"573 425 CURVE SMOOTH",
+"520 419 LINE SMOOTH",
+"481 415 OFFCURVE",
+"438 411 OFFCURVE",
+"389 411 CURVE SMOOTH",
+"330 411 OFFCURVE",
+"278 415 OFFCURVE",
+"234 422 CURVE SMOOTH",
+"190 429 OFFCURVE",
+"143 445 OFFCURVE",
+"93 470 CURVE",
+"63 406 LINE",
+"118 366 OFFCURVE",
+"230 337 OFFCURVE",
+"370 337 CURVE SMOOTH",
+"383 337 OFFCURVE",
+"397 337 OFFCURVE",
+"412 338 CURVE SMOOTH",
+"453 340 LINE",
+"436 266 OFFCURVE",
+"416 211 OFFCURVE",
+"393 176 CURVE SMOOTH",
+"370 141 OFFCURVE",
+"342 116 OFFCURVE",
+"307 100 CURVE SMOOTH",
+"273 84 OFFCURVE",
+"231 76 OFFCURVE",
+"180 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 880;
+}
+);
+},
+{
+glyphname = uni0722;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{192, -150}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"78 110 OFFCURVE",
+"59 93 OFFCURVE",
+"59 65 CURVE SMOOTH",
+"59 56 OFFCURVE",
+"62 47 OFFCURVE",
+"68 37 CURVE SMOOTH",
+"75 27 OFFCURVE",
+"99 14 OFFCURVE",
+"140 -3 CURVE SMOOTH",
+"182 -20 OFFCURVE",
+"308 -62 OFFCURVE",
+"518 -129 CURVE SMOOTH",
+"728 -196 OFFCURVE",
+"916 -249 OFFCURVE",
+"1082 -288 CURVE",
+"1102 -223 LINE",
+"1000 -197 OFFCURVE",
+"912 -174 OFFCURVE",
+"839 -153 CURVE SMOOTH",
+"766 -132 OFFCURVE",
+"675 -104 OFFCURVE",
+"566 -67 CURVE SMOOTH",
+"437 -23 LINE",
+"418 -18 OFFCURVE",
+"385 -6 OFFCURVE",
+"338 13 CURVE SMOOTH",
+"292 32 OFFCURVE",
+"258 46 OFFCURVE",
+"237 56 CURVE SMOOTH",
+"206 71 LINE SMOOTH",
+"159 92 OFFCURVE",
+"115 110 OFFCURVE",
+"99 110 CURVE SMOOTH"
+);
+}
+);
+width = 678;
+}
+);
+unicode = 0722;
+},
+{
+glyphname = uni0722.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{123, -391}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"126 96 LINE",
+"120 97 OFFCURVE",
+"115 98 OFFCURVE",
+"112 98 CURVE SMOOTH",
+"81 98 OFFCURVE",
+"62 74 OFFCURVE",
+"62 35 CURVE SMOOTH",
+"62 -7 OFFCURVE",
+"87 -70 OFFCURVE",
+"137 -153 CURVE SMOOTH",
+"188 -237 OFFCURVE",
+"249 -324 OFFCURVE",
+"322 -415 CURVE",
+"380 -373 LINE",
+"335 -316 OFFCURVE",
+"287 -248 OFFCURVE",
+"236 -168 CURVE SMOOTH",
+"185 -88 OFFCURVE",
+"150 -25 OFFCURVE",
+"133 22 CURVE",
+"136 25 LINE",
+"167 13 OFFCURVE",
+"229 0 OFFCURVE",
+"278 0 CURVE",
+"278 76 LINE",
+"237 76 OFFCURVE",
+"200 78 OFFCURVE",
+"140 93 CURVE SMOOTH",
+"126 96 LINE"
+);
+}
+);
+width = 278;
+}
+);
+},
+{
+glyphname = uni0722.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{149, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"90 415 LINE",
+"107 320 OFFCURVE",
+"121 253 OFFCURVE",
+"137 178 CURVE",
+"144 152 LINE",
+"152 120 LINE",
+"139 91 OFFCURVE",
+"97 76 OFFCURVE",
+"30 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"29 0 LINE SMOOTH",
+"108 0 OFFCURVE",
+"155 21 OFFCURVE",
+"184 52 CURVE",
+"188 52 LINE",
+"209 20 OFFCURVE",
+"249 0 OFFCURVE",
+"296 0 CURVE",
+"296 76 LINE",
+"240 74 OFFCURVE",
+"210 148 OFFCURVE",
+"187 296 CURVE",
+"175 356 LINE",
+"163 426 LINE"
+);
+}
+);
+width = 296;
+}
+);
+},
+{
+glyphname = uni0722.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{132, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"91 414 LINE",
+"106 353 OFFCURVE",
+"120 287 OFFCURVE",
+"133 218 CURVE SMOOTH",
+"146 149 OFFCURVE",
+"153 105 OFFCURVE",
+"153 85 CURVE",
+"144 82 OFFCURVE",
+"127 80 OFFCURVE",
+"101 78 CURVE SMOOTH",
+"76 77 OFFCURVE",
+"52 76 OFFCURVE",
+"29 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-26 0 OFFCURVE",
+"15 0 CURVE SMOOTH",
+"112 0 OFFCURVE",
+"170 9 OFFCURVE",
+"191 26 CURVE SMOOTH",
+"212 44 OFFCURVE",
+"223 68 OFFCURVE",
+"223 98 CURVE SMOOTH",
+"223 125 OFFCURVE",
+"217 170 OFFCURVE",
+"206 231 CURVE SMOOTH",
+"195 293 OFFCURVE",
+"181 358 OFFCURVE",
+"164 426 CURVE"
+);
+}
+);
+width = 291;
+}
+);
+leftKerningGroup = uni0722.Init;
+},
+{
+glyphname = uni0723;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{458, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"456 300 LINE",
+"424 391 OFFCURVE",
+"353 440 OFFCURVE",
+"262 440 CURVE SMOOTH",
+"207 440 OFFCURVE",
+"160 420 OFFCURVE",
+"123 379 CURVE SMOOTH",
+"86 339 OFFCURVE",
+"68 286 OFFCURVE",
+"68 221 CURVE SMOOTH",
+"68 73 OFFCURVE",
+"150 0 OFFCURVE",
+"307 0 CURVE SMOOTH",
+"535 0 LINE SMOOTH",
+"686 0 OFFCURVE",
+"754 24 OFFCURVE",
+"790 83 CURVE",
+"809 112 OFFCURVE",
+"818 154 OFFCURVE",
+"818 208 CURVE SMOOTH",
+"818 273 OFFCURVE",
+"801 326 OFFCURVE",
+"767 367 CURVE SMOOTH",
+"734 408 OFFCURVE",
+"692 429 OFFCURVE",
+"641 429 CURVE SMOOTH",
+"558 429 OFFCURVE",
+"492 383 OFFCURVE",
+"459 300 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 76 LINE",
+"201 76 OFFCURVE",
+"142 126 OFFCURVE",
+"142 222 CURVE SMOOTH",
+"142 310 OFFCURVE",
+"191 367 OFFCURVE",
+"263 367 CURVE SMOOTH",
+"352 367 OFFCURVE",
+"407 294 OFFCURVE",
+"414 169 CURVE",
+"418 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"486 177 LINE",
+"486 229 OFFCURVE",
+"501 272 OFFCURVE",
+"530 305 CURVE SMOOTH",
+"559 338 OFFCURVE",
+"594 355 OFFCURVE",
+"633 355 CURVE SMOOTH",
+"702 355 OFFCURVE",
+"745 297 OFFCURVE",
+"745 206 CURVE SMOOTH",
+"745 159 OFFCURVE",
+"733 125 OFFCURVE",
+"708 105 CURVE SMOOTH",
+"684 86 OFFCURVE",
+"639 76 OFFCURVE",
+"574 76 CURVE SMOOTH",
+"489 76 LINE",
+"488 102 OFFCURVE",
+"487 123 OFFCURVE",
+"487 139 CURVE SMOOTH"
+);
+}
+);
+width = 886;
+}
+);
+unicode = 0723;
+},
+{
+glyphname = uni0723.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{452, -99}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"456 300 LINE",
+"424 391 OFFCURVE",
+"353 440 OFFCURVE",
+"262 440 CURVE SMOOTH",
+"207 440 OFFCURVE",
+"160 420 OFFCURVE",
+"123 379 CURVE SMOOTH",
+"86 339 OFFCURVE",
+"68 286 OFFCURVE",
+"68 221 CURVE SMOOTH",
+"68 73 OFFCURVE",
+"150 0 OFFCURVE",
+"307 0 CURVE SMOOTH",
+"535 0 LINE SMOOTH",
+"626 0 OFFCURVE",
+"695 7 OFFCURVE",
+"743 38 CURVE",
+"749 38 LINE",
+"777 11 OFFCURVE",
+"818 0 OFFCURVE",
+"891 0 CURVE",
+"891 76 LINE",
+"843 76 OFFCURVE",
+"810 81 OFFCURVE",
+"795 93 CURVE",
+"811 122 OFFCURVE",
+"818 159 OFFCURVE",
+"818 208 CURVE SMOOTH",
+"818 273 OFFCURVE",
+"801 326 OFFCURVE",
+"767 367 CURVE SMOOTH",
+"734 408 OFFCURVE",
+"692 429 OFFCURVE",
+"641 429 CURVE SMOOTH",
+"558 429 OFFCURVE",
+"492 383 OFFCURVE",
+"459 300 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 76 LINE",
+"201 76 OFFCURVE",
+"142 126 OFFCURVE",
+"142 222 CURVE SMOOTH",
+"142 310 OFFCURVE",
+"191 367 OFFCURVE",
+"263 367 CURVE SMOOTH",
+"352 367 OFFCURVE",
+"407 294 OFFCURVE",
+"414 169 CURVE",
+"418 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"486 177 LINE",
+"486 229 OFFCURVE",
+"501 272 OFFCURVE",
+"530 305 CURVE SMOOTH",
+"559 338 OFFCURVE",
+"594 355 OFFCURVE",
+"633 355 CURVE SMOOTH",
+"702 355 OFFCURVE",
+"745 297 OFFCURVE",
+"745 206 CURVE SMOOTH",
+"745 159 OFFCURVE",
+"733 125 OFFCURVE",
+"708 105 CURVE SMOOTH",
+"684 86 OFFCURVE",
+"639 76 OFFCURVE",
+"574 76 CURVE SMOOTH",
+"489 76 LINE",
+"488 102 OFFCURVE",
+"487 123 OFFCURVE",
+"487 139 CURVE SMOOTH"
+);
+}
+);
+width = 891;
+}
+);
+},
+{
+glyphname = uni0723.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{457, -99}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"460 300 LINE",
+"429 391 OFFCURVE",
+"356 440 OFFCURVE",
+"267 440 CURVE SMOOTH",
+"212 440 OFFCURVE",
+"165 421 OFFCURVE",
+"128 384 CURVE SMOOTH",
+"91 347 OFFCURVE",
+"73 299 OFFCURVE",
+"73 241 CURVE SMOOTH",
+"73 169 OFFCURVE",
+"92 113 OFFCURVE",
+"135 78 CURVE",
+"135 74 LINE",
+"125 75 OFFCURVE",
+"115 76 OFFCURVE",
+"104 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"540 0 LINE SMOOTH",
+"628 0 OFFCURVE",
+"699 7 OFFCURVE",
+"748 38 CURVE",
+"753 38 LINE",
+"781 11 OFFCURVE",
+"823 0 OFFCURVE",
+"896 0 CURVE",
+"896 76 LINE",
+"848 76 OFFCURVE",
+"815 81 OFFCURVE",
+"800 93 CURVE",
+"815 122 OFFCURVE",
+"822 159 OFFCURVE",
+"822 208 CURVE SMOOTH",
+"822 273 OFFCURVE",
+"805 326 OFFCURVE",
+"771 367 CURVE SMOOTH",
+"738 408 OFFCURVE",
+"696 429 OFFCURVE",
+"646 429 CURVE SMOOTH",
+"562 429 OFFCURVE",
+"496 383 OFFCURVE",
+"464 300 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 76 LINE",
+"204 76 OFFCURVE",
+"146 137 OFFCURVE",
+"146 241 CURVE SMOOTH",
+"146 317 OFFCURVE",
+"196 367 OFFCURVE",
+"268 367 CURVE SMOOTH",
+"356 367 OFFCURVE",
+"411 294 OFFCURVE",
+"418 169 CURVE SMOOTH",
+"423 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 177 LINE",
+"491 229 OFFCURVE",
+"505 272 OFFCURVE",
+"534 305 CURVE SMOOTH",
+"563 338 OFFCURVE",
+"598 355 OFFCURVE",
+"638 355 CURVE SMOOTH",
+"706 355 OFFCURVE",
+"749 297 OFFCURVE",
+"749 206 CURVE SMOOTH",
+"749 159 OFFCURVE",
+"737 125 OFFCURVE",
+"713 105 CURVE SMOOTH",
+"689 86 OFFCURVE",
+"644 76 OFFCURVE",
+"579 76 CURVE SMOOTH",
+"493 76 LINE",
+"492 102 OFFCURVE",
+"491 123 OFFCURVE",
+"491 139 CURVE SMOOTH"
+);
+}
+);
+width = 896;
+}
+);
+},
+{
+glyphname = uni0723.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{458, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"460 300 LINE",
+"429 391 OFFCURVE",
+"356 440 OFFCURVE",
+"267 440 CURVE SMOOTH",
+"212 440 OFFCURVE",
+"165 421 OFFCURVE",
+"128 384 CURVE SMOOTH",
+"91 347 OFFCURVE",
+"73 299 OFFCURVE",
+"73 241 CURVE SMOOTH",
+"73 169 OFFCURVE",
+"92 113 OFFCURVE",
+"135 78 CURVE",
+"135 74 LINE",
+"125 75 OFFCURVE",
+"115 76 OFFCURVE",
+"104 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"540 0 LINE SMOOTH",
+"624 0 OFFCURVE",
+"684 8 OFFCURVE",
+"720 23 CURVE SMOOTH",
+"757 38 OFFCURVE",
+"783 61 OFFCURVE",
+"798 90 CURVE SMOOTH",
+"814 119 OFFCURVE",
+"822 159 OFFCURVE",
+"822 208 CURVE SMOOTH",
+"822 273 OFFCURVE",
+"805 326 OFFCURVE",
+"771 367 CURVE SMOOTH",
+"738 408 OFFCURVE",
+"696 429 OFFCURVE",
+"646 429 CURVE SMOOTH",
+"562 429 OFFCURVE",
+"496 383 OFFCURVE",
+"464 300 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"292 76 LINE",
+"204 76 OFFCURVE",
+"146 137 OFFCURVE",
+"146 241 CURVE SMOOTH",
+"146 317 OFFCURVE",
+"196 367 OFFCURVE",
+"268 367 CURVE SMOOTH",
+"356 367 OFFCURVE",
+"411 294 OFFCURVE",
+"418 169 CURVE SMOOTH",
+"423 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 177 LINE",
+"491 229 OFFCURVE",
+"505 272 OFFCURVE",
+"534 305 CURVE SMOOTH",
+"563 338 OFFCURVE",
+"598 355 OFFCURVE",
+"638 355 CURVE SMOOTH",
+"706 355 OFFCURVE",
+"749 297 OFFCURVE",
+"749 206 CURVE SMOOTH",
+"749 159 OFFCURVE",
+"737 125 OFFCURVE",
+"713 105 CURVE SMOOTH",
+"689 86 OFFCURVE",
+"644 76 OFFCURVE",
+"579 76 CURVE SMOOTH",
+"493 76 LINE",
+"492 102 OFFCURVE",
+"491 123 OFFCURVE",
+"491 139 CURVE SMOOTH"
+);
+}
+);
+width = 891;
+}
+);
+},
+{
+glyphname = uni0724;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{454, -97}";
+}
+);
+components = (
+{
+name = uni0723;
+}
+);
+layerId = UUID0;
+width = 886;
+}
+);
+unicode = 0724;
+},
+{
+glyphname = uni0724.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{453, -97}";
+}
+);
+components = (
+{
+name = uni0723.Fina;
+}
+);
+layerId = UUID0;
+width = 891;
+}
+);
+},
+{
+glyphname = uni0724.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{458, -98}";
+}
+);
+components = (
+{
+name = uni0723.Medi;
+}
+);
+layerId = UUID0;
+width = 896;
+}
+);
+},
+{
+glyphname = uni0724.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{458, -98}";
+}
+);
+components = (
+{
+name = uni0723.Init;
+}
+);
+layerId = UUID0;
+width = 891;
+}
+);
+},
+{
+glyphname = uni0725;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{452, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"904 0 LINE",
+"904 76 LINE",
+"868 76 LINE SMOOTH",
+"812 76 OFFCURVE",
+"766 82 OFFCURVE",
+"730 94 CURVE SMOOTH",
+"695 106 OFFCURVE",
+"654 130 OFFCURVE",
+"609 165 CURVE SMOOTH",
+"564 200 OFFCURVE",
+"519 244 OFFCURVE",
+"474 295 CURVE SMOOTH",
+"429 347 OFFCURVE",
+"395 391 OFFCURVE",
+"371 427 CURVE",
+"307 383 LINE",
+"390 260 OFFCURVE",
+"496 150 OFFCURVE",
+"607 78 CURVE",
+"607 72 LINE",
+"567 74 LINE",
+"511 75 LINE",
+"472 76 LINE",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH"
+);
+}
+);
+width = 953;
+}
+);
+leftKerningGroup = uni0725;
+unicode = 0725;
+},
+{
+glyphname = uni0725.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{452, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"743 0 LINE",
+"743 76 LINE",
+"707 76 OFFCURVE",
+"647 118 OFFCURVE",
+"563 202 CURVE",
+"480 287 OFFCURVE",
+"415 362 OFFCURVE",
+"369 427 CURVE",
+"305 383 LINE",
+"332 343 OFFCURVE",
+"377 289 OFFCURVE",
+"440 220 CURVE SMOOTH",
+"503 152 OFFCURVE",
+"556 105 OFFCURVE",
+"597 78 CURVE",
+"597 72 LINE",
+"558 74 LINE",
+"501 75 LINE",
+"462 76 LINE",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH"
+);
+}
+);
+width = 743;
+}
+);
+},
+{
+glyphname = uni0725.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{272, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"500 0 LINE",
+"500 76 LINE",
+"464 76 OFFCURVE",
+"404 118 OFFCURVE",
+"320 202 CURVE",
+"237 287 OFFCURVE",
+"172 362 OFFCURVE",
+"125 427 CURVE",
+"61 383 LINE",
+"88 343 OFFCURVE",
+"134 288 OFFCURVE",
+"197 219 CURVE SMOOTH",
+"261 150 OFFCURVE",
+"313 103 OFFCURVE",
+"354 78 CURVE",
+"354 72 LINE",
+"314 74 LINE",
+"257 75 LINE",
+"219 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 500;
+}
+);
+},
+{
+glyphname = uni0725.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{272, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"660 0 LINE",
+"660 76 LINE",
+"624 76 LINE SMOOTH",
+"568 76 OFFCURVE",
+"522 82 OFFCURVE",
+"487 94 CURVE SMOOTH",
+"452 106 OFFCURVE",
+"411 130 OFFCURVE",
+"366 165 CURVE SMOOTH",
+"321 200 OFFCURVE",
+"276 244 OFFCURVE",
+"231 295 CURVE SMOOTH",
+"186 347 OFFCURVE",
+"152 391 OFFCURVE",
+"127 427 CURVE",
+"63 383 LINE",
+"146 260 OFFCURVE",
+"252 150 OFFCURVE",
+"363 78 CURVE",
+"363 72 LINE",
+"324 74 LINE",
+"267 75 LINE",
+"229 76 LINE"
+);
+}
+);
+width = 709;
+}
+);
+leftKerningGroup = uni0725;
+},
+{
+glyphname = uni0726;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{737, -94}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"711 0 LINE",
+"758 0 OFFCURVE",
+"785 29 OFFCURVE",
+"785 84 CURVE SMOOTH",
+"785 103 OFFCURVE",
+"777 138 OFFCURVE",
+"761 187 CURVE SMOOTH",
+"745 236 OFFCURVE",
+"729 280 OFFCURVE",
+"714 319 CURVE SMOOTH",
+"693 373 LINE SMOOTH",
+"667 436 OFFCURVE",
+"640 481 OFFCURVE",
+"611 509 CURVE",
+"583 538 OFFCURVE",
+"542 552 OFFCURVE",
+"489 552 CURVE SMOOTH",
+"442 552 OFFCURVE",
+"399 532 OFFCURVE",
+"362 493 CURVE SMOOTH",
+"325 454 OFFCURVE",
+"307 407 OFFCURVE",
+"307 353 CURVE SMOOTH",
+"307 250 OFFCURVE",
+"367 202 OFFCURVE",
+"510 202 CURVE SMOOTH",
+"561 202 OFFCURVE",
+"616 207 OFFCURVE",
+"671 226 CURVE",
+"694 163 OFFCURVE",
+"712 101 OFFCURVE",
+"715 76 CURVE",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"647 291 LINE",
+"610 280 OFFCURVE",
+"565 274 OFFCURVE",
+"513 274 CURVE SMOOTH",
+"424 274 OFFCURVE",
+"380 296 OFFCURVE",
+"380 359 CURVE SMOOTH",
+"380 389 OFFCURVE",
+"391 416 OFFCURVE",
+"413 440 CURVE SMOOTH",
+"436 465 OFFCURVE",
+"461 477 OFFCURVE",
+"488 477 CURVE SMOOTH",
+"541 477 OFFCURVE",
+"562 460 OFFCURVE",
+"586 423 CURVE",
+"599 405 OFFCURVE",
+"614 375 OFFCURVE",
+"631 332 CURVE SMOOTH"
+);
+}
+);
+width = 843;
+}
+);
+unicode = 0726;
+},
+{
+glyphname = uni0726.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{736, -81}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"846 76 LINE",
+"821 76 OFFCURVE",
+"801 93 OFFCURVE",
+"786 126 CURVE SMOOTH",
+"771 160 OFFCURVE",
+"748 222 OFFCURVE",
+"716 311 CURVE SMOOTH",
+"684 401 OFFCURVE",
+"653 464 OFFCURVE",
+"622 499 CURVE SMOOTH",
+"591 534 OFFCURVE",
+"547 552 OFFCURVE",
+"488 552 CURVE SMOOTH",
+"441 552 OFFCURVE",
+"398 532 OFFCURVE",
+"361 493 CURVE SMOOTH",
+"324 454 OFFCURVE",
+"306 407 OFFCURVE",
+"306 353 CURVE SMOOTH",
+"306 250 OFFCURVE",
+"366 202 OFFCURVE",
+"509 202 CURVE SMOOTH",
+"560 202 OFFCURVE",
+"615 207 OFFCURVE",
+"671 226 CURVE",
+"692 168 LINE SMOOTH",
+"699 150 OFFCURVE",
+"706 133 OFFCURVE",
+"711 118 CURVE",
+"698 89 OFFCURVE",
+"651 76 OFFCURVE",
+"602 76 CURVE SMOOTH",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH",
+"591 0 LINE SMOOTH",
+"667 0 OFFCURVE",
+"717 21 OFFCURVE",
+"744 50 CURVE",
+"748 50 LINE",
+"772 14 OFFCURVE",
+"805 0 OFFCURVE",
+"846 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 280 OFFCURVE",
+"564 274 OFFCURVE",
+"512 274 CURVE SMOOTH",
+"423 274 OFFCURVE",
+"379 296 OFFCURVE",
+"379 359 CURVE SMOOTH",
+"379 389 OFFCURVE",
+"390 416 OFFCURVE",
+"412 440 CURVE SMOOTH",
+"435 465 OFFCURVE",
+"460 477 OFFCURVE",
+"487 477 CURVE",
+"580 474 OFFCURVE",
+"588 428 OFFCURVE",
+"646 291 CURVE"
+);
+}
+);
+width = 846;
+}
+);
+},
+{
+glyphname = uni0726.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{509, -83}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"620 76 LINE",
+"595 76 OFFCURVE",
+"575 93 OFFCURVE",
+"560 126 CURVE SMOOTH",
+"545 160 OFFCURVE",
+"522 222 OFFCURVE",
+"489 311 CURVE",
+"457 401 OFFCURVE",
+"426 464 OFFCURVE",
+"395 499 CURVE SMOOTH",
+"365 534 OFFCURVE",
+"321 552 OFFCURVE",
+"262 552 CURVE SMOOTH",
+"215 552 OFFCURVE",
+"172 532 OFFCURVE",
+"135 493 CURVE SMOOTH",
+"98 454 OFFCURVE",
+"79 407 OFFCURVE",
+"79 353 CURVE SMOOTH",
+"79 250 OFFCURVE",
+"139 202 OFFCURVE",
+"283 202 CURVE SMOOTH",
+"332 202 OFFCURVE",
+"389 207 OFFCURVE",
+"444 226 CURVE",
+"466 168 LINE",
+"485 118 LINE",
+"470 89 OFFCURVE",
+"426 76 OFFCURVE",
+"375 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"365 0 LINE SMOOTH",
+"440 0 OFFCURVE",
+"492 21 OFFCURVE",
+"517 50 CURVE",
+"521 50 LINE",
+"545 14 OFFCURVE",
+"579 0 OFFCURVE",
+"620 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 280 OFFCURVE",
+"337 274 OFFCURVE",
+"285 274 CURVE SMOOTH",
+"196 274 OFFCURVE",
+"152 296 OFFCURVE",
+"152 359 CURVE SMOOTH",
+"152 389 OFFCURVE",
+"163 416 OFFCURVE",
+"185 440 CURVE SMOOTH",
+"208 465 OFFCURVE",
+"233 477 OFFCURVE",
+"260 477 CURVE",
+"354 474 OFFCURVE",
+"363 428 OFFCURVE",
+"420 291 CURVE"
+);
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = uni0726.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{511, -94}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"484 0 LINE",
+"529 0 OFFCURVE",
+"557 29 OFFCURVE",
+"557 84 CURVE SMOOTH",
+"557 103 OFFCURVE",
+"549 138 OFFCURVE",
+"533 187 CURVE SMOOTH",
+"517 236 OFFCURVE",
+"501 280 OFFCURVE",
+"486 319 CURVE",
+"487 319 LINE",
+"465 373 LINE SMOOTH",
+"440 436 OFFCURVE",
+"413 481 OFFCURVE",
+"384 509 CURVE SMOOTH",
+"355 538 OFFCURVE",
+"315 552 OFFCURVE",
+"262 552 CURVE SMOOTH",
+"215 552 OFFCURVE",
+"172 532 OFFCURVE",
+"135 493 CURVE SMOOTH",
+"98 454 OFFCURVE",
+"79 407 OFFCURVE",
+"79 353 CURVE SMOOTH",
+"79 250 OFFCURVE",
+"139 202 OFFCURVE",
+"283 202 CURVE SMOOTH",
+"332 202 OFFCURVE",
+"389 207 OFFCURVE",
+"444 226 CURVE",
+"465 163 OFFCURVE",
+"485 101 OFFCURVE",
+"488 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"420 291 LINE",
+"382 280 OFFCURVE",
+"337 274 OFFCURVE",
+"285 274 CURVE SMOOTH",
+"196 274 OFFCURVE",
+"152 296 OFFCURVE",
+"152 359 CURVE SMOOTH",
+"152 389 OFFCURVE",
+"163 416 OFFCURVE",
+"185 440 CURVE SMOOTH",
+"208 465 OFFCURVE",
+"233 477 OFFCURVE",
+"260 477 CURVE SMOOTH",
+"313 477 OFFCURVE",
+"335 460 OFFCURVE",
+"359 423 CURVE SMOOTH",
+"371 405 OFFCURVE",
+"386 375 OFFCURVE",
+"404 332 CURVE SMOOTH"
+);
+}
+);
+width = 616;
+}
+);
+},
+{
+glyphname = uni0727;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{439, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"758 76 LINE",
+"689 76 LINE SMOOTH",
+"454 76 OFFCURVE",
+"338 150 OFFCURVE",
+"338 287 CURVE SMOOTH",
+"338 327 OFFCURVE",
+"352 360 OFFCURVE",
+"379 385 CURVE SMOOTH",
+"407 410 OFFCURVE",
+"441 423 OFFCURVE",
+"481 423 CURVE SMOOTH",
+"557 423 OFFCURVE",
+"610 387 OFFCURVE",
+"610 328 CURVE SMOOTH",
+"610 284 OFFCURVE",
+"586 255 OFFCURVE",
+"541 255 CURVE SMOOTH",
+"508 255 OFFCURVE",
+"480 275 OFFCURVE",
+"475 319 CURVE",
+"416 312 LINE",
+"416 239 OFFCURVE",
+"465 189 OFFCURVE",
+"544 189 CURVE SMOOTH",
+"631 189 OFFCURVE",
+"680 240 OFFCURVE",
+"680 329 CURVE SMOOTH",
+"680 377 OFFCURVE",
+"661 417 OFFCURVE",
+"622 449 CURVE SMOOTH",
+"583 481 OFFCURVE",
+"536 497 OFFCURVE",
+"479 497 CURVE SMOOTH",
+"417 497 OFFCURVE",
+"366 477 OFFCURVE",
+"325 436 CURVE SMOOTH",
+"284 395 OFFCURVE",
+"264 344 OFFCURVE",
+"264 283 CURVE SMOOTH",
+"264 190 OFFCURVE",
+"306 111 OFFCURVE",
+"375 78 CURVE",
+"375 74 LINE",
+"364 75 OFFCURVE",
+"354 76 OFFCURVE",
+"343 76 CURVE SMOOTH",
+"272 76 LINE SMOOTH",
+"184 76 OFFCURVE",
+"139 89 OFFCURVE",
+"104 138 CURVE",
+"59 78 LINE",
+"79 30 OFFCURVE",
+"146 0 OFFCURVE",
+"250 0 CURVE SMOOTH",
+"758 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"433 643 OFFCURVE",
+"414 663 OFFCURVE",
+"381 663 CURVE SMOOTH",
+"350 663 OFFCURVE",
+"332 643 OFFCURVE",
+"332 606 CURVE SMOOTH",
+"332 566 OFFCURVE",
+"353 550 OFFCURVE",
+"381 550 CURVE SMOOTH",
+"414 550 OFFCURVE",
+"433 570 OFFCURVE",
+"433 606 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 643 OFFCURVE",
+"599 663 OFFCURVE",
+"566 663 CURVE SMOOTH",
+"534 663 OFFCURVE",
+"517 643 OFFCURVE",
+"517 606 CURVE SMOOTH",
+"517 566 OFFCURVE",
+"537 550 OFFCURVE",
+"566 550 CURVE SMOOTH",
+"598 550 OFFCURVE",
+"618 570 OFFCURVE",
+"618 606 CURVE SMOOTH"
+);
+}
+);
+width = 807;
+}
+);
+leftKerningGroup = uni0727;
+unicode = 0727;
+},
+{
+glyphname = uni0727.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{440, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"758 76 LINE",
+"689 76 LINE SMOOTH",
+"454 76 OFFCURVE",
+"338 150 OFFCURVE",
+"338 287 CURVE SMOOTH",
+"338 327 OFFCURVE",
+"352 360 OFFCURVE",
+"379 385 CURVE SMOOTH",
+"407 410 OFFCURVE",
+"441 423 OFFCURVE",
+"481 423 CURVE SMOOTH",
+"557 423 OFFCURVE",
+"610 387 OFFCURVE",
+"610 328 CURVE SMOOTH",
+"610 284 OFFCURVE",
+"586 255 OFFCURVE",
+"541 255 CURVE SMOOTH",
+"508 255 OFFCURVE",
+"480 275 OFFCURVE",
+"475 319 CURVE",
+"416 312 LINE",
+"416 239 OFFCURVE",
+"465 189 OFFCURVE",
+"544 189 CURVE SMOOTH",
+"631 189 OFFCURVE",
+"680 240 OFFCURVE",
+"680 329 CURVE SMOOTH",
+"680 377 OFFCURVE",
+"661 417 OFFCURVE",
+"622 449 CURVE SMOOTH",
+"583 481 OFFCURVE",
+"536 497 OFFCURVE",
+"479 497 CURVE SMOOTH",
+"417 497 OFFCURVE",
+"366 477 OFFCURVE",
+"325 436 CURVE SMOOTH",
+"284 395 OFFCURVE",
+"264 344 OFFCURVE",
+"264 283 CURVE SMOOTH",
+"264 190 OFFCURVE",
+"306 111 OFFCURVE",
+"375 78 CURVE",
+"375 74 LINE",
+"364 75 OFFCURVE",
+"354 76 OFFCURVE",
+"343 76 CURVE SMOOTH",
+"272 76 LINE SMOOTH",
+"184 76 OFFCURVE",
+"139 89 OFFCURVE",
+"104 138 CURVE",
+"59 78 LINE",
+"79 30 OFFCURVE",
+"146 0 OFFCURVE",
+"250 0 CURVE SMOOTH",
+"758 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"433 643 OFFCURVE",
+"414 663 OFFCURVE",
+"381 663 CURVE SMOOTH",
+"350 663 OFFCURVE",
+"332 643 OFFCURVE",
+"332 606 CURVE SMOOTH",
+"332 566 OFFCURVE",
+"353 550 OFFCURVE",
+"381 550 CURVE SMOOTH",
+"414 550 OFFCURVE",
+"433 570 OFFCURVE",
+"433 606 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 643 OFFCURVE",
+"599 663 OFFCURVE",
+"566 663 CURVE SMOOTH",
+"534 663 OFFCURVE",
+"517 643 OFFCURVE",
+"517 606 CURVE SMOOTH",
+"517 566 OFFCURVE",
+"537 550 OFFCURVE",
+"566 550 CURVE SMOOTH",
+"598 550 OFFCURVE",
+"618 570 OFFCURVE",
+"618 606 CURVE SMOOTH"
+);
+}
+);
+width = 758;
+}
+);
+},
+{
+glyphname = uni0727.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{311, -96}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"581 76 LINE",
+"512 76 LINE SMOOTH",
+"277 76 OFFCURVE",
+"161 150 OFFCURVE",
+"161 287 CURVE SMOOTH",
+"161 327 OFFCURVE",
+"175 360 OFFCURVE",
+"203 385 CURVE SMOOTH",
+"231 410 OFFCURVE",
+"265 423 OFFCURVE",
+"305 423 CURVE SMOOTH",
+"380 423 OFFCURVE",
+"433 387 OFFCURVE",
+"433 328 CURVE SMOOTH",
+"433 284 OFFCURVE",
+"409 255 OFFCURVE",
+"364 255 CURVE SMOOTH",
+"331 255 OFFCURVE",
+"303 275 OFFCURVE",
+"298 319 CURVE",
+"239 312 LINE",
+"239 239 OFFCURVE",
+"290 189 OFFCURVE",
+"367 189 CURVE SMOOTH",
+"455 189 OFFCURVE",
+"503 240 OFFCURVE",
+"503 329 CURVE SMOOTH",
+"503 377 OFFCURVE",
+"484 417 OFFCURVE",
+"445 449 CURVE SMOOTH",
+"407 481 OFFCURVE",
+"359 497 OFFCURVE",
+"302 497 CURVE SMOOTH",
+"240 497 OFFCURVE",
+"189 477 OFFCURVE",
+"148 436 CURVE SMOOTH",
+"107 395 OFFCURVE",
+"87 344 OFFCURVE",
+"87 283 CURVE SMOOTH",
+"87 190 OFFCURVE",
+"129 111 OFFCURVE",
+"198 78 CURVE",
+"198 74 LINE",
+"187 75 OFFCURVE",
+"177 76 OFFCURVE",
+"167 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"581 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 643 OFFCURVE",
+"237 663 OFFCURVE",
+"205 663 CURVE SMOOTH",
+"173 663 OFFCURVE",
+"155 643 OFFCURVE",
+"155 606 CURVE SMOOTH",
+"155 566 OFFCURVE",
+"176 550 OFFCURVE",
+"205 550 CURVE SMOOTH",
+"237 550 OFFCURVE",
+"256 570 OFFCURVE",
+"256 606 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 643 OFFCURVE",
+"422 663 OFFCURVE",
+"389 663 CURVE SMOOTH",
+"358 663 OFFCURVE",
+"340 643 OFFCURVE",
+"340 606 CURVE SMOOTH",
+"340 566 OFFCURVE",
+"361 550 OFFCURVE",
+"389 550 CURVE SMOOTH",
+"422 550 OFFCURVE",
+"441 570 OFFCURVE",
+"441 606 CURVE SMOOTH"
+);
+}
+);
+width = 581;
+}
+);
+},
+{
+glyphname = uni0727.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{310, -95}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"581 76 LINE",
+"512 76 LINE SMOOTH",
+"277 76 OFFCURVE",
+"161 150 OFFCURVE",
+"161 287 CURVE SMOOTH",
+"161 327 OFFCURVE",
+"175 360 OFFCURVE",
+"203 385 CURVE SMOOTH",
+"231 410 OFFCURVE",
+"265 423 OFFCURVE",
+"305 423 CURVE SMOOTH",
+"380 423 OFFCURVE",
+"433 387 OFFCURVE",
+"433 328 CURVE SMOOTH",
+"433 284 OFFCURVE",
+"409 255 OFFCURVE",
+"364 255 CURVE SMOOTH",
+"331 255 OFFCURVE",
+"303 275 OFFCURVE",
+"298 319 CURVE",
+"239 312 LINE",
+"239 239 OFFCURVE",
+"290 189 OFFCURVE",
+"367 189 CURVE SMOOTH",
+"455 189 OFFCURVE",
+"503 240 OFFCURVE",
+"503 329 CURVE SMOOTH",
+"503 377 OFFCURVE",
+"484 417 OFFCURVE",
+"445 449 CURVE SMOOTH",
+"407 481 OFFCURVE",
+"359 497 OFFCURVE",
+"302 497 CURVE SMOOTH",
+"240 497 OFFCURVE",
+"189 477 OFFCURVE",
+"148 436 CURVE SMOOTH",
+"107 395 OFFCURVE",
+"87 344 OFFCURVE",
+"87 283 CURVE SMOOTH",
+"87 190 OFFCURVE",
+"129 111 OFFCURVE",
+"198 78 CURVE",
+"198 74 LINE",
+"187 75 OFFCURVE",
+"177 76 OFFCURVE",
+"167 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"581 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 643 OFFCURVE",
+"237 663 OFFCURVE",
+"205 663 CURVE SMOOTH",
+"173 663 OFFCURVE",
+"155 643 OFFCURVE",
+"155 606 CURVE SMOOTH",
+"155 566 OFFCURVE",
+"176 550 OFFCURVE",
+"205 550 CURVE SMOOTH",
+"237 550 OFFCURVE",
+"256 570 OFFCURVE",
+"256 606 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 643 OFFCURVE",
+"422 663 OFFCURVE",
+"389 663 CURVE SMOOTH",
+"358 663 OFFCURVE",
+"340 643 OFFCURVE",
+"340 606 CURVE SMOOTH",
+"340 566 OFFCURVE",
+"361 550 OFFCURVE",
+"389 550 CURVE SMOOTH",
+"422 550 OFFCURVE",
+"441 570 OFFCURVE",
+"441 606 CURVE SMOOTH"
+);
+}
+);
+width = 592;
+}
+);
+leftKerningGroup = uni0727;
+},
+{
+glyphname = uni0728;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{293, -444}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"298 22 LINE",
+"325 13 OFFCURVE",
+"359 0 OFFCURVE",
+"402 0 CURVE SMOOTH",
+"481 0 OFFCURVE",
+"535 42 OFFCURVE",
+"539 114 CURVE",
+"470 114 LINE",
+"462 89 OFFCURVE",
+"440 76 OFFCURVE",
+"404 76 CURVE SMOOTH",
+"377 76 OFFCURVE",
+"348 83 OFFCURVE",
+"317 98 CURVE SMOOTH",
+"286 113 OFFCURVE",
+"257 120 OFFCURVE",
+"229 120 CURVE SMOOTH",
+"194 120 OFFCURVE",
+"164 108 OFFCURVE",
+"139 84 CURVE SMOOTH",
+"114 61 OFFCURVE",
+"101 32 OFFCURVE",
+"101 -1 CURVE SMOOTH",
+"101 -73 OFFCURVE",
+"147 -117 OFFCURVE",
+"231 -146 CURVE SMOOTH",
+"273 -161 OFFCURVE",
+"321 -176 OFFCURVE",
+"374 -193 CURVE SMOOTH",
+"427 -210 OFFCURVE",
+"454 -228 OFFCURVE",
+"454 -247 CURVE SMOOTH",
+"454 -274 OFFCURVE",
+"440 -289 OFFCURVE",
+"369 -298 CURVE SMOOTH",
+"334 -303 OFFCURVE",
+"266 -305 OFFCURVE",
+"165 -305 CURVE SMOOTH",
+"53 -305 OFFCURVE",
+"-54 -302 OFFCURVE",
+"-189 -297 CURVE",
+"-195 -367 LINE",
+"-143 -371 OFFCURVE",
+"-93 -374 OFFCURVE",
+"-48 -375 CURVE SMOOTH",
+"25 -377 LINE",
+"66 -380 OFFCURVE",
+"109 -380 OFFCURVE",
+"145 -380 CURVE SMOOTH",
+"183 -381 LINE",
+"352 -381 OFFCURVE",
+"441 -367 OFFCURVE",
+"490 -334 CURVE SMOOTH",
+"515 -317 OFFCURVE",
+"527 -288 OFFCURVE",
+"527 -247 CURVE SMOOTH",
+"527 -178 OFFCURVE",
+"470 -141 OFFCURVE",
+"338 -102 CURVE SMOOTH",
+"272 -83 OFFCURVE",
+"228 -67 OFFCURVE",
+"206 -52 CURVE SMOOTH",
+"185 -38 OFFCURVE",
+"174 -21 OFFCURVE",
+"174 -2 CURVE SMOOTH",
+"174 27 OFFCURVE",
+"198 45 OFFCURVE",
+"227 45 CURVE SMOOTH",
+"238 45 OFFCURVE",
+"249 43 OFFCURVE",
+"260 38 CURVE SMOOTH",
+"298 22 LINE"
+);
+}
+);
+width = 626;
+}
+);
+rightKerningGroup = uni0728;
+unicode = 0728;
+},
+{
+glyphname = uni0728.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{294, -443}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"162 27 OFFCURVE",
+"185 45 OFFCURVE",
+"214 45 CURVE SMOOTH",
+"229 45 OFFCURVE",
+"255 37 OFFCURVE",
+"290 22 CURVE SMOOTH",
+"326 7 OFFCURVE",
+"355 0 OFFCURVE",
+"377 0 CURVE SMOOTH",
+"417 0 OFFCURVE",
+"450 6 OFFCURVE",
+"471 33 CURVE",
+"475 33 LINE",
+"495 6 OFFCURVE",
+"525 0 OFFCURVE",
+"556 0 CURVE",
+"556 76 LINE",
+"536 76 OFFCURVE",
+"518 91 OFFCURVE",
+"515 114 CURVE",
+"458 114 LINE",
+"447 87 OFFCURVE",
+"425 76 OFFCURVE",
+"389 76 CURVE SMOOTH",
+"368 76 OFFCURVE",
+"342 83 OFFCURVE",
+"309 98 CURVE SMOOTH",
+"277 113 OFFCURVE",
+"246 120 OFFCURVE",
+"217 120 CURVE SMOOTH",
+"182 120 OFFCURVE",
+"152 108 OFFCURVE",
+"127 84 CURVE SMOOTH",
+"102 61 OFFCURVE",
+"89 32 OFFCURVE",
+"89 -1 CURVE SMOOTH",
+"89 -74 OFFCURVE",
+"146 -118 OFFCURVE",
+"227 -145 CURVE SMOOTH",
+"297 -168 LINE",
+"354 -186 LINE SMOOTH",
+"421 -206 OFFCURVE",
+"454 -223 OFFCURVE",
+"454 -247 CURVE SMOOTH",
+"454 -274 OFFCURVE",
+"440 -289 OFFCURVE",
+"369 -298 CURVE SMOOTH",
+"334 -303 OFFCURVE",
+"266 -305 OFFCURVE",
+"165 -305 CURVE SMOOTH",
+"53 -305 OFFCURVE",
+"-54 -302 OFFCURVE",
+"-189 -297 CURVE",
+"-195 -367 LINE",
+"-143 -371 OFFCURVE",
+"-93 -374 OFFCURVE",
+"-48 -375 CURVE SMOOTH",
+"25 -377 LINE",
+"66 -380 OFFCURVE",
+"109 -380 OFFCURVE",
+"145 -380 CURVE SMOOTH",
+"183 -381 LINE",
+"352 -381 OFFCURVE",
+"441 -367 OFFCURVE",
+"490 -334 CURVE SMOOTH",
+"515 -317 OFFCURVE",
+"527 -288 OFFCURVE",
+"527 -247 CURVE SMOOTH",
+"527 -178 OFFCURVE",
+"469 -141 OFFCURVE",
+"333 -101 CURVE SMOOTH",
+"265 -81 OFFCURVE",
+"219 -64 OFFCURVE",
+"196 -50 CURVE SMOOTH",
+"173 -37 OFFCURVE",
+"162 -21 OFFCURVE",
+"162 -2 CURVE SMOOTH"
+);
+}
+);
+width = 556;
+}
+);
+rightKerningGroup = uni0728;
+},
+{
+glyphname = uni0729;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{533, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"380 426 LINE",
+"308 426 OFFCURVE",
+"265 376 OFFCURVE",
+"265 304 CURVE SMOOTH",
+"265 181 OFFCURVE",
+"278 124 OFFCURVE",
+"309 84 CURVE",
+"286 53 OFFCURVE",
+"259 32 OFFCURVE",
+"208 32 CURVE SMOOTH",
+"160 32 OFFCURVE",
+"125 49 OFFCURVE",
+"94 93 CURVE",
+"49 50 LINE",
+"69 1 OFFCURVE",
+"132 -39 OFFCURVE",
+"201 -39 CURVE SMOOTH",
+"274 -39 OFFCURVE",
+"327 -15 OFFCURVE",
+"359 29 CURVE",
+"386 10 OFFCURVE",
+"421 0 OFFCURVE",
+"466 0 CURVE SMOOTH",
+"585 0 LINE SMOOTH",
+"709 0 OFFCURVE",
+"766 53 OFFCURVE",
+"766 170 CURVE SMOOTH",
+"766 189 OFFCURVE",
+"763 221 OFFCURVE",
+"758 268 CURVE SMOOTH",
+"753 315 OFFCURVE",
+"744 348 OFFCURVE",
+"731 369 CURVE SMOOTH",
+"704 412 OFFCURVE",
+"665 426 OFFCURVE",
+"584 426 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 353 LINE",
+"624 353 OFFCURVE",
+"649 347 OFFCURVE",
+"661 334 CURVE SMOOTH",
+"674 321 OFFCURVE",
+"682 297 OFFCURVE",
+"687 260 CURVE SMOOTH",
+"692 224 OFFCURVE",
+"694 192 OFFCURVE",
+"694 164 CURVE SMOOTH",
+"694 107 OFFCURVE",
+"669 76 OFFCURVE",
+"606 76 CURVE SMOOTH",
+"488 76 LINE SMOOTH",
+"400 76 OFFCURVE",
+"370 103 OFFCURVE",
+"351 162 CURVE SMOOTH",
+"342 192 OFFCURVE",
+"337 231 OFFCURVE",
+"337 280 CURVE SMOOTH",
+"337 333 OFFCURVE",
+"354 353 OFFCURVE",
+"401 353 CURVE SMOOTH"
+);
+}
+);
+width = 834;
+}
+);
+unicode = 0729;
+},
+{
+glyphname = uni0729.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{534, -99}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"380 426 LINE",
+"308 426 OFFCURVE",
+"265 376 OFFCURVE",
+"265 304 CURVE SMOOTH",
+"265 187 OFFCURVE",
+"276 125 OFFCURVE",
+"311 81 CURVE",
+"290 52 OFFCURVE",
+"257 32 OFFCURVE",
+"208 32 CURVE SMOOTH",
+"160 32 OFFCURVE",
+"125 49 OFFCURVE",
+"94 93 CURVE",
+"49 50 LINE",
+"69 1 OFFCURVE",
+"132 -39 OFFCURVE",
+"201 -39 CURVE SMOOTH",
+"270 -39 OFFCURVE",
+"323 -18 OFFCURVE",
+"358 30 CURVE",
+"362 30 LINE",
+"383 10 OFFCURVE",
+"421 0 OFFCURVE",
+"466 0 CURVE SMOOTH",
+"585 0 LINE SMOOTH",
+"648 0 OFFCURVE",
+"684 9 OFFCURVE",
+"717 42 CURVE",
+"723 42 LINE",
+"751 7 OFFCURVE",
+"785 0 OFFCURVE",
+"845 0 CURVE",
+"845 76 LINE",
+"785 76 OFFCURVE",
+"764 84 OFFCURVE",
+"757 103 CURVE",
+"763 122 OFFCURVE",
+"766 144 OFFCURVE",
+"766 170 CURVE SMOOTH",
+"766 189 OFFCURVE",
+"763 221 OFFCURVE",
+"758 268 CURVE SMOOTH",
+"753 315 OFFCURVE",
+"744 348 OFFCURVE",
+"731 369 CURVE SMOOTH",
+"704 412 OFFCURVE",
+"665 426 OFFCURVE",
+"584 426 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 353 LINE",
+"624 353 OFFCURVE",
+"649 347 OFFCURVE",
+"661 334 CURVE SMOOTH",
+"674 321 OFFCURVE",
+"682 297 OFFCURVE",
+"687 260 CURVE SMOOTH",
+"692 224 OFFCURVE",
+"694 192 OFFCURVE",
+"694 164 CURVE SMOOTH",
+"694 107 OFFCURVE",
+"669 76 OFFCURVE",
+"606 76 CURVE SMOOTH",
+"488 76 LINE SMOOTH",
+"400 76 OFFCURVE",
+"370 103 OFFCURVE",
+"351 162 CURVE SMOOTH",
+"342 192 OFFCURVE",
+"337 231 OFFCURVE",
+"337 280 CURVE SMOOTH",
+"337 333 OFFCURVE",
+"354 353 OFFCURVE",
+"401 353 CURVE SMOOTH"
+);
+}
+);
+width = 845;
+}
+);
+},
+{
+glyphname = uni0729.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{364, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"211 426 LINE",
+"138 426 OFFCURVE",
+"95 376 OFFCURVE",
+"95 304 CURVE SMOOTH",
+"95 211 OFFCURVE",
+"102 148 OFFCURVE",
+"127 103 CURVE",
+"122 84 OFFCURVE",
+"98 76 OFFCURVE",
+"45 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"35 0 LINE SMOOTH",
+"107 0 OFFCURVE",
+"150 15 OFFCURVE",
+"167 48 CURVE",
+"172 48 LINE",
+"200 15 OFFCURVE",
+"237 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"416 0 LINE SMOOTH",
+"480 0 OFFCURVE",
+"516 11 OFFCURVE",
+"548 42 CURVE",
+"553 42 LINE",
+"582 7 OFFCURVE",
+"616 0 OFFCURVE",
+"675 0 CURVE",
+"675 76 LINE",
+"616 76 OFFCURVE",
+"595 84 OFFCURVE",
+"588 103 CURVE",
+"594 122 OFFCURVE",
+"597 145 OFFCURVE",
+"597 170 CURVE SMOOTH",
+"597 220 OFFCURVE",
+"592 267 OFFCURVE",
+"581 311 CURVE",
+"571 356 OFFCURVE",
+"553 386 OFFCURVE",
+"528 402 CURVE SMOOTH",
+"503 418 OFFCURVE",
+"465 426 OFFCURVE",
+"415 426 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"418 353 LINE",
+"455 353 OFFCURVE",
+"479 347 OFFCURVE",
+"492 334 CURVE SMOOTH",
+"505 321 OFFCURVE",
+"513 297 OFFCURVE",
+"518 260 CURVE SMOOTH",
+"523 224 OFFCURVE",
+"525 192 OFFCURVE",
+"525 164 CURVE SMOOTH",
+"525 107 OFFCURVE",
+"498 76 OFFCURVE",
+"437 76 CURVE SMOOTH",
+"318 76 LINE SMOOTH",
+"230 76 OFFCURVE",
+"200 103 OFFCURVE",
+"181 162 CURVE SMOOTH",
+"172 192 OFFCURVE",
+"168 231 OFFCURVE",
+"168 280 CURVE SMOOTH",
+"168 333 OFFCURVE",
+"185 353 OFFCURVE",
+"232 353 CURVE SMOOTH"
+);
+}
+);
+width = 675;
+}
+);
+},
+{
+glyphname = uni0729.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{364, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"211 426 LINE",
+"138 426 OFFCURVE",
+"95 376 OFFCURVE",
+"95 304 CURVE SMOOTH",
+"95 211 OFFCURVE",
+"102 148 OFFCURVE",
+"127 103 CURVE",
+"122 84 OFFCURVE",
+"98 76 OFFCURVE",
+"45 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"35 0 LINE SMOOTH",
+"107 0 OFFCURVE",
+"150 15 OFFCURVE",
+"167 48 CURVE",
+"172 48 LINE",
+"200 15 OFFCURVE",
+"237 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"416 0 LINE SMOOTH",
+"540 0 OFFCURVE",
+"597 53 OFFCURVE",
+"597 170 CURVE SMOOTH",
+"597 220 OFFCURVE",
+"592 267 OFFCURVE",
+"581 311 CURVE",
+"571 356 OFFCURVE",
+"553 386 OFFCURVE",
+"528 402 CURVE SMOOTH",
+"503 418 OFFCURVE",
+"465 426 OFFCURVE",
+"415 426 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"418 353 LINE",
+"455 353 OFFCURVE",
+"479 347 OFFCURVE",
+"492 334 CURVE SMOOTH",
+"505 321 OFFCURVE",
+"513 297 OFFCURVE",
+"518 260 CURVE SMOOTH",
+"523 224 OFFCURVE",
+"525 192 OFFCURVE",
+"525 164 CURVE SMOOTH",
+"525 107 OFFCURVE",
+"498 76 OFFCURVE",
+"437 76 CURVE SMOOTH",
+"318 76 LINE SMOOTH",
+"230 76 OFFCURVE",
+"200 103 OFFCURVE",
+"181 162 CURVE SMOOTH",
+"172 192 OFFCURVE",
+"168 231 OFFCURVE",
+"168 280 CURVE SMOOTH",
+"168 333 OFFCURVE",
+"185 353 OFFCURVE",
+"232 353 CURVE SMOOTH"
+);
+}
+);
+width = 665;
+}
+);
+},
+{
+glyphname = uni072A;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{203, -73}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 221, 494}";
+},
+{
+name = uni0716;
+}
+);
+layerId = UUID0;
+width = 539;
+}
+);
+rightKerningGroup = uni0715;
+unicode = 072A;
+},
+{
+glyphname = uni072A.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{203, -73}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 221, 494}";
+},
+{
+name = uni0716.Fina;
+}
+);
+layerId = UUID0;
+width = 531;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+glyphname = uni072B;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{474, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"486 86 LINE",
+"519 27 OFFCURVE",
+"582 0 OFFCURVE",
+"662 0 CURVE SMOOTH",
+"705 0 LINE SMOOTH",
+"809 0 OFFCURVE",
+"871 28 OFFCURVE",
+"896 85 CURVE",
+"846 129 LINE",
+"830 108 OFFCURVE",
+"810 93 OFFCURVE",
+"787 86 CURVE SMOOTH",
+"764 79 OFFCURVE",
+"726 76 OFFCURVE",
+"671 76 CURVE SMOOTH",
+"563 76 OFFCURVE",
+"513 130 OFFCURVE",
+"513 231 CURVE SMOOTH",
+"513 294 OFFCURVE",
+"542 333 OFFCURVE",
+"590 344 CURVE SMOOTH",
+"614 350 OFFCURVE",
+"637 354 OFFCURVE",
+"660 355 CURVE SMOOTH",
+"683 357 OFFCURVE",
+"694 369 OFFCURVE",
+"694 391 CURVE SMOOTH",
+"694 415 OFFCURVE",
+"679 428 OFFCURVE",
+"656 428 CURVE SMOOTH",
+"649 428 OFFCURVE",
+"640 427 OFFCURVE",
+"629 425 CURVE SMOOTH",
+"587 417 LINE",
+"558 410 OFFCURVE",
+"518 401 OFFCURVE",
+"479 401 CURVE SMOOTH",
+"442 401 OFFCURVE",
+"403 406 OFFCURVE",
+"372 413 CURVE SMOOTH",
+"331 421 LINE SMOOTH",
+"320 423 OFFCURVE",
+"310 424 OFFCURVE",
+"303 424 CURVE SMOOTH",
+"280 424 OFFCURVE",
+"264 412 OFFCURVE",
+"264 388 CURVE SMOOTH",
+"264 367 OFFCURVE",
+"274 355 OFFCURVE",
+"295 352 CURVE SMOOTH",
+"316 350 OFFCURVE",
+"336 347 OFFCURVE",
+"357 343 CURVE SMOOTH",
+"378 340 OFFCURVE",
+"396 331 OFFCURVE",
+"411 318 CURVE SMOOTH",
+"440 291 OFFCURVE",
+"446 246 OFFCURVE",
+"446 205 CURVE SMOOTH",
+"446 124 OFFCURVE",
+"403 76 OFFCURVE",
+"328 76 CURVE SMOOTH",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH",
+"312 0 LINE SMOOTH",
+"395 0 OFFCURVE",
+"455 31 OFFCURVE",
+"482 86 CURVE"
+);
+}
+);
+width = 945;
+}
+);
+leftKerningGroup = uni072B;
+unicode = 072B;
+},
+{
+glyphname = uni072B.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{473, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"312 0 LINE SMOOTH",
+"395 0 OFFCURVE",
+"455 31 OFFCURVE",
+"482 86 CURVE",
+"486 86 LINE",
+"519 27 OFFCURVE",
+"582 0 OFFCURVE",
+"662 0 CURVE SMOOTH",
+"751 0 LINE",
+"751 76 LINE",
+"665 76 LINE SMOOTH",
+"565 76 OFFCURVE",
+"513 130 OFFCURVE",
+"513 231 CURVE SMOOTH",
+"513 294 OFFCURVE",
+"542 333 OFFCURVE",
+"590 344 CURVE SMOOTH",
+"614 350 OFFCURVE",
+"637 354 OFFCURVE",
+"660 355 CURVE SMOOTH",
+"683 357 OFFCURVE",
+"694 369 OFFCURVE",
+"694 391 CURVE SMOOTH",
+"694 415 OFFCURVE",
+"679 428 OFFCURVE",
+"656 428 CURVE SMOOTH",
+"649 428 OFFCURVE",
+"640 427 OFFCURVE",
+"629 425 CURVE SMOOTH",
+"587 417 LINE",
+"558 410 OFFCURVE",
+"518 401 OFFCURVE",
+"479 401 CURVE SMOOTH",
+"442 401 OFFCURVE",
+"403 406 OFFCURVE",
+"372 413 CURVE SMOOTH",
+"331 421 LINE SMOOTH",
+"320 423 OFFCURVE",
+"310 424 OFFCURVE",
+"303 424 CURVE SMOOTH",
+"280 424 OFFCURVE",
+"264 412 OFFCURVE",
+"264 388 CURVE SMOOTH",
+"264 367 OFFCURVE",
+"274 355 OFFCURVE",
+"295 352 CURVE SMOOTH",
+"316 350 OFFCURVE",
+"336 347 OFFCURVE",
+"357 343 CURVE SMOOTH",
+"378 340 OFFCURVE",
+"396 331 OFFCURVE",
+"411 318 CURVE SMOOTH",
+"440 291 OFFCURVE",
+"446 246 OFFCURVE",
+"446 205 CURVE SMOOTH",
+"446 124 OFFCURVE",
+"403 76 OFFCURVE",
+"328 76 CURVE SMOOTH",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH"
+);
+}
+);
+width = 751;
+}
+);
+},
+{
+glyphname = uni072B.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{268, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"105 0 LINE SMOOTH",
+"188 0 OFFCURVE",
+"250 31 OFFCURVE",
+"275 86 CURVE",
+"279 86 LINE",
+"314 27 OFFCURVE",
+"376 0 OFFCURVE",
+"455 0 CURVE SMOOTH",
+"544 0 LINE",
+"544 76 LINE",
+"458 76 LINE SMOOTH",
+"358 76 OFFCURVE",
+"306 130 OFFCURVE",
+"306 231 CURVE SMOOTH",
+"306 294 OFFCURVE",
+"335 333 OFFCURVE",
+"383 344 CURVE SMOOTH",
+"407 350 OFFCURVE",
+"430 354 OFFCURVE",
+"453 355 CURVE SMOOTH",
+"476 357 OFFCURVE",
+"487 369 OFFCURVE",
+"487 391 CURVE SMOOTH",
+"487 415 OFFCURVE",
+"473 428 OFFCURVE",
+"449 428 CURVE SMOOTH",
+"442 428 OFFCURVE",
+"433 427 OFFCURVE",
+"422 425 CURVE SMOOTH",
+"381 417 LINE SMOOTH",
+"350 410 OFFCURVE",
+"310 401 OFFCURVE",
+"273 401 CURVE SMOOTH",
+"236 401 OFFCURVE",
+"196 406 OFFCURVE",
+"165 413 CURVE SMOOTH",
+"124 421 LINE SMOOTH",
+"113 423 OFFCURVE",
+"104 424 OFFCURVE",
+"97 424 CURVE SMOOTH",
+"73 424 OFFCURVE",
+"57 412 OFFCURVE",
+"57 388 CURVE SMOOTH",
+"57 367 OFFCURVE",
+"67 355 OFFCURVE",
+"88 352 CURVE SMOOTH",
+"109 350 OFFCURVE",
+"129 347 OFFCURVE",
+"150 343 CURVE SMOOTH",
+"171 340 OFFCURVE",
+"189 331 OFFCURVE",
+"204 318 CURVE SMOOTH",
+"233 291 OFFCURVE",
+"240 246 OFFCURVE",
+"240 205 CURVE SMOOTH",
+"240 124 OFFCURVE",
+"197 76 OFFCURVE",
+"121 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 544;
+}
+);
+},
+{
+glyphname = uni072B.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{268, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"499 0 LINE SMOOTH",
+"602 0 OFFCURVE",
+"665 28 OFFCURVE",
+"690 85 CURVE",
+"639 129 LINE",
+"623 108 OFFCURVE",
+"603 93 OFFCURVE",
+"580 86 CURVE SMOOTH",
+"557 79 OFFCURVE",
+"519 76 OFFCURVE",
+"464 76 CURVE SMOOTH",
+"356 76 OFFCURVE",
+"306 130 OFFCURVE",
+"306 231 CURVE SMOOTH",
+"306 294 OFFCURVE",
+"335 333 OFFCURVE",
+"383 344 CURVE SMOOTH",
+"407 350 OFFCURVE",
+"430 354 OFFCURVE",
+"453 355 CURVE SMOOTH",
+"476 357 OFFCURVE",
+"487 369 OFFCURVE",
+"487 391 CURVE SMOOTH",
+"487 415 OFFCURVE",
+"473 428 OFFCURVE",
+"449 428 CURVE SMOOTH",
+"442 428 OFFCURVE",
+"433 427 OFFCURVE",
+"422 425 CURVE SMOOTH",
+"381 417 LINE SMOOTH",
+"350 410 OFFCURVE",
+"310 401 OFFCURVE",
+"273 401 CURVE SMOOTH",
+"236 401 OFFCURVE",
+"196 406 OFFCURVE",
+"165 413 CURVE SMOOTH",
+"124 421 LINE SMOOTH",
+"113 423 OFFCURVE",
+"104 424 OFFCURVE",
+"97 424 CURVE SMOOTH",
+"73 424 OFFCURVE",
+"57 412 OFFCURVE",
+"57 388 CURVE SMOOTH",
+"57 367 OFFCURVE",
+"67 355 OFFCURVE",
+"88 352 CURVE SMOOTH",
+"109 350 OFFCURVE",
+"129 347 OFFCURVE",
+"150 343 CURVE SMOOTH",
+"171 340 OFFCURVE",
+"189 331 OFFCURVE",
+"204 318 CURVE SMOOTH",
+"233 291 OFFCURVE",
+"240 246 OFFCURVE",
+"240 205 CURVE SMOOTH",
+"240 124 OFFCURVE",
+"197 76 OFFCURVE",
+"121 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"105 0 LINE SMOOTH",
+"188 0 OFFCURVE",
+"250 31 OFFCURVE",
+"275 86 CURVE",
+"279 86 LINE",
+"314 27 OFFCURVE",
+"376 0 OFFCURVE",
+"455 0 CURVE SMOOTH"
+);
+}
+);
+width = 739;
+}
+);
+leftKerningGroup = uni072B;
+},
+{
+glyphname = uni072C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{648, -106}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"515 325 OFFCURVE",
+"530 286 OFFCURVE",
+"553 214 CURVE SMOOTH",
+"576 142 OFFCURVE",
+"597 69 OFFCURVE",
+"615 -5 CURVE",
+"688 -5 LINE",
+"668 80 OFFCURVE",
+"648 156 OFFCURVE",
+"627 223 CURVE",
+"607 291 OFFCURVE",
+"590 337 OFFCURVE",
+"575 361 CURVE SMOOTH",
+"560 385 OFFCURVE",
+"535 397 OFFCURVE",
+"500 397 CURVE SMOOTH",
+"475 397 OFFCURVE",
+"425 384 OFFCURVE",
+"350 349 CURVE",
+"213 713 LINE",
+"143 686 LINE",
+"282 317 LINE",
+"217 283 OFFCURVE",
+"172 256 OFFCURVE",
+"145 237 CURVE SMOOTH",
+"119 218 OFFCURVE",
+"99 198 OFFCURVE",
+"85 177 CURVE SMOOTH",
+"72 156 OFFCURVE",
+"65 133 OFFCURVE",
+"65 108 CURVE SMOOTH",
+"65 58 OFFCURVE",
+"89 23 OFFCURVE",
+"136 2 CURVE SMOOTH",
+"183 -19 OFFCURVE",
+"233 -29 OFFCURVE",
+"285 -29 CURVE SMOOTH",
+"382 -29 OFFCURVE",
+"433 14 OFFCURVE",
+"433 94 CURVE SMOOTH",
+"433 110 OFFCURVE",
+"428 138 OFFCURVE",
+"420 159 CURVE SMOOTH",
+"414 178 LINE",
+"374 284 LINE",
+"437 311 OFFCURVE",
+"492 330 OFFCURVE",
+"507 330 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 166 LINE",
+"352 135 OFFCURVE",
+"358 107 OFFCURVE",
+"358 90 CURVE SMOOTH",
+"358 58 OFFCURVE",
+"345 42 OFFCURVE",
+"290 42 CURVE SMOOTH",
+"198 42 OFFCURVE",
+"138 68 OFFCURVE",
+"138 115 CURVE SMOOTH",
+"138 154 OFFCURVE",
+"194 197 OFFCURVE",
+"307 253 CURVE"
+);
+}
+);
+width = 743;
+}
+);
+rightKerningGroup = uni072C;
+unicode = 072C;
+},
+{
+glyphname = uni072C.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{648, -106}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"515 325 OFFCURVE",
+"530 286 OFFCURVE",
+"553 214 CURVE SMOOTH",
+"576 142 OFFCURVE",
+"597 69 OFFCURVE",
+"615 -5 CURVE",
+"684 -5 LINE",
+"679 18 LINE",
+"683 18 LINE",
+"694 7 OFFCURVE",
+"711 0 OFFCURVE",
+"730 0 CURVE",
+"730 76 LINE",
+"689 76 OFFCURVE",
+"666 88 OFFCURVE",
+"659 111 CURVE SMOOTH",
+"626 224 LINE SMOOTH",
+"611 277 OFFCURVE",
+"596 319 OFFCURVE",
+"581 350 CURVE SMOOTH",
+"567 381 OFFCURVE",
+"540 397 OFFCURVE",
+"500 397 CURVE SMOOTH",
+"475 397 OFFCURVE",
+"425 384 OFFCURVE",
+"350 349 CURVE",
+"213 713 LINE",
+"143 686 LINE",
+"282 317 LINE",
+"217 283 OFFCURVE",
+"172 256 OFFCURVE",
+"145 237 CURVE SMOOTH",
+"119 218 OFFCURVE",
+"99 198 OFFCURVE",
+"85 177 CURVE SMOOTH",
+"72 156 OFFCURVE",
+"65 133 OFFCURVE",
+"65 108 CURVE SMOOTH",
+"65 58 OFFCURVE",
+"89 23 OFFCURVE",
+"136 2 CURVE SMOOTH",
+"183 -19 OFFCURVE",
+"233 -29 OFFCURVE",
+"285 -29 CURVE SMOOTH",
+"382 -29 OFFCURVE",
+"433 14 OFFCURVE",
+"433 94 CURVE SMOOTH",
+"433 110 OFFCURVE",
+"428 138 OFFCURVE",
+"420 159 CURVE SMOOTH",
+"414 178 LINE",
+"374 284 LINE",
+"437 311 OFFCURVE",
+"492 330 OFFCURVE",
+"507 330 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 166 LINE",
+"352 135 OFFCURVE",
+"358 107 OFFCURVE",
+"358 90 CURVE SMOOTH",
+"358 58 OFFCURVE",
+"345 42 OFFCURVE",
+"290 42 CURVE SMOOTH",
+"198 42 OFFCURVE",
+"138 68 OFFCURVE",
+"138 115 CURVE SMOOTH",
+"138 154 OFFCURVE",
+"194 197 OFFCURVE",
+"307 253 CURVE"
+);
+}
+);
+width = 730;
+}
+);
+rightKerningGroup = uni072C;
+},
+{
+glyphname = uni072D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{475, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"417 426 LINE",
+"432 439 LINE",
+"472 479 LINE",
+"493 500 LINE",
+"512 519 LINE SMOOTH",
+"518 524 OFFCURVE",
+"523 529 OFFCURVE",
+"526 534 CURVE",
+"576 587 LINE",
+"523 632 LINE",
+"320 405 LINE",
+"344 355 LINE",
+"351 354 OFFCURVE",
+"369 352 OFFCURVE",
+"398 350 CURVE",
+"428 349 OFFCURVE",
+"455 348 OFFCURVE",
+"479 348 CURVE SMOOTH",
+"548 348 OFFCURVE",
+"621 353 OFFCURVE",
+"690 353 CURVE SMOOTH",
+"759 353 OFFCURVE",
+"789 334 OFFCURVE",
+"805 270 CURVE SMOOTH",
+"813 239 OFFCURVE",
+"817 207 OFFCURVE",
+"817 175 CURVE SMOOTH",
+"817 100 OFFCURVE",
+"793 76 OFFCURVE",
+"729 76 CURVE SMOOTH",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"708 0 LINE SMOOTH",
+"837 0 OFFCURVE",
+"889 50 OFFCURVE",
+"889 175 CURVE SMOOTH",
+"889 195 OFFCURVE",
+"886 225 OFFCURVE",
+"883 253 CURVE",
+"879 275 LINE SMOOTH",
+"862 376 OFFCURVE",
+"809 426 OFFCURVE",
+"705 426 CURVE SMOOTH",
+"628 426 OFFCURVE",
+"551 421 OFFCURVE",
+"474 421 CURVE SMOOTH",
+"454 421 OFFCURVE",
+"436 422 OFFCURVE",
+"417 422 CURVE"
+);
+}
+);
+width = 958;
+}
+);
+unicode = 072D;
+},
+{
+glyphname = uni072D.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{475, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"879 275 LINE",
+"862 376 OFFCURVE",
+"809 426 OFFCURVE",
+"705 426 CURVE SMOOTH",
+"628 426 OFFCURVE",
+"551 421 OFFCURVE",
+"474 421 CURVE SMOOTH",
+"454 421 OFFCURVE",
+"436 422 OFFCURVE",
+"417 422 CURVE",
+"417 426 LINE",
+"432 439 LINE",
+"472 479 LINE",
+"493 500 LINE",
+"512 519 LINE SMOOTH",
+"518 524 OFFCURVE",
+"523 529 OFFCURVE",
+"526 534 CURVE",
+"576 587 LINE",
+"523 632 LINE",
+"320 405 LINE",
+"344 355 LINE",
+"351 354 OFFCURVE",
+"369 352 OFFCURVE",
+"398 350 CURVE",
+"428 349 OFFCURVE",
+"455 348 OFFCURVE",
+"479 348 CURVE SMOOTH",
+"548 348 OFFCURVE",
+"621 353 OFFCURVE",
+"690 353 CURVE SMOOTH",
+"759 353 OFFCURVE",
+"789 334 OFFCURVE",
+"805 270 CURVE SMOOTH",
+"813 239 OFFCURVE",
+"817 207 OFFCURVE",
+"817 175 CURVE SMOOTH",
+"817 100 OFFCURVE",
+"793 76 OFFCURVE",
+"729 76 CURVE SMOOTH",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"708 0 LINE SMOOTH",
+"773 0 OFFCURVE",
+"814 14 OFFCURVE",
+"841 42 CURVE",
+"846 42 LINE",
+"874 7 OFFCURVE",
+"908 0 OFFCURVE",
+"968 0 CURVE",
+"968 76 LINE",
+"907 76 OFFCURVE",
+"887 85 OFFCURVE",
+"880 104 CURVE",
+"887 124 OFFCURVE",
+"889 148 OFFCURVE",
+"889 175 CURVE SMOOTH",
+"889 195 OFFCURVE",
+"886 225 OFFCURVE",
+"883 253 CURVE",
+"879 275 LINE"
+);
+}
+);
+width = 968;
+}
+);
+},
+{
+glyphname = uni072D.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{319, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"651 275 LINE",
+"634 376 OFFCURVE",
+"581 426 OFFCURVE",
+"477 426 CURVE SMOOTH",
+"400 426 OFFCURVE",
+"323 421 OFFCURVE",
+"246 421 CURVE SMOOTH",
+"226 421 OFFCURVE",
+"208 422 OFFCURVE",
+"189 422 CURVE",
+"189 426 LINE",
+"204 439 LINE",
+"244 479 LINE",
+"265 500 LINE",
+"284 519 LINE",
+"298 534 LINE",
+"348 587 LINE",
+"295 632 LINE",
+"92 405 LINE",
+"116 355 LINE",
+"123 354 OFFCURVE",
+"141 352 OFFCURVE",
+"170 350 CURVE",
+"200 349 OFFCURVE",
+"227 348 OFFCURVE",
+"251 348 CURVE SMOOTH",
+"320 348 OFFCURVE",
+"393 353 OFFCURVE",
+"462 353 CURVE SMOOTH",
+"531 353 OFFCURVE",
+"561 334 OFFCURVE",
+"577 270 CURVE SMOOTH",
+"585 239 OFFCURVE",
+"589 207 OFFCURVE",
+"589 175 CURVE SMOOTH",
+"589 100 OFFCURVE",
+"565 76 OFFCURVE",
+"501 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"480 0 LINE SMOOTH",
+"545 0 OFFCURVE",
+"586 14 OFFCURVE",
+"613 42 CURVE",
+"618 42 LINE",
+"646 7 OFFCURVE",
+"680 0 OFFCURVE",
+"740 0 CURVE",
+"740 76 LINE",
+"679 76 OFFCURVE",
+"659 85 OFFCURVE",
+"652 104 CURVE",
+"659 124 OFFCURVE",
+"661 148 OFFCURVE",
+"661 175 CURVE SMOOTH",
+"661 195 OFFCURVE",
+"658 225 OFFCURVE",
+"655 253 CURVE",
+"651 275 LINE"
+);
+}
+);
+width = 740;
+}
+);
+},
+{
+glyphname = uni072D.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{321, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"651 275 LINE",
+"634 376 OFFCURVE",
+"581 426 OFFCURVE",
+"477 426 CURVE SMOOTH",
+"400 426 OFFCURVE",
+"323 421 OFFCURVE",
+"246 421 CURVE SMOOTH",
+"226 421 OFFCURVE",
+"208 422 OFFCURVE",
+"189 422 CURVE",
+"189 426 LINE",
+"204 439 LINE",
+"244 479 LINE",
+"265 500 LINE",
+"284 519 LINE",
+"298 534 LINE",
+"348 587 LINE",
+"295 632 LINE",
+"92 405 LINE",
+"116 355 LINE",
+"123 354 OFFCURVE",
+"141 352 OFFCURVE",
+"170 350 CURVE",
+"200 349 OFFCURVE",
+"227 348 OFFCURVE",
+"251 348 CURVE SMOOTH",
+"320 348 OFFCURVE",
+"393 353 OFFCURVE",
+"462 353 CURVE SMOOTH",
+"531 353 OFFCURVE",
+"561 334 OFFCURVE",
+"577 270 CURVE SMOOTH",
+"585 239 OFFCURVE",
+"589 207 OFFCURVE",
+"589 175 CURVE SMOOTH",
+"589 100 OFFCURVE",
+"565 76 OFFCURVE",
+"501 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"480 0 LINE SMOOTH",
+"609 0 OFFCURVE",
+"661 50 OFFCURVE",
+"661 175 CURVE SMOOTH",
+"661 195 OFFCURVE",
+"658 225 OFFCURVE",
+"655 253 CURVE",
+"651 275 LINE"
+);
+}
+);
+width = 730;
+}
+);
+},
+{
+glyphname = uni072E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{604, -146}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"955 -100 LINE",
+"877 -52 OFFCURVE",
+"804 -17 OFFCURVE",
+"737 5 CURVE SMOOTH",
+"670 28 OFFCURVE",
+"600 45 OFFCURVE",
+"529 57 CURVE SMOOTH",
+"458 70 OFFCURVE",
+"375 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"246 76 OFFCURVE",
+"207 74 OFFCURVE",
+"160 71 CURVE SMOOTH",
+"114 68 OFFCURVE",
+"77 63 OFFCURVE",
+"49 58 CURVE",
+"63 -12 LINE",
+"87 -9 OFFCURVE",
+"120 -7 OFFCURVE",
+"163 -4 CURVE SMOOTH",
+"206 -1 OFFCURVE",
+"250 0 OFFCURVE",
+"293 0 CURVE SMOOTH",
+"440 0 OFFCURVE",
+"587 -24 OFFCURVE",
+"743 -77 CURVE SMOOTH",
+"822 -104 OFFCURVE",
+"895 -136 OFFCURVE",
+"962 -171 CURVE SMOOTH",
+"1029 -206 OFFCURVE",
+"1116 -261 OFFCURVE",
+"1222 -335 CURVE SMOOTH",
+"1278 -375 LINE",
+"1324 -316 LINE",
+"1228 -253 OFFCURVE",
+"1117 -162 OFFCURVE",
+"991 -42 CURVE SMOOTH",
+"866 78 OFFCURVE",
+"736 224 OFFCURVE",
+"602 396 CURVE",
+"603 400 LINE",
+"612 396 OFFCURVE",
+"626 394 OFFCURVE",
+"639 394 CURVE SMOOTH",
+"700 394 OFFCURVE",
+"746 439 OFFCURVE",
+"746 506 CURVE SMOOTH",
+"746 519 OFFCURVE",
+"743 534 OFFCURVE",
+"737 549 CURVE SMOOTH",
+"731 565 OFFCURVE",
+"714 593 OFFCURVE",
+"687 634 CURVE SMOOTH",
+"657 680 LINE",
+"592 643 LINE",
+"628 590 LINE",
+"655 553 OFFCURVE",
+"671 529 OFFCURVE",
+"671 506 CURVE SMOOTH",
+"671 473 OFFCURVE",
+"647 452 OFFCURVE",
+"610 452 CURVE SMOOTH",
+"578 452 OFFCURVE",
+"548 465 OFFCURVE",
+"531 490 CURVE",
+"497 536 LINE",
+"427 496 LINE",
+"518 368 OFFCURVE",
+"612 250 OFFCURVE",
+"708 141 CURVE SMOOTH",
+"805 32 OFFCURVE",
+"888 -47 OFFCURVE",
+"958 -97 CURVE"
+);
+}
+);
+width = 1091;
+}
+);
+leftKerningGroup = uni0713;
+unicode = 072E;
+},
+{
+glyphname = uni072E.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{603, -146}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"955 -100 LINE",
+"877 -52 OFFCURVE",
+"804 -17 OFFCURVE",
+"737 5 CURVE SMOOTH",
+"670 28 OFFCURVE",
+"600 45 OFFCURVE",
+"529 57 CURVE SMOOTH",
+"458 70 OFFCURVE",
+"375 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"246 76 OFFCURVE",
+"207 74 OFFCURVE",
+"160 71 CURVE SMOOTH",
+"114 68 OFFCURVE",
+"77 63 OFFCURVE",
+"49 58 CURVE",
+"63 -12 LINE",
+"87 -9 OFFCURVE",
+"120 -7 OFFCURVE",
+"163 -4 CURVE SMOOTH",
+"206 -1 OFFCURVE",
+"250 0 OFFCURVE",
+"293 0 CURVE SMOOTH",
+"440 0 OFFCURVE",
+"587 -24 OFFCURVE",
+"743 -77 CURVE SMOOTH",
+"822 -104 OFFCURVE",
+"895 -136 OFFCURVE",
+"962 -171 CURVE SMOOTH",
+"1029 -206 OFFCURVE",
+"1116 -261 OFFCURVE",
+"1222 -335 CURVE SMOOTH",
+"1278 -375 LINE",
+"1324 -316 LINE",
+"1263 -277 OFFCURVE",
+"1198 -226 OFFCURVE",
+"1127 -165 CURVE SMOOTH",
+"1057 -104 OFFCURVE",
+"996 -48 OFFCURVE",
+"945 3 CURVE",
+"945 76 LINE",
+"875 76 LINE",
+"774 183 OFFCURVE",
+"682 293 OFFCURVE",
+"602 396 CURVE",
+"603 400 LINE",
+"612 396 OFFCURVE",
+"626 394 OFFCURVE",
+"639 394 CURVE SMOOTH",
+"700 394 OFFCURVE",
+"746 439 OFFCURVE",
+"746 506 CURVE SMOOTH",
+"746 519 OFFCURVE",
+"743 534 OFFCURVE",
+"737 549 CURVE SMOOTH",
+"731 565 OFFCURVE",
+"714 593 OFFCURVE",
+"687 634 CURVE SMOOTH",
+"657 680 LINE",
+"592 643 LINE",
+"628 590 LINE",
+"655 553 OFFCURVE",
+"671 529 OFFCURVE",
+"671 506 CURVE SMOOTH",
+"671 473 OFFCURVE",
+"647 452 OFFCURVE",
+"610 452 CURVE SMOOTH",
+"578 452 OFFCURVE",
+"548 465 OFFCURVE",
+"531 490 CURVE",
+"497 536 LINE",
+"427 496 LINE",
+"518 368 OFFCURVE",
+"612 250 OFFCURVE",
+"708 141 CURVE SMOOTH",
+"805 32 OFFCURVE",
+"888 -47 OFFCURVE",
+"958 -97 CURVE"
+);
+}
+);
+width = 945;
+}
+);
+},
+{
+glyphname = uni072E.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{248, -157}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"535 -61 LINE",
+"438 -8 OFFCURVE",
+"349 28 OFFCURVE",
+"270 47 CURVE SMOOTH",
+"191 66 OFFCURVE",
+"101 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"151 0 OFFCURVE",
+"282 -25 OFFCURVE",
+"399 -69 CURVE SMOOTH",
+"518 -114 OFFCURVE",
+"619 -174 OFFCURVE",
+"750 -266 CURVE SMOOTH",
+"870 -351 LINE",
+"905 -375 LINE",
+"951 -316 LINE",
+"839 -243 OFFCURVE",
+"704 -126 OFFCURVE",
+"571 3 CURVE",
+"571 76 LINE",
+"501 76 LINE",
+"401 183 OFFCURVE",
+"309 293 OFFCURVE",
+"229 396 CURVE",
+"229 400 LINE",
+"238 396 OFFCURVE",
+"252 394 OFFCURVE",
+"265 394 CURVE SMOOTH",
+"328 394 OFFCURVE",
+"372 439 OFFCURVE",
+"372 506 CURVE SMOOTH",
+"372 519 OFFCURVE",
+"369 534 OFFCURVE",
+"363 549 CURVE SMOOTH",
+"357 565 OFFCURVE",
+"341 593 OFFCURVE",
+"314 634 CURVE SMOOTH",
+"283 680 LINE",
+"219 643 LINE",
+"255 590 LINE",
+"282 553 OFFCURVE",
+"297 529 OFFCURVE",
+"297 506 CURVE SMOOTH",
+"297 473 OFFCURVE",
+"273 452 OFFCURVE",
+"236 452 CURVE SMOOTH",
+"205 452 OFFCURVE",
+"177 463 OFFCURVE",
+"157 490 CURVE SMOOTH",
+"124 536 LINE",
+"54 496 LINE",
+"221 261 OFFCURVE",
+"385 73 OFFCURVE",
+"538 -58 CURVE"
+);
+}
+);
+width = 571;
+}
+);
+},
+{
+glyphname = uni072E.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{248, -159}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"535 -61 LINE",
+"438 -8 OFFCURVE",
+"349 28 OFFCURVE",
+"270 47 CURVE SMOOTH",
+"191 66 OFFCURVE",
+"101 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"151 0 OFFCURVE",
+"282 -25 OFFCURVE",
+"399 -69 CURVE SMOOTH",
+"518 -114 OFFCURVE",
+"619 -174 OFFCURVE",
+"750 -266 CURVE SMOOTH",
+"870 -351 LINE",
+"905 -375 LINE",
+"951 -316 LINE",
+"856 -254 OFFCURVE",
+"745 -163 OFFCURVE",
+"618 -42 CURVE SMOOTH",
+"492 79 OFFCURVE",
+"362 225 OFFCURVE",
+"229 396 CURVE",
+"229 400 LINE",
+"238 396 OFFCURVE",
+"252 394 OFFCURVE",
+"265 394 CURVE SMOOTH",
+"328 394 OFFCURVE",
+"372 439 OFFCURVE",
+"372 506 CURVE SMOOTH",
+"372 519 OFFCURVE",
+"369 534 OFFCURVE",
+"363 549 CURVE SMOOTH",
+"357 565 OFFCURVE",
+"341 593 OFFCURVE",
+"314 634 CURVE SMOOTH",
+"283 680 LINE",
+"219 643 LINE",
+"255 590 LINE",
+"282 553 OFFCURVE",
+"297 529 OFFCURVE",
+"297 506 CURVE SMOOTH",
+"297 473 OFFCURVE",
+"273 452 OFFCURVE",
+"236 452 CURVE SMOOTH",
+"205 452 OFFCURVE",
+"177 463 OFFCURVE",
+"157 490 CURVE SMOOTH",
+"124 536 LINE",
+"54 496 LINE",
+"221 261 OFFCURVE",
+"385 73 OFFCURVE",
+"538 -58 CURVE"
+);
+}
+);
+width = 718;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+glyphname = uni072F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{206, -209}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 118, -16}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 219, -158}";
+},
+{
+name = uni0716;
+}
+);
+layerId = UUID0;
+width = 539;
+}
+);
+rightKerningGroup = uni072F;
+unicode = 072F;
+},
+{
+glyphname = uni072F.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{205, -210}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 118, -16}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 219, -158}";
+},
+{
+name = uni0716.Fina;
+}
+);
+layerId = UUID0;
+width = 531;
+}
+);
+rightKerningGroup = uni072F;
+},
+{
+glyphname = uni074D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{272, -444}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"303 -361 LINE",
+"347 -300 OFFCURVE",
+"391 -212 OFFCURVE",
+"435 -97 CURVE SMOOTH",
+"479 18 OFFCURVE",
+"506 133 OFFCURVE",
+"515 246 CURVE",
+"446 246 LINE",
+"439 170 OFFCURVE",
+"422 86 OFFCURVE",
+"395 -5 CURVE SMOOTH",
+"368 -96 OFFCURVE",
+"332 -185 OFFCURVE",
+"285 -270 CURVE",
+"222 -110 OFFCURVE",
+"176 58 OFFCURVE",
+"140 246 CURVE",
+"68 246 LINE",
+"80 159 OFFCURVE",
+"104 54 OFFCURVE",
+"140 -69 CURVE SMOOTH",
+"177 -192 OFFCURVE",
+"211 -290 OFFCURVE",
+"244 -361 CURVE"
+);
+}
+);
+width = 583;
+}
+);
+rightKerningGroup = uni074D;
+unicode = 074D;
+},
+{
+glyphname = uni074D.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{272, -444}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"303 -361 LINE",
+"334 -318 OFFCURVE",
+"367 -258 OFFCURVE",
+"400 -183 CURVE SMOOTH",
+"433 -108 OFFCURVE",
+"459 -37 OFFCURVE",
+"477 32 CURVE",
+"480 32 LINE",
+"499 12 OFFCURVE",
+"528 0 OFFCURVE",
+"583 0 CURVE",
+"583 76 LINE",
+"561 76 LINE SMOOTH",
+"533 76 OFFCURVE",
+"504 82 OFFCURVE",
+"493 94 CURVE",
+"502 141 OFFCURVE",
+"511 189 OFFCURVE",
+"515 246 CURVE",
+"446 246 LINE",
+"439 170 OFFCURVE",
+"422 86 OFFCURVE",
+"395 -5 CURVE SMOOTH",
+"368 -96 OFFCURVE",
+"332 -185 OFFCURVE",
+"285 -270 CURVE",
+"222 -110 OFFCURVE",
+"176 58 OFFCURVE",
+"140 246 CURVE",
+"68 246 LINE",
+"80 159 OFFCURVE",
+"104 54 OFFCURVE",
+"140 -69 CURVE SMOOTH",
+"177 -192 OFFCURVE",
+"211 -290 OFFCURVE",
+"244 -361 CURVE"
+);
+}
+);
+width = 583;
+}
+);
+rightKerningGroup = uni074D;
+},
+{
+glyphname = uni074E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{412, -96}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"548 540 LINE SMOOTH",
+"528 547 OFFCURVE",
+"514 552 OFFCURVE",
+"487 556 CURVE",
+"470 489 LINE",
+"499 482 OFFCURVE",
+"519 476 OFFCURVE",
+"530 469 CURVE SMOOTH",
+"542 462 OFFCURVE",
+"554 452 OFFCURVE",
+"566 438 CURVE SMOOTH",
+"578 424 OFFCURVE",
+"591 402 OFFCURVE",
+"605 371 CURVE SMOOTH",
+"629 315 LINE SMOOTH",
+"650 265 OFFCURVE",
+"669 217 OFFCURVE",
+"686 172 CURVE SMOOTH",
+"703 127 OFFCURVE",
+"712 95 OFFCURVE",
+"715 76 CURVE",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH",
+"711 0 LINE SMOOTH",
+"758 0 OFFCURVE",
+"785 29 OFFCURVE",
+"785 84 CURVE SMOOTH",
+"785 102 OFFCURVE",
+"776 135 OFFCURVE",
+"759 182 CURVE SMOOTH",
+"742 230 OFFCURVE",
+"724 277 OFFCURVE",
+"705 323 CURVE SMOOTH",
+"683 373 LINE SMOOTH",
+"668 405 OFFCURVE",
+"654 435 OFFCURVE",
+"635 456 CURVE",
+"636 460 LINE",
+"643 457 OFFCURVE",
+"651 458 OFFCURVE",
+"656 458 CURVE SMOOTH",
+"720 458 OFFCURVE",
+"759 502 OFFCURVE",
+"759 566 CURVE SMOOTH",
+"759 581 OFFCURVE",
+"756 597 OFFCURVE",
+"749 614 CURVE SMOOTH",
+"742 631 OFFCURVE",
+"727 658 OFFCURVE",
+"703 694 CURVE SMOOTH",
+"672 740 LINE",
+"608 703 LINE",
+"644 650 LINE",
+"671 613 OFFCURVE",
+"687 589 OFFCURVE",
+"687 566 CURVE SMOOTH",
+"687 533 OFFCURVE",
+"665 516 OFFCURVE",
+"628 516 CURVE SMOOTH",
+"619 516 OFFCURVE",
+"596 522 OFFCURVE",
+"577 529 CURVE SMOOTH"
+);
+}
+);
+width = 843;
+}
+);
+unicode = 074E;
+},
+{
+glyphname = uni074E.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{411, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"591 0 LINE SMOOTH",
+"667 0 OFFCURVE",
+"717 21 OFFCURVE",
+"744 50 CURVE",
+"748 50 LINE",
+"772 14 OFFCURVE",
+"805 0 OFFCURVE",
+"846 0 CURVE",
+"846 76 LINE",
+"815 76 OFFCURVE",
+"796 96 OFFCURVE",
+"776 151 CURVE SMOOTH",
+"757 204 LINE",
+"741 245 OFFCURVE",
+"722 292 OFFCURVE",
+"699 346 CURVE SMOOTH",
+"677 400 OFFCURVE",
+"657 437 OFFCURVE",
+"640 456 CURVE",
+"641 460 LINE",
+"648 457 OFFCURVE",
+"656 458 OFFCURVE",
+"661 458 CURVE SMOOTH",
+"724 458 OFFCURVE",
+"764 502 OFFCURVE",
+"764 566 CURVE SMOOTH",
+"764 581 OFFCURVE",
+"761 597 OFFCURVE",
+"754 614 CURVE SMOOTH",
+"747 631 OFFCURVE",
+"732 658 OFFCURVE",
+"708 694 CURVE SMOOTH",
+"677 740 LINE",
+"613 703 LINE",
+"649 650 LINE",
+"676 613 OFFCURVE",
+"691 589 OFFCURVE",
+"691 566 CURVE SMOOTH",
+"691 533 OFFCURVE",
+"670 516 OFFCURVE",
+"633 516 CURVE SMOOTH",
+"624 516 OFFCURVE",
+"601 522 OFFCURVE",
+"582 529 CURVE SMOOTH",
+"553 540 LINE SMOOTH",
+"533 547 OFFCURVE",
+"519 552 OFFCURVE",
+"492 556 CURVE",
+"475 489 LINE",
+"504 482 OFFCURVE",
+"524 475 OFFCURVE",
+"536 468 CURVE SMOOTH",
+"549 461 OFFCURVE",
+"564 446 OFFCURVE",
+"583 421 CURVE SMOOTH",
+"602 396 OFFCURVE",
+"644 295 OFFCURVE",
+"711 118 CURVE",
+"698 89 OFFCURVE",
+"651 76 OFFCURVE",
+"602 76 CURVE SMOOTH",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH"
+);
+}
+);
+width = 846;
+}
+);
+},
+{
+glyphname = uni074E.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{301, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"447 89 OFFCURVE",
+"400 76 OFFCURVE",
+"351 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"340 0 LINE SMOOTH",
+"416 0 OFFCURVE",
+"466 21 OFFCURVE",
+"493 50 CURVE",
+"497 50 LINE",
+"521 14 OFFCURVE",
+"554 0 OFFCURVE",
+"595 0 CURVE",
+"595 76 LINE",
+"564 76 OFFCURVE",
+"545 96 OFFCURVE",
+"525 151 CURVE SMOOTH",
+"506 204 LINE",
+"490 245 OFFCURVE",
+"471 292 OFFCURVE",
+"448 346 CURVE SMOOTH",
+"426 400 OFFCURVE",
+"406 437 OFFCURVE",
+"389 456 CURVE",
+"390 460 LINE",
+"397 457 OFFCURVE",
+"405 458 OFFCURVE",
+"410 458 CURVE SMOOTH",
+"474 458 OFFCURVE",
+"513 502 OFFCURVE",
+"513 566 CURVE SMOOTH",
+"513 581 OFFCURVE",
+"510 597 OFFCURVE",
+"503 614 CURVE SMOOTH",
+"496 631 OFFCURVE",
+"481 658 OFFCURVE",
+"457 694 CURVE SMOOTH",
+"426 740 LINE",
+"362 703 LINE",
+"398 650 LINE",
+"425 613 OFFCURVE",
+"440 589 OFFCURVE",
+"440 566 CURVE SMOOTH",
+"440 533 OFFCURVE",
+"419 516 OFFCURVE",
+"382 516 CURVE SMOOTH",
+"373 516 OFFCURVE",
+"350 522 OFFCURVE",
+"331 529 CURVE SMOOTH",
+"302 540 LINE SMOOTH",
+"282 547 OFFCURVE",
+"268 552 OFFCURVE",
+"241 556 CURVE",
+"224 489 LINE",
+"253 482 OFFCURVE",
+"273 475 OFFCURVE",
+"285 468 CURVE SMOOTH",
+"298 461 OFFCURVE",
+"313 446 OFFCURVE",
+"332 421 CURVE SMOOTH",
+"351 396 OFFCURVE",
+"393 295 OFFCURVE",
+"460 118 CURVE"
+);
+}
+);
+width = 595;
+}
+);
+},
+{
+glyphname = uni074E.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{303, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"459 0 LINE",
+"506 0 OFFCURVE",
+"533 29 OFFCURVE",
+"533 84 CURVE SMOOTH",
+"533 102 OFFCURVE",
+"524 135 OFFCURVE",
+"507 182 CURVE SMOOTH",
+"490 230 OFFCURVE",
+"472 277 OFFCURVE",
+"453 323 CURVE SMOOTH",
+"431 373 LINE SMOOTH",
+"416 405 OFFCURVE",
+"402 435 OFFCURVE",
+"383 456 CURVE",
+"384 460 LINE",
+"391 457 OFFCURVE",
+"399 458 OFFCURVE",
+"404 458 CURVE SMOOTH",
+"468 458 OFFCURVE",
+"507 502 OFFCURVE",
+"507 566 CURVE SMOOTH",
+"507 581 OFFCURVE",
+"504 597 OFFCURVE",
+"497 614 CURVE SMOOTH",
+"490 631 OFFCURVE",
+"475 658 OFFCURVE",
+"451 694 CURVE SMOOTH",
+"420 740 LINE",
+"356 703 LINE",
+"392 650 LINE",
+"419 613 OFFCURVE",
+"435 589 OFFCURVE",
+"435 566 CURVE SMOOTH",
+"435 533 OFFCURVE",
+"413 516 OFFCURVE",
+"376 516 CURVE SMOOTH",
+"367 516 OFFCURVE",
+"344 522 OFFCURVE",
+"325 529 CURVE SMOOTH",
+"296 540 LINE SMOOTH",
+"276 547 OFFCURVE",
+"262 552 OFFCURVE",
+"235 556 CURVE",
+"218 489 LINE",
+"247 482 OFFCURVE",
+"267 476 OFFCURVE",
+"278 469 CURVE SMOOTH",
+"290 462 OFFCURVE",
+"302 452 OFFCURVE",
+"314 438 CURVE SMOOTH",
+"326 424 OFFCURVE",
+"339 402 OFFCURVE",
+"353 371 CURVE SMOOTH",
+"377 315 LINE SMOOTH",
+"398 265 OFFCURVE",
+"417 217 OFFCURVE",
+"434 172 CURVE SMOOTH",
+"451 127 OFFCURVE",
+"460 95 OFFCURVE",
+"463 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"459 0 LINE"
+);
+}
+);
+width = 591;
+}
+);
+},
+{
+glyphname = uni074F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{324, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"543 0 LINE",
+"574 0 OFFCURVE",
+"591 24 OFFCURVE",
+"591 61 CURVE SMOOTH",
+"591 81 OFFCURVE",
+"587 104 OFFCURVE",
+"580 129 CURVE SMOOTH",
+"573 154 OFFCURVE",
+"559 199 OFFCURVE",
+"537 264 CURVE",
+"540 265 LINE",
+"546 263 OFFCURVE",
+"552 262 OFFCURVE",
+"558 262 CURVE SMOOTH",
+"609 262 OFFCURVE",
+"646 301 OFFCURVE",
+"646 357 CURVE SMOOTH",
+"646 414 OFFCURVE",
+"609 452 OFFCURVE",
+"552 452 CURVE SMOOTH",
+"525 452 OFFCURVE",
+"500 442 OFFCURVE",
+"484 421 CURVE",
+"480 421 LINE",
+"469 453 OFFCURVE",
+"456 487 OFFCURVE",
+"444 518 CURVE SMOOTH",
+"418 586 LINE",
+"346 558 LINE",
+"349 551 OFFCURVE",
+"354 540 OFFCURVE",
+"360 524 CURVE SMOOTH",
+"382 469 LINE",
+"409 399 LINE SMOOTH",
+"434 334 OFFCURVE",
+"457 268 OFFCURVE",
+"480 201 CURVE SMOOTH",
+"503 134 OFFCURVE",
+"516 93 OFFCURVE",
+"518 76 CURVE",
+"268 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"49 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 388 OFFCURVE",
+"521 407 OFFCURVE",
+"550 407 CURVE SMOOTH",
+"578 407 OFFCURVE",
+"599 388 OFFCURVE",
+"599 356 CURVE SMOOTH",
+"599 324 OFFCURVE",
+"578 305 OFFCURVE",
+"550 305 CURVE SMOOTH",
+"522 305 OFFCURVE",
+"501 324 OFFCURVE",
+"501 356 CURVE SMOOTH"
+);
+}
+);
+width = 656;
+}
+);
+leftKerningGroup = uni074F;
+unicode = 074F;
+},
+{
+glyphname = uni074F.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{324, -97}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"536 264 LINE",
+"540 265 LINE",
+"546 263 OFFCURVE",
+"552 262 OFFCURVE",
+"558 262 CURVE SMOOTH",
+"609 262 OFFCURVE",
+"646 301 OFFCURVE",
+"646 357 CURVE SMOOTH",
+"646 414 OFFCURVE",
+"610 452 OFFCURVE",
+"551 452 CURVE SMOOTH",
+"524 452 OFFCURVE",
+"500 442 OFFCURVE",
+"484 421 CURVE",
+"480 421 LINE",
+"473 440 OFFCURVE",
+"467 458 OFFCURVE",
+"460 475 CURVE SMOOTH",
+"417 586 LINE",
+"346 558 LINE",
+"359 527 OFFCURVE",
+"385 459 OFFCURVE",
+"424 356 CURVE SMOOTH",
+"463 253 OFFCURVE",
+"491 174 OFFCURVE",
+"508 119 CURVE",
+"496 91 OFFCURVE",
+"452 76 OFFCURVE",
+"403 76 CURVE SMOOTH",
+"267 76 LINE SMOOTH",
+"218 76 OFFCURVE",
+"182 79 OFFCURVE",
+"159 86 CURVE SMOOTH",
+"136 93 OFFCURVE",
+"117 108 OFFCURVE",
+"101 131 CURVE",
+"48 85 LINE",
+"76 24 OFFCURVE",
+"133 0 OFFCURVE",
+"230 0 CURVE SMOOTH",
+"392 0 LINE SMOOTH",
+"465 0 OFFCURVE",
+"516 21 OFFCURVE",
+"541 50 CURVE",
+"544 50 LINE",
+"568 19 OFFCURVE",
+"599 0 OFFCURVE",
+"652 0 CURVE SMOOTH",
+"667 0 LINE",
+"667 76 LINE",
+"654 76 LINE SMOOTH",
+"619 76 OFFCURVE",
+"594 100 OFFCURVE",
+"575 156 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 388 OFFCURVE",
+"520 407 OFFCURVE",
+"549 407 CURVE SMOOTH",
+"577 407 OFFCURVE",
+"598 388 OFFCURVE",
+"598 356 CURVE SMOOTH",
+"598 324 OFFCURVE",
+"578 305 OFFCURVE",
+"549 305 CURVE SMOOTH",
+"522 305 OFFCURVE",
+"501 324 OFFCURVE",
+"501 356 CURVE SMOOTH"
+);
+}
+);
+width = 667;
+}
+);
+},
+{
+glyphname = uni074F.Medi;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{191, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"220 264 LINE",
+"223 265 LINE",
+"229 263 OFFCURVE",
+"235 262 OFFCURVE",
+"241 262 CURVE SMOOTH",
+"292 262 OFFCURVE",
+"330 301 OFFCURVE",
+"330 357 CURVE SMOOTH",
+"330 414 OFFCURVE",
+"292 452 OFFCURVE",
+"235 452 CURVE SMOOTH",
+"208 452 OFFCURVE",
+"183 442 OFFCURVE",
+"167 421 CURVE",
+"164 421 LINE",
+"144 475 LINE",
+"101 586 LINE",
+"29 558 LINE",
+"43 527 OFFCURVE",
+"69 459 OFFCURVE",
+"108 356 CURVE SMOOTH",
+"147 253 OFFCURVE",
+"174 174 OFFCURVE",
+"191 119 CURVE",
+"179 91 OFFCURVE",
+"137 76 OFFCURVE",
+"86 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"76 0 LINE SMOOTH",
+"148 0 OFFCURVE",
+"200 21 OFFCURVE",
+"224 50 CURVE",
+"228 50 LINE",
+"251 19 OFFCURVE",
+"283 0 OFFCURVE",
+"335 0 CURVE SMOOTH",
+"350 0 LINE",
+"350 76 LINE",
+"337 76 LINE SMOOTH",
+"304 76 OFFCURVE",
+"278 100 OFFCURVE",
+"258 156 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 388 OFFCURVE",
+"204 407 OFFCURVE",
+"233 407 CURVE SMOOTH",
+"261 407 OFFCURVE",
+"282 388 OFFCURVE",
+"282 356 CURVE SMOOTH",
+"282 324 OFFCURVE",
+"261 305 OFFCURVE",
+"233 305 CURVE SMOOTH",
+"205 305 OFFCURVE",
+"185 324 OFFCURVE",
+"185 356 CURVE SMOOTH"
+);
+}
+);
+width = 350;
+}
+);
+},
+{
+glyphname = uni074F.Init;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{147, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"29 558 LINE",
+"32 551 OFFCURVE",
+"37 540 OFFCURVE",
+"43 524 CURVE SMOOTH",
+"65 469 LINE",
+"92 399 LINE SMOOTH",
+"117 334 OFFCURVE",
+"140 268 OFFCURVE",
+"163 201 CURVE SMOOTH",
+"186 134 OFFCURVE",
+"199 93 OFFCURVE",
+"201 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"227 0 LINE SMOOTH",
+"258 0 OFFCURVE",
+"274 24 OFFCURVE",
+"274 61 CURVE SMOOTH",
+"274 81 OFFCURVE",
+"270 104 OFFCURVE",
+"263 129 CURVE SMOOTH",
+"256 154 OFFCURVE",
+"242 199 OFFCURVE",
+"220 264 CURVE",
+"223 265 LINE",
+"229 263 OFFCURVE",
+"235 262 OFFCURVE",
+"241 262 CURVE SMOOTH",
+"292 262 OFFCURVE",
+"330 301 OFFCURVE",
+"330 357 CURVE SMOOTH",
+"330 414 OFFCURVE",
+"292 452 OFFCURVE",
+"235 452 CURVE SMOOTH",
+"208 452 OFFCURVE",
+"183 442 OFFCURVE",
+"167 421 CURVE",
+"163 421 LINE",
+"152 453 OFFCURVE",
+"139 487 OFFCURVE",
+"127 518 CURVE SMOOTH",
+"101 586 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 388 OFFCURVE",
+"204 407 OFFCURVE",
+"233 407 CURVE SMOOTH",
+"261 407 OFFCURVE",
+"282 388 OFFCURVE",
+"282 356 CURVE SMOOTH",
+"282 324 OFFCURVE",
+"261 305 OFFCURVE",
+"233 305 CURVE SMOOTH",
+"205 305 OFFCURVE",
+"185 324 OFFCURVE",
+"185 356 CURVE SMOOTH"
+);
+}
+);
+width = 339;
+}
+);
+leftKerningGroup = uni074F;
+},
+{
+glyphname = uni0621;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{229, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 76 LINE SMOOTH",
+"225 76 OFFCURVE",
+"193 94 OFFCURVE",
+"168 131 CURVE SMOOTH",
+"156 150 OFFCURVE",
+"150 170 OFFCURVE",
+"150 193 CURVE SMOOTH",
+"150 258 OFFCURVE",
+"197 300 OFFCURVE",
+"269 300 CURVE SMOOTH",
+"292 300 OFFCURVE",
+"318 296 OFFCURVE",
+"345 289 CURVE",
+"368 348 LINE",
+"332 364 OFFCURVE",
+"292 367 OFFCURVE",
+"261 367 CURVE SMOOTH",
+"210 367 OFFCURVE",
+"167 351 OFFCURVE",
+"131 318 CURVE SMOOTH",
+"96 285 OFFCURVE",
+"78 243 OFFCURVE",
+"78 191 CURVE SMOOTH",
+"78 143 OFFCURVE",
+"98 101 OFFCURVE",
+"139 73 CURVE",
+"139 70 LINE",
+"44 70 LINE",
+"44 7 LINE",
+"392 7 LINE",
+"392 76 LINE"
+);
+}
+);
+width = 462;
+}
+);
+unicode = 0621;
+},
+{
+glyphname = uni0640;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{186, -98}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"379 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"379 0 LINE"
+);
+}
+);
+width = 379;
+}
+);
+unicode = 0640;
+},
+{
+glyphname = uni0700;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 294, 254}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 294, -15}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 426, 120}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 164, 120}";
+}
+);
+layerId = UUID0;
+width = 592;
+}
+);
+unicode = 0700;
+},
+{
+glyphname = uni0701;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, 254}";
+}
+);
+layerId = UUID0;
+width = 256;
+}
+);
+unicode = 0701;
+},
+{
+glyphname = uni0702;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, -115}";
+}
+);
+layerId = UUID0;
+width = 256;
+}
+);
+leftKerningGroup = uni0702;
+unicode = 0702;
+},
+{
+glyphname = uni0703;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 137, 373}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 137, 203}";
+}
+);
+layerId = UUID0;
+width = 277;
+}
+);
+unicode = 0703;
+},
+{
+glyphname = uni0704;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, -15}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, -185}";
+}
+);
+layerId = UUID0;
+width = 256;
+}
+);
+leftKerningGroup = uni0702;
+unicode = 0704;
+},
+{
+glyphname = uni0705;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, 320}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 296, 320}";
+}
+);
+layerId = UUID0;
+width = 425;
+}
+);
+unicode = 0705;
+},
+{
+glyphname = uni0706;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, 154}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 215, -15}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+leftKerningGroup = uni0702;
+unicode = 0706;
+},
+{
+glyphname = uni0707;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 215, 154}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, -15}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+unicode = 0707;
+},
+{
+glyphname = uni0708;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, 373}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 215, 204}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+unicode = 0708;
+},
+{
+glyphname = uni0709;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 127, -15}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 215, -185}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+leftKerningGroup = uni0702;
+unicode = 0709;
+},
+{
+glyphname = uni070A;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"120 486 LINE",
+"120 425 LINE",
+"459 425 LINE",
+"459 486 LINE",
+"429 486 LINE SMOOTH",
+"400 486 OFFCURVE",
+"386 498 OFFCURVE",
+"386 525 CURVE SMOOTH",
+"386 573 LINE",
+"342 573 LINE",
+"342 525 LINE SMOOTH",
+"342 498 OFFCURVE",
+"327 486 OFFCURVE",
+"296 486 CURVE SMOOTH",
+"283 486 LINE SMOOTH",
+"252 486 OFFCURVE",
+"237 498 OFFCURVE",
+"237 525 CURVE SMOOTH",
+"237 573 LINE",
+"193 573 LINE",
+"193 525 LINE SMOOTH",
+"193 498 OFFCURVE",
+"179 486 OFFCURVE",
+"150 486 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 308 OFFCURVE",
+"321 329 OFFCURVE",
+"290 329 CURVE SMOOTH",
+"261 329 OFFCURVE",
+"238 312 OFFCURVE",
+"238 272 CURVE SMOOTH",
+"238 233 OFFCURVE",
+"261 215 OFFCURVE",
+"290 215 CURVE SMOOTH",
+"318 215 OFFCURVE",
+"342 233 OFFCURVE",
+"342 272 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 82 OFFCURVE",
+"321 103 OFFCURVE",
+"290 103 CURVE SMOOTH",
+"261 103 OFFCURVE",
+"238 86 OFFCURVE",
+"238 46 CURVE SMOOTH",
+"238 7 OFFCURVE",
+"261 -11 OFFCURVE",
+"290 -11 CURVE SMOOTH",
+"318 -11 OFFCURVE",
+"342 7 OFFCURVE",
+"342 46 CURVE SMOOTH"
+);
+}
+);
+width = 579;
+}
+);
+unicode = 070A;
+},
+{
+glyphname = uni070B;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"119 586 LINE",
+"804 586 LINE",
+"804 647 LINE",
+"119 647 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"514 485 OFFCURVE",
+"493 506 OFFCURVE",
+"462 506 CURVE SMOOTH",
+"431 506 OFFCURVE",
+"410 489 OFFCURVE",
+"410 449 CURVE SMOOTH",
+"410 410 OFFCURVE",
+"431 392 OFFCURVE",
+"462 392 CURVE SMOOTH",
+"489 392 OFFCURVE",
+"514 410 OFFCURVE",
+"514 449 CURVE SMOOTH"
+);
+}
+);
+width = 923;
+}
+);
+unicode = 070B;
+},
+{
+glyphname = uni070C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"423 319 LINE",
+"472 314 OFFCURVE",
+"518 312 OFFCURVE",
+"567 312 CURVE",
+"567 363 OFFCURVE",
+"565 408 OFFCURVE",
+"561 459 CURVE",
+"556 459 LINE",
+"522 395 LINE",
+"163 753 LINE",
+"127 719 LINE",
+"486 358 LINE",
+"423 324 LINE"
+);
+}
+);
+width = 694;
+}
+);
+unicode = 070C;
+},
+{
+glyphname = uni070D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"354 69 LINE",
+"405 69 LINE",
+"405 323 LINE",
+"648 323 LINE",
+"648 374 LINE",
+"405 374 LINE",
+"405 627 LINE",
+"354 627 LINE",
+"354 374 LINE",
+"110 374 LINE",
+"110 323 LINE",
+"354 323 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 506 OFFCURVE",
+"279 519 OFFCURVE",
+"256 519 CURVE SMOOTH",
+"232 519 OFFCURVE",
+"214 506 OFFCURVE",
+"214 474 CURVE SMOOTH",
+"214 442 OFFCURVE",
+"232 428 OFFCURVE",
+"256 428 CURVE SMOOTH",
+"279 428 OFFCURVE",
+"298 442 OFFCURVE",
+"298 474 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 506 OFFCURVE",
+"525 519 OFFCURVE",
+"502 519 CURVE SMOOTH",
+"478 519 OFFCURVE",
+"460 506 OFFCURVE",
+"460 474 CURVE SMOOTH",
+"460 442 OFFCURVE",
+"478 428 OFFCURVE",
+"502 428 CURVE SMOOTH",
+"525 428 OFFCURVE",
+"544 442 OFFCURVE",
+"544 474 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 256 OFFCURVE",
+"525 269 OFFCURVE",
+"502 269 CURVE SMOOTH",
+"478 269 OFFCURVE",
+"460 256 OFFCURVE",
+"460 224 CURVE SMOOTH",
+"460 192 OFFCURVE",
+"478 178 OFFCURVE",
+"502 178 CURVE SMOOTH",
+"525 178 OFFCURVE",
+"544 192 OFFCURVE",
+"544 224 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 256 OFFCURVE",
+"279 269 OFFCURVE",
+"256 269 CURVE SMOOTH",
+"232 269 OFFCURVE",
+"214 256 OFFCURVE",
+"214 224 CURVE SMOOTH",
+"214 192 OFFCURVE",
+"232 178 OFFCURVE",
+"256 178 CURVE SMOOTH",
+"279 178 OFFCURVE",
+"298 192 OFFCURVE",
+"298 224 CURVE SMOOTH"
+);
+}
+);
+width = 758;
+}
+);
+unicode = 070D;
+},
+{
+glyphname = uni070F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"24 -90 LINE",
+"24 779 LINE",
+"97 779 LINE",
+"97 813 LINE",
+"-86 813 LINE",
+"-86 779 LINE",
+"-13 779 LINE",
+"-13 -90 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 070F;
+},
+{
+glyphname = uni0730;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"61 724 LINE",
+"-87 736 LINE",
+"-89 585 LINE",
+"-119 559 LINE",
+"-95 533 LINE",
+"112 723 LINE",
+"88 749 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"26 692 LINE",
+"-56 617 LINE",
+"-53 697 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0730;
+},
+{
+glyphname = uni0731;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-61 -183 LINE",
+"87 -194 LINE",
+"89 -43 LINE",
+"119 -17 LINE",
+"94 9 LINE",
+"-112 -182 LINE",
+"-88 -208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-26 -150 LINE",
+"56 -75 LINE",
+"53 -155 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0731;
+},
+{
+glyphname = uni0732;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, 11, 541}";
+},
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, -9, -130}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0732;
+},
+{
+glyphname = uni0733;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"78 726 OFFCURVE",
+"55 753 OFFCURVE",
+"15 753 CURVE SMOOTH",
+"-33 753 OFFCURVE",
+"-60 714 OFFCURVE",
+"-60 665 CURVE SMOOTH",
+"-60 638 OFFCURVE",
+"-54 616 OFFCURVE",
+"-42 591 CURVE",
+"-54 582 OFFCURVE",
+"-70 572 OFFCURVE",
+"-87 559 CURVE",
+"-66 531 LINE",
+"-6 572 OFFCURVE",
+"33 604 OFFCURVE",
+"51 625 CURVE SMOOTH",
+"69 647 OFFCURVE",
+"78 669 OFFCURVE",
+"78 691 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"29 717 OFFCURVE",
+"41 706 OFFCURVE",
+"41 687 CURVE SMOOTH",
+"41 663 OFFCURVE",
+"20 639 OFFCURVE",
+"-11 615 CURVE",
+"-19 628 OFFCURVE",
+"-24 645 OFFCURVE",
+"-24 665 CURVE SMOOTH",
+"-24 694 OFFCURVE",
+"-11 717 OFFCURVE",
+"13 717 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0733;
+},
+{
+glyphname = uni0734;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-78 -187 OFFCURVE",
+"-54 -214 OFFCURVE",
+"-14 -214 CURVE SMOOTH",
+"33 -214 OFFCURVE",
+"61 -177 OFFCURVE",
+"61 -125 CURVE SMOOTH",
+"61 -100 OFFCURVE",
+"55 -77 OFFCURVE",
+"43 -52 CURVE",
+"88 -20 LINE",
+"67 9 LINE",
+"9 -31 OFFCURVE",
+"-30 -62 OFFCURVE",
+"-49 -84 CURVE SMOOTH",
+"-68 -106 OFFCURVE",
+"-78 -129 OFFCURVE",
+"-78 -152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-3 -88 LINE",
+"12 -75 LINE",
+"20 -88 OFFCURVE",
+"25 -106 OFFCURVE",
+"25 -125 CURVE SMOOTH",
+"25 -154 OFFCURVE",
+"12 -177 OFFCURVE",
+"-12 -177 CURVE SMOOTH",
+"-29 -177 OFFCURVE",
+"-40 -167 OFFCURVE",
+"-40 -148 CURVE SMOOTH",
+"-40 -135 OFFCURVE",
+"-34 -119 OFFCURVE",
+"-17 -102 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0734;
+},
+{
+glyphname = uni0735;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"61 639 OFFCURVE",
+"53 650 OFFCURVE",
+"38 650 CURVE SMOOTH",
+"25 650 OFFCURVE",
+"11 639 OFFCURVE",
+"-5 618 CURVE SMOOTH",
+"-21 597 OFFCURVE",
+"-29 581 OFFCURVE",
+"-29 568 CURVE SMOOTH",
+"-29 556 OFFCURVE",
+"-22 545 OFFCURVE",
+"-6 545 CURVE SMOOTH",
+"7 545 OFFCURVE",
+"21 555 OFFCURVE",
+"37 576 CURVE SMOOTH",
+"53 597 OFFCURVE",
+"61 614 OFFCURVE",
+"61 627 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"32 759 OFFCURVE",
+"24 770 OFFCURVE",
+"9 770 CURVE SMOOTH",
+"-4 770 OFFCURVE",
+"-19 759 OFFCURVE",
+"-35 738 CURVE SMOOTH",
+"-51 717 OFFCURVE",
+"-59 701 OFFCURVE",
+"-59 688 CURVE SMOOTH",
+"-59 676 OFFCURVE",
+"-51 666 OFFCURVE",
+"-36 666 CURVE SMOOTH",
+"-23 666 OFFCURVE",
+"-9 676 OFFCURVE",
+"7 697 CURVE SMOOTH",
+"24 718 OFFCURVE",
+"32 735 OFFCURVE",
+"32 747 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0735;
+},
+{
+glyphname = uni0736;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-86 595 LINE",
+"-61 651 OFFCURVE",
+"-35 673 OFFCURVE",
+"1 673 CURVE SMOOTH",
+"9 673 LINE",
+"-29 574 LINE",
+"6 562 LINE",
+"43 662 LINE",
+"64 650 OFFCURVE",
+"74 628 OFFCURVE",
+"74 585 CURVE SMOOTH",
+"74 577 OFFCURVE",
+"72 559 OFFCURVE",
+"69 548 CURVE",
+"105 540 LINE",
+"108 553 OFFCURVE",
+"111 572 OFFCURVE",
+"111 589 CURVE SMOOTH",
+"111 674 OFFCURVE",
+"66 707 OFFCURVE",
+"3 707 CURVE SMOOTH",
+"-50 707 OFFCURVE",
+"-89 679 OFFCURVE",
+"-121 607 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0736;
+},
+{
+glyphname = uni0737;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"86 -53 LINE",
+"62 -105 OFFCURVE",
+"39 -132 OFFCURVE",
+"-1 -132 CURVE",
+"-9 -131 LINE",
+"29 -32 LINE",
+"-6 -21 LINE",
+"-43 -121 LINE",
+"-64 -109 OFFCURVE",
+"-74 -87 OFFCURVE",
+"-74 -44 CURVE SMOOTH",
+"-74 -35 OFFCURVE",
+"-72 -18 OFFCURVE",
+"-69 -7 CURVE",
+"-105 1 LINE",
+"-108 -12 OFFCURVE",
+"-111 -31 OFFCURVE",
+"-111 -47 CURVE SMOOTH",
+"-111 -132 OFFCURVE",
+"-66 -166 OFFCURVE",
+"-3 -166 CURVE SMOOTH",
+"50 -166 OFFCURVE",
+"89 -138 OFFCURVE",
+"121 -66 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0737;
+},
+{
+glyphname = uni0738;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, -64, -130}";
+},
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, 65, -130}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0738;
+},
+{
+glyphname = uni0739;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, -64, -193}";
+},
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, 65, -130}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0739;
+},
+{
+glyphname = uni073A;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"26 635 LINE",
+"-5 670 LINE",
+"57 724 LINE",
+"33 749 LINE",
+"-117 619 LINE",
+"-93 594 LINE",
+"-32 647 LINE",
+"0 612 LINE",
+"-63 558 LINE",
+"-40 533 LINE",
+"110 663 LINE",
+"87 687 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 073A;
+},
+{
+glyphname = uni073B;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-26 -93 LINE",
+"5 -129 LINE",
+"-57 -183 LINE",
+"-33 -208 LINE",
+"117 -78 LINE",
+"93 -52 LINE",
+"32 -105 LINE",
+"0 -70 LINE",
+"62 -17 LINE",
+"40 9 LINE",
+"-110 -122 LINE",
+"-87 -146 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 073B;
+},
+{
+glyphname = uni073C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, 0, -130}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 073C;
+},
+{
+glyphname = uni073D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"22 687 LINE",
+"70 741 LINE",
+"42 762 LINE",
+"-104 598 LINE",
+"-77 576 LINE",
+"-2 660 LINE",
+"77 573 LINE",
+"104 599 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"29 599 OFFCURVE",
+"15 608 OFFCURVE",
+"-1 608 CURVE SMOOTH",
+"-18 608 OFFCURVE",
+"-31 599 OFFCURVE",
+"-31 576 CURVE SMOOTH",
+"-31 552 OFFCURVE",
+"-18 542 OFFCURVE",
+"-1 542 CURVE SMOOTH",
+"15 542 OFFCURVE",
+"29 552 OFFCURVE",
+"29 576 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 073D;
+},
+{
+glyphname = uni073E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-23 -146 LINE",
+"-70 -199 LINE",
+"-42 -221 LINE",
+"104 -57 LINE",
+"78 -35 LINE",
+"2 -118 LINE",
+"-77 -32 LINE",
+"-104 -57 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-29 -57 OFFCURVE",
+"-15 -67 OFFCURVE",
+"1 -67 CURVE SMOOTH",
+"18 -67 OFFCURVE",
+"31 -57 OFFCURVE",
+"31 -34 CURVE SMOOTH",
+"31 -11 OFFCURVE",
+"18 0 OFFCURVE",
+"1 0 CURVE SMOOTH",
+"-15 0 OFFCURVE",
+"-29 -11 OFFCURVE",
+"-29 -34 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 073E;
+},
+{
+glyphname = uni073F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, 0, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 073F;
+},
+{
+glyphname = uni0740;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, -348, 333}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0740;
+},
+{
+glyphname = uni0741;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, -27, 551}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0741;
+},
+{
+glyphname = uni0742;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 0, -103}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0742;
+},
+{
+glyphname = uni0743;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 0, 542}";
+},
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 0, 666}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0743;
+},
+{
+glyphname = uni0744;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 0, -206}";
+},
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 0, -82}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0744;
+},
+{
+glyphname = uni0745;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 69, 542}";
+},
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 0, 666}";
+},
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, -68, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0745;
+},
+{
+glyphname = uni0746;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 69, -82}";
+},
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, 0, -206}";
+},
+{
+name = Dot3;
+transform = "{1, 0, 0, 1, -68, -82}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0746;
+},
+{
+glyphname = uni0747;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-113 554 LINE",
+"-84 524 LINE",
+"102 679 LINE",
+"74 709 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0747;
+},
+{
+glyphname = uni0748;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"73 -168 LINE",
+"102 -138 LINE",
+"-84 18 LINE",
+"-113 -13 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0748;
+},
+{
+glyphname = uni0749;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-92 729 LINE",
+"-159 769 LINE",
+"-172 747 LINE",
+"-104 708 LINE",
+"-135 656 LINE",
+"-115 644 LINE",
+"-84 696 LINE",
+"-61 682 LINE",
+"-91 630 LINE",
+"-71 619 LINE",
+"-41 670 LINE",
+"-17 657 LINE",
+"-46 604 LINE",
+"-26 593 LINE",
+"4 645 LINE",
+"27 631 LINE",
+"-2 580 LINE",
+"18 568 LINE",
+"48 620 LINE",
+"71 606 LINE",
+"42 554 LINE",
+"62 542 LINE",
+"92 594 LINE",
+"163 553 LINE",
+"176 574 LINE",
+"104 616 LINE",
+"133 666 LINE",
+"113 677 LINE",
+"84 628 LINE",
+"61 642 LINE",
+"89 690 LINE",
+"69 703 LINE",
+"41 653 LINE",
+"17 667 LINE",
+"45 716 LINE",
+"25 728 LINE",
+"-3 679 LINE",
+"-27 692 LINE",
+"1 741 LINE",
+"-20 753 LINE",
+"-48 704 LINE",
+"-71 718 LINE",
+"-43 767 LINE",
+"-64 778 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0749;
+},
+{
+glyphname = uni074A;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-12 542 LINE",
+"12 542 LINE",
+"12 655 LINE",
+"121 655 LINE",
+"121 679 LINE",
+"12 679 LINE",
+"12 792 LINE",
+"-12 792 LINE",
+"-12 679 LINE",
+"-122 679 LINE",
+"-122 655 LINE",
+"-12 655 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-37 738 OFFCURVE",
+"-45 744 OFFCURVE",
+"-56 744 CURVE SMOOTH",
+"-67 744 OFFCURVE",
+"-74 738 OFFCURVE",
+"-74 723 CURVE SMOOTH",
+"-74 710 OFFCURVE",
+"-67 703 OFFCURVE",
+"-56 703 CURVE SMOOTH",
+"-45 703 OFFCURVE",
+"-37 710 OFFCURVE",
+"-37 723 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"74 738 OFFCURVE",
+"64 744 OFFCURVE",
+"56 744 CURVE SMOOTH",
+"44 744 OFFCURVE",
+"36 738 OFFCURVE",
+"36 723 CURVE SMOOTH",
+"36 710 OFFCURVE",
+"44 703 OFFCURVE",
+"56 703 CURVE SMOOTH",
+"64 703 OFFCURVE",
+"74 710 OFFCURVE",
+"74 723 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"74 626 OFFCURVE",
+"64 631 OFFCURVE",
+"56 631 CURVE SMOOTH",
+"44 631 OFFCURVE",
+"36 626 OFFCURVE",
+"36 611 CURVE SMOOTH",
+"36 598 OFFCURVE",
+"44 590 OFFCURVE",
+"56 590 CURVE SMOOTH",
+"64 590 OFFCURVE",
+"74 598 OFFCURVE",
+"74 611 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-37 626 OFFCURVE",
+"-45 631 OFFCURVE",
+"-56 631 CURVE SMOOTH",
+"-67 631 OFFCURVE",
+"-74 626 OFFCURVE",
+"-74 611 CURVE SMOOTH",
+"-74 598 OFFCURVE",
+"-67 590 OFFCURVE",
+"-56 590 CURVE SMOOTH",
+"-45 590 OFFCURVE",
+"-37 598 OFFCURVE",
+"-37 611 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 074A;
+},
+{
+glyphname = uni0303;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"94 629 LINE",
+"89 600 OFFCURVE",
+"80 588 OFFCURVE",
+"57 588 CURVE SMOOTH",
+"46 588 OFFCURVE",
+"30 595 OFFCURVE",
+"7 609 CURVE SMOOTH",
+"-16 623 OFFCURVE",
+"-36 630 OFFCURVE",
+"-53 630 CURVE SMOOTH",
+"-97 630 OFFCURVE",
+"-125 598 OFFCURVE",
+"-130 542 CURVE",
+"-93 542 LINE",
+"-89 570 OFFCURVE",
+"-79 583 OFFCURVE",
+"-56 583 CURVE SMOOTH",
+"-44 583 OFFCURVE",
+"-27 576 OFFCURVE",
+"-4 562 CURVE SMOOTH",
+"19 548 OFFCURVE",
+"38 541 OFFCURVE",
+"54 541 CURVE SMOOTH",
+"98 541 OFFCURVE",
+"126 572 OFFCURVE",
+"131 629 CURVE",
+"94 629 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0303;
+},
+{
+glyphname = uni0304;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-127 550 LINE",
+"127 550 LINE",
+"127 596 LINE",
+"-127 596 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0304;
+},
+{
+glyphname = uni0307;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, -1, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0307;
+},
+{
+glyphname = uni0308;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, -86, 542}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 82, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0308;
+},
+{
+glyphname = uni030A;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-64 571 OFFCURVE",
+"-37 547 OFFCURVE",
+"0 547 CURVE SMOOTH",
+"36 547 OFFCURVE",
+"64 573 OFFCURVE",
+"64 613 CURVE SMOOTH",
+"64 653 OFFCURVE",
+"37 675 OFFCURVE",
+"0 675 CURVE SMOOTH",
+"-37 675 OFFCURVE",
+"-64 649 OFFCURVE",
+"-64 610 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"32 590 OFFCURVE",
+"19 577 OFFCURVE",
+"0 577 CURVE SMOOTH",
+"-19 577 OFFCURVE",
+"-33 590 OFFCURVE",
+"-33 611 CURVE SMOOTH",
+"-33 632 OFFCURVE",
+"-19 646 OFFCURVE",
+"0 646 CURVE SMOOTH",
+"19 646 OFFCURVE",
+"32 632 OFFCURVE",
+"32 611 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 030A;
+},
+{
+glyphname = uni0320;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+components = (
+{
+name = uni0331;
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0320;
+},
+{
+glyphname = uni0323;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 0, -118}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0323;
+},
+{
+glyphname = uni0324;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, -86, -115}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 82, -115}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+unicode = 0324;
+},
+{
+glyphname = uni0325;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"64 -30 OFFCURVE",
+"37 -6 OFFCURVE",
+"0 -6 CURVE SMOOTH",
+"-36 -6 OFFCURVE",
+"-64 -32 OFFCURVE",
+"-64 -71 CURVE SMOOTH",
+"-64 -112 OFFCURVE",
+"-37 -134 OFFCURVE",
+"0 -134 CURVE SMOOTH",
+"37 -134 OFFCURVE",
+"64 -106 OFFCURVE",
+"64 -69 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-32 -49 OFFCURVE",
+"-19 -36 OFFCURVE",
+"0 -36 CURVE SMOOTH",
+"19 -36 OFFCURVE",
+"33 -49 OFFCURVE",
+"33 -70 CURVE SMOOTH",
+"33 -91 OFFCURVE",
+"19 -104 OFFCURVE",
+"0 -104 CURVE SMOOTH",
+"-19 -104 OFFCURVE",
+"-32 -91 OFFCURVE",
+"-32 -70 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0325;
+},
+{
+glyphname = uni032D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-120 -100 LINE",
+"-75 -100 LINE",
+"-39 -71 LINE",
+"-1 -41 LINE",
+"36 -72 LINE SMOOTH",
+"48 -83 OFFCURVE",
+"59 -92 OFFCURVE",
+"69 -100 CURVE",
+"120 -100 LINE",
+"120 -96 LINE",
+"95 -73 LINE",
+"70 -48 OFFCURVE",
+"42 -21 OFFCURVE",
+"22 0 CURVE",
+"-21 0 LINE",
+"-43 -22 LINE",
+"-69 -48 LINE",
+"-95 -73 LINE",
+"-120 -96 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 032D;
+},
+{
+glyphname = uni032E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"89 49 LINE",
+"82 12 OFFCURVE",
+"51 -14 OFFCURVE",
+"0 -14 CURVE SMOOTH",
+"-49 -14 OFFCURVE",
+"-79 8 OFFCURVE",
+"-88 49 CURVE",
+"-126 49 LINE",
+"-123 -20 OFFCURVE",
+"-75 -61 OFFCURVE",
+"-2 -61 CURVE SMOOTH",
+"70 -61 OFFCURVE",
+"123 -16 OFFCURVE",
+"128 49 CURVE",
+"89 49 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 032E;
+},
+{
+glyphname = uni0330;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-95 -88 LINE",
+"-90 -59 OFFCURVE",
+"-80 -47 OFFCURVE",
+"-57 -47 CURVE SMOOTH",
+"-46 -47 OFFCURVE",
+"-29 -54 OFFCURVE",
+"-6 -68 CURVE SMOOTH",
+"16 -82 OFFCURVE",
+"36 -89 OFFCURVE",
+"53 -89 CURVE SMOOTH",
+"97 -89 OFFCURVE",
+"125 -57 OFFCURVE",
+"130 0 CURVE",
+"93 0 LINE",
+"89 -29 OFFCURVE",
+"79 -41 OFFCURVE",
+"56 -41 CURVE SMOOTH",
+"44 -41 OFFCURVE",
+"27 -34 OFFCURVE",
+"4 -20 CURVE SMOOTH",
+"-19 -6 OFFCURVE",
+"-38 1 OFFCURVE",
+"-54 1 CURVE SMOOTH",
+"-98 1 OFFCURVE",
+"-126 -31 OFFCURVE",
+"-131 -88 CURVE",
+"-95 -88 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0330;
+},
+{
+glyphname = uni0331;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"127 -9 LINE",
+"-127 -9 LINE",
+"-127 -52 LINE",
+"127 -52 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0331;
+},
+{
+glyphname = uni064B;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-92 572 LINE",
+"-91 538 LINE",
+"93 607 LINE",
+"92 642 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-98 648 LINE",
+"-96 613 LINE",
+"88 683 LINE",
+"86 718 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 064B;
+},
+{
+glyphname = uni064C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-64 582 LINE",
+"-60 590 OFFCURVE",
+"-59 600 OFFCURVE",
+"-59 607 CURVE SMOOTH",
+"-59 640 OFFCURVE",
+"-83 659 OFFCURVE",
+"-116 659 CURVE",
+"-115 625 LINE",
+"-98 625 OFFCURVE",
+"-89 611 OFFCURVE",
+"-89 598 CURVE SMOOTH",
+"-89 587 OFFCURVE",
+"-91 579 OFFCURVE",
+"-98 570 CURVE",
+"-95 537 LINE",
+"-40 558 LINE SMOOTH",
+"11 577 OFFCURVE",
+"46 593 OFFCURVE",
+"64 606 CURVE SMOOTH",
+"83 620 OFFCURVE",
+"92 639 OFFCURVE",
+"92 662 CURVE SMOOTH",
+"92 694 OFFCURVE",
+"67 717 OFFCURVE",
+"36 717 CURVE SMOOTH",
+"1 717 OFFCURVE",
+"-27 690 OFFCURVE",
+"-27 655 CURVE SMOOTH",
+"-27 635 OFFCURVE",
+"-18 618 OFFCURVE",
+"-5 607 CURVE",
+"-33 595 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"26 621 LINE",
+"14 628 OFFCURVE",
+"5 640 OFFCURVE",
+"5 655 CURVE SMOOTH",
+"5 671 OFFCURVE",
+"18 682 OFFCURVE",
+"33 682 CURVE SMOOTH",
+"48 682 OFFCURVE",
+"59 672 OFFCURVE",
+"59 657 CURVE SMOOTH",
+"59 641 OFFCURVE",
+"46 628 OFFCURVE",
+"30 623 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 064C;
+},
+{
+glyphname = uni064D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-92 -140 LINE",
+"-91 -175 LINE",
+"93 -105 LINE",
+"92 -71 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-98 -64 LINE",
+"-96 -99 LINE",
+"88 -30 LINE",
+"86 5 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 064D;
+},
+{
+glyphname = uni064E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-92 572 LINE",
+"-91 538 LINE",
+"93 607 LINE",
+"92 642 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 064E;
+},
+{
+glyphname = uni064F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-94 538 LINE",
+"-17 565 OFFCURVE",
+"33 585 OFFCURVE",
+"56 600 CURVE SMOOTH",
+"79 615 OFFCURVE",
+"90 635 OFFCURVE",
+"90 660 CURVE SMOOTH",
+"90 692 OFFCURVE",
+"63 715 OFFCURVE",
+"31 715 CURVE SMOOTH",
+"-4 715 OFFCURVE",
+"-34 687 OFFCURVE",
+"-34 652 CURVE SMOOTH",
+"-34 629 OFFCURVE",
+"-23 616 OFFCURVE",
+"-10 605 CURVE",
+"-32 597 LINE",
+"-77 580 LINE",
+"-95 573 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"22 619 LINE",
+"9 626 OFFCURVE",
+"0 637 OFFCURVE",
+"0 652 CURVE SMOOTH",
+"0 669 OFFCURVE",
+"13 679 OFFCURVE",
+"29 679 CURVE SMOOTH",
+"48 679 OFFCURVE",
+"57 668 OFFCURVE",
+"57 655 CURVE SMOOTH",
+"57 640 OFFCURVE",
+"46 629 OFFCURVE",
+"25 620 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 064F;
+},
+{
+glyphname = uni0650;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-98 -64 LINE",
+"-96 -99 LINE",
+"88 -30 LINE",
+"86 5 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0650;
+},
+{
+glyphname = uni0651;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"1 582 OFFCURVE",
+"16 576 OFFCURVE",
+"32 576 CURVE SMOOTH",
+"63 576 OFFCURVE",
+"85 598 OFFCURVE",
+"85 637 CURVE SMOOTH",
+"85 657 OFFCURVE",
+"77 676 OFFCURVE",
+"64 688 CURVE",
+"35 677 LINE",
+"43 668 OFFCURVE",
+"54 654 OFFCURVE",
+"54 637 CURVE SMOOTH",
+"54 622 OFFCURVE",
+"47 610 OFFCURVE",
+"30 610 CURVE SMOOTH",
+"15 610 OFFCURVE",
+"4 620 OFFCURVE",
+"-7 657 CURVE",
+"-38 645 LINE",
+"-34 636 OFFCURVE",
+"-32 624 OFFCURVE",
+"-32 612 CURVE SMOOTH",
+"-32 595 OFFCURVE",
+"-38 578 OFFCURVE",
+"-59 578 CURVE SMOOTH",
+"-79 578 OFFCURVE",
+"-89 598 OFFCURVE",
+"-89 629 CURVE",
+"-118 620 LINE",
+"-118 616 LINE SMOOTH",
+"-118 573 OFFCURVE",
+"-96 543 OFFCURVE",
+"-61 543 CURVE SMOOTH",
+"-29 543 OFFCURVE",
+"-11 564 OFFCURVE",
+"-7 597 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0651;
+},
+{
+glyphname = uni0652;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-71 569 OFFCURVE",
+"-44 542 OFFCURVE",
+"-4 542 CURVE SMOOTH",
+"33 542 OFFCURVE",
+"62 571 OFFCURVE",
+"62 604 CURVE SMOOTH",
+"62 645 OFFCURVE",
+"33 674 OFFCURVE",
+"-6 674 CURVE SMOOTH",
+"-39 674 OFFCURVE",
+"-71 643 OFFCURVE",
+"-71 606 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-26 573 OFFCURVE",
+"-40 588 OFFCURVE",
+"-40 607 CURVE SMOOTH",
+"-40 627 OFFCURVE",
+"-25 642 OFFCURVE",
+"-4 642 CURVE SMOOTH",
+"16 642 OFFCURVE",
+"31 629 OFFCURVE",
+"31 608 CURVE SMOOTH",
+"31 589 OFFCURVE",
+"19 573 OFFCURVE",
+"-5 573 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0652;
+},
+{
+glyphname = uni0653;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-100 533 LINE",
+"-83 553 LINE SMOOTH",
+"-78 560 OFFCURVE",
+"-74 564 OFFCURVE",
+"-71 567 CURVE",
+"-47 556 OFFCURVE",
+"-22 549 OFFCURVE",
+"15 549 CURVE SMOOTH",
+"50 549 OFFCURVE",
+"93 563 OFFCURVE",
+"116 580 CURVE",
+"95 609 LINE",
+"75 597 OFFCURVE",
+"48 589 OFFCURVE",
+"20 589 CURVE SMOOTH",
+"-8 589 OFFCURVE",
+"-34 592 OFFCURVE",
+"-78 608 CURVE",
+"-81 605 OFFCURVE",
+"-85 602 OFFCURVE",
+"-88 598 CURVE SMOOTH",
+"-102 583 LINE",
+"-110 571 OFFCURVE",
+"-120 561 OFFCURVE",
+"-127 550 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0653;
+},
+{
+glyphname = uni0654;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"22 591 LINE",
+"21 590 OFFCURVE",
+"19 590 OFFCURVE",
+"17 590 CURVE SMOOTH",
+"9 590 LINE SMOOTH",
+"-14 590 OFFCURVE",
+"-27 608 OFFCURVE",
+"-27 625 CURVE SMOOTH",
+"-27 649 OFFCURVE",
+"-11 662 OFFCURVE",
+"14 662 CURVE SMOOTH",
+"23 662 OFFCURVE",
+"35 661 OFFCURVE",
+"47 656 CURVE",
+"59 688 LINE",
+"43 696 OFFCURVE",
+"23 699 OFFCURVE",
+"10 699 CURVE SMOOTH",
+"-31 699 OFFCURVE",
+"-66 669 OFFCURVE",
+"-66 625 CURVE SMOOTH",
+"-66 612 OFFCURVE",
+"-62 594 OFFCURVE",
+"-47 582 CURVE",
+"-78 578 LINE",
+"-78 542 LINE",
+"67 559 LINE",
+"67 596 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0654;
+},
+{
+glyphname = uni0655;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"14 -109 LINE",
+"9 -109 LINE SMOOTH",
+"-11 -109 OFFCURVE",
+"-27 -94 OFFCURVE",
+"-27 -74 CURVE SMOOTH",
+"-27 -51 OFFCURVE",
+"-11 -37 OFFCURVE",
+"14 -37 CURVE SMOOTH",
+"25 -37 OFFCURVE",
+"36 -39 OFFCURVE",
+"47 -43 CURVE",
+"59 -10 LINE",
+"43 -2 OFFCURVE",
+"23 0 OFFCURVE",
+"10 0 CURVE SMOOTH",
+"-31 0 OFFCURVE",
+"-66 -30 OFFCURVE",
+"-66 -74 CURVE SMOOTH",
+"-66 -86 OFFCURVE",
+"-62 -105 OFFCURVE",
+"-47 -118 CURVE",
+"-78 -121 LINE",
+"-78 -157 LINE",
+"67 -141 LINE",
+"67 -104 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0655;
+},
+{
+glyphname = uni0670;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-23 722 LINE",
+"-23 542 LINE",
+"23 542 LINE",
+"23 722 LINE"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 0670;
+},
+{
+glyphname = Wasla;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 543}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-90 598 OFFCURVE",
+"-113 569 OFFCURVE",
+"-127 550 CURVE",
+"-100 533 LINE",
+"-88 546 OFFCURVE",
+"-76 562 OFFCURVE",
+"-71 567 CURVE",
+"-47 556 OFFCURVE",
+"-17 549 OFFCURVE",
+"15 549 CURVE SMOOTH",
+"96 549 OFFCURVE",
+"118 588 OFFCURVE",
+"118 621 CURVE SMOOTH",
+"118 658 OFFCURVE",
+"87 679 OFFCURVE",
+"60 679 CURVE SMOOTH",
+"31 679 OFFCURVE",
+"2 667 OFFCURVE",
+"-39 595 CURVE",
+"-53 599 OFFCURVE",
+"-65 603 OFFCURVE",
+"-78 608 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"72 643 OFFCURVE",
+"83 632 OFFCURVE",
+"83 617 CURVE SMOOTH",
+"83 606 OFFCURVE",
+"73 587 OFFCURVE",
+"25 587 CURVE SMOOTH",
+"15 587 OFFCURVE",
+"5 587 OFFCURVE",
+"-3 588 CURVE",
+"16 622 OFFCURVE",
+"34 643 OFFCURVE",
+"56 643 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-90 598 OFFCURVE",
+"-113 569 OFFCURVE",
+"-127 550 CURVE",
+"-100 533 LINE",
+"-88 546 OFFCURVE",
+"-76 562 OFFCURVE",
+"-71 567 CURVE",
+"-47 556 OFFCURVE",
+"-17 549 OFFCURVE",
+"15 549 CURVE SMOOTH",
+"96 549 OFFCURVE",
+"118 588 OFFCURVE",
+"118 621 CURVE SMOOTH",
+"118 658 OFFCURVE",
+"87 679 OFFCURVE",
+"60 679 CURVE SMOOTH",
+"31 679 OFFCURVE",
+"2 667 OFFCURVE",
+"-39 595 CURVE",
+"-53 599 OFFCURVE",
+"-65 603 OFFCURVE",
+"-78 608 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"72 643 OFFCURVE",
+"83 632 OFFCURVE",
+"83 617 CURVE SMOOTH",
+"83 606 OFFCURVE",
+"73 587 OFFCURVE",
+"25 587 CURVE SMOOTH",
+"15 587 OFFCURVE",
+"5 587 OFFCURVE",
+"-3 588 CURVE",
+"16 622 OFFCURVE",
+"34 643 OFFCURVE",
+"56 643 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = FC5E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0651;
+},
+{
+name = uni064C;
+transform = "{1, 0, 0, 1, -23, 142}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = FC5F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni064B;
+},
+{
+name = uni0651;
+transform = "{1, 0, 0, 1, -1, 177}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni064B0651;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0651;
+},
+{
+name = uni064B;
+transform = "{1, 0, 0, 1, -23, 138}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = FC60;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0651;
+},
+{
+name = uni064E;
+transform = "{1, 0, 0, 1, -23, 138}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = FC61;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0651;
+},
+{
+name = uni064F;
+transform = "{1, 0, 0, 1, -23, 142}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = FC62;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni064E;
+},
+{
+name = uni0651;
+transform = "{1, 0, 0, 1, 4, 102}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = FC63;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"1 582 OFFCURVE",
+"16 576 OFFCURVE",
+"32 576 CURVE SMOOTH",
+"63 576 OFFCURVE",
+"85 598 OFFCURVE",
+"85 637 CURVE SMOOTH",
+"85 657 OFFCURVE",
+"77 676 OFFCURVE",
+"64 688 CURVE",
+"35 677 LINE",
+"43 668 OFFCURVE",
+"54 654 OFFCURVE",
+"54 637 CURVE SMOOTH",
+"54 622 OFFCURVE",
+"47 610 OFFCURVE",
+"30 610 CURVE SMOOTH",
+"15 610 OFFCURVE",
+"4 620 OFFCURVE",
+"-7 657 CURVE",
+"-38 645 LINE",
+"-34 636 OFFCURVE",
+"-32 624 OFFCURVE",
+"-32 612 CURVE SMOOTH",
+"-32 595 OFFCURVE",
+"-38 578 OFFCURVE",
+"-59 578 CURVE SMOOTH",
+"-79 578 OFFCURVE",
+"-89 598 OFFCURVE",
+"-89 629 CURVE",
+"-118 620 LINE",
+"-118 616 LINE SMOOTH",
+"-118 573 OFFCURVE",
+"-96 543 OFFCURVE",
+"-61 543 CURVE SMOOTH",
+"-29 543 OFFCURVE",
+"-11 564 OFFCURVE",
+"-7 597 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-44 857 LINE",
+"-44 705 LINE",
+"-3 705 LINE",
+"-3 857 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = uni0654064B;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0654;
+},
+{
+name = uni064B;
+transform = "{1, 0, 0, 1, -9, 174}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni0654064E;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0654;
+},
+{
+name = uni064E;
+transform = "{1, 0, 0, 1, -9, 179}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni0654064C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0654;
+},
+{
+name = uni064C;
+transform = "{1, 0, 0, 1, -9, 174}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni0654064F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0654;
+},
+{
+name = uni064F;
+transform = "{1, 0, 0, 1, -9, 174}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni06540652;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni0654;
+},
+{
+name = uni0652;
+transform = "{1, 0, 0, 1, 0, 202}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni06550650;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = uni0655;
+},
+{
+name = uni0650;
+transform = "{1, 0, 0, 1, 0, -186}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni0655064D;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = uni0655;
+},
+{
+name = uni064D;
+transform = "{1, 0, 0, 1, 0, -181}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni0660;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"29 202 OFFCURVE",
+"61 175 OFFCURVE",
+"97 175 CURVE SMOOTH",
+"130 175 OFFCURVE",
+"161 202 OFFCURVE",
+"161 241 CURVE SMOOTH",
+"161 276 OFFCURVE",
+"127 304 OFFCURVE",
+"94 304 CURVE SMOOTH",
+"63 304 OFFCURVE",
+"29 276 OFFCURVE",
+"29 241 CURVE SMOOTH"
+);
+}
+);
+width = 190;
+}
+);
+unicode = 0660;
+},
+{
+glyphname = uni0661;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"93 586 LINE",
+"118 0 LINE",
+"187 0 LINE",
+"163 586 LINE"
+);
+}
+);
+width = 280;
+}
+);
+unicode = 0661;
+},
+{
+glyphname = uni0662;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"119 458 LINE",
+"144 442 OFFCURVE",
+"176 437 OFFCURVE",
+"204 437 CURVE SMOOTH",
+"305 437 OFFCURVE",
+"371 490 OFFCURVE",
+"392 586 CURVE",
+"325 586 LINE",
+"305 531 OFFCURVE",
+"270 507 OFFCURVE",
+"195 507 CURVE SMOOTH",
+"158 507 OFFCURVE",
+"123 520 OFFCURVE",
+"104 541 CURVE",
+"97 586 LINE",
+"24 586 LINE",
+"37 514 OFFCURVE",
+"55 408 OFFCURVE",
+"70 313 CURVE SMOOTH",
+"119 0 LINE",
+"190 0 LINE"
+);
+}
+);
+width = 407;
+}
+);
+unicode = 0662;
+},
+{
+glyphname = uni0663;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"219 586 LINE",
+"216 522 OFFCURVE",
+"200 491 OFFCURVE",
+"161 491 CURVE SMOOTH",
+"141 491 OFFCURVE",
+"119 501 OFFCURVE",
+"108 518 CURVE",
+"97 586 LINE",
+"24 586 LINE",
+"37 514 OFFCURVE",
+"55 408 OFFCURVE",
+"70 313 CURVE SMOOTH",
+"119 0 LINE",
+"190 0 LINE",
+"122 438 LINE",
+"123 438 LINE",
+"136 429 OFFCURVE",
+"154 426 OFFCURVE",
+"169 426 CURVE SMOOTH",
+"196 426 OFFCURVE",
+"223 432 OFFCURVE",
+"243 455 CURVE",
+"262 438 OFFCURVE",
+"286 426 OFFCURVE",
+"325 426 CURVE SMOOTH",
+"398 426 OFFCURVE",
+"449 486 OFFCURVE",
+"449 586 CURVE",
+"384 586 LINE",
+"383 525 OFFCURVE",
+"364 492 OFFCURVE",
+"320 492 CURVE SMOOTH",
+"301 492 OFFCURVE",
+"284 498 OFFCURVE",
+"273 511 CURVE",
+"278 527 OFFCURVE",
+"284 554 OFFCURVE",
+"284 586 CURVE",
+"219 586 LINE"
+);
+}
+);
+width = 463;
+}
+);
+unicode = 0663;
+},
+{
+glyphname = uni0664;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"280 600 LINE",
+"112 564 OFFCURVE",
+"29 503 OFFCURVE",
+"29 422 CURVE SMOOTH",
+"29 373 OFFCURVE",
+"62 338 OFFCURVE",
+"138 318 CURVE SMOOTH",
+"205 300 LINE",
+"180 281 LINE SMOOTH",
+"129 242 OFFCURVE",
+"94 208 OFFCURVE",
+"75 181 CURVE SMOOTH",
+"56 154 OFFCURVE",
+"47 127 OFFCURVE",
+"47 98 CURVE SMOOTH",
+"47 33 OFFCURVE",
+"102 -2 OFFCURVE",
+"234 -2 CURVE SMOOTH",
+"287 -2 OFFCURVE",
+"327 5 OFFCURVE",
+"370 17 CURVE",
+"370 86 LINE",
+"326 75 OFFCURVE",
+"280 69 OFFCURVE",
+"239 69 CURVE SMOOTH",
+"160 69 OFFCURVE",
+"115 82 OFFCURVE",
+"115 109 CURVE SMOOTH",
+"115 132 OFFCURVE",
+"133 154 OFFCURVE",
+"177 193 CURVE SMOOTH",
+"247 254 LINE",
+"283 287 OFFCURVE",
+"285 301 OFFCURVE",
+"285 313 CURVE SMOOTH",
+"285 340 OFFCURVE",
+"274 354 OFFCURVE",
+"226 366 CURVE SMOOTH",
+"199 373 LINE SMOOTH",
+"132 389 OFFCURVE",
+"97 405 OFFCURVE",
+"97 429 CURVE SMOOTH",
+"97 468 OFFCURVE",
+"160 501 OFFCURVE",
+"280 534 CURVE"
+);
+}
+);
+width = 390;
+}
+);
+unicode = 0664;
+},
+{
+glyphname = uni0665;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"174 529 OFFCURVE",
+"126 503 OFFCURVE",
+"89 451 CURVE SMOOTH",
+"52 400 OFFCURVE",
+"34 336 OFFCURVE",
+"34 261 CURVE SMOOTH",
+"34 118 OFFCURVE",
+"108 39 OFFCURVE",
+"225 39 CURVE SMOOTH",
+"348 39 OFFCURVE",
+"420 121 OFFCURVE",
+"420 272 CURVE SMOOTH",
+"420 347 OFFCURVE",
+"403 409 OFFCURVE",
+"370 457 CURVE SMOOTH",
+"337 505 OFFCURVE",
+"290 529 OFFCURVE",
+"231 529 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"302 455 OFFCURVE",
+"347 381 OFFCURVE",
+"347 270 CURVE SMOOTH",
+"347 163 OFFCURVE",
+"308 112 OFFCURVE",
+"225 112 CURVE SMOOTH",
+"149 112 OFFCURVE",
+"107 166 OFFCURVE",
+"107 261 CURVE SMOOTH",
+"107 381 OFFCURVE",
+"156 455 OFFCURVE",
+"231 455 CURVE SMOOTH"
+);
+}
+);
+width = 454;
+}
+);
+unicode = 0665;
+},
+{
+glyphname = uni0666;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"258 516 LINE",
+"259 453 OFFCURVE",
+"262 370 OFFCURVE",
+"268 267 CURVE SMOOTH",
+"275 164 OFFCURVE",
+"281 75 OFFCURVE",
+"288 0 CURVE",
+"360 0 LINE",
+"354 79 LINE",
+"351 108 OFFCURVE",
+"349 139 OFFCURVE",
+"346 172 CURVE SMOOTH",
+"339 272 LINE",
+"330 416 LINE",
+"328 469 OFFCURVE",
+"327 510 OFFCURVE",
+"327 539 CURVE SMOOTH",
+"327 586 LINE",
+"194 586 LINE",
+"159 586 LINE SMOOTH",
+"114 586 OFFCURVE",
+"53 589 OFFCURVE",
+"18 592 CURVE",
+"10 525 LINE",
+"70 518 OFFCURVE",
+"134 516 OFFCURVE",
+"194 516 CURVE SMOOTH"
+);
+}
+);
+width = 409;
+}
+);
+unicode = 0666;
+},
+{
+glyphname = uni0667;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"389 586 LINE",
+"362 515 OFFCURVE",
+"337 443 OFFCURVE",
+"308 359 CURVE SMOOTH",
+"269 244 LINE SMOOTH",
+"256 205 OFFCURVE",
+"242 166 OFFCURVE",
+"227 125 CURVE",
+"225 125 LINE",
+"204 195 LINE",
+"155 356 LINE",
+"104 517 LINE",
+"97 542 OFFCURVE",
+"90 565 OFFCURVE",
+"83 586 CURVE",
+"0 586 LINE",
+"39 474 OFFCURVE",
+"68 382 OFFCURVE",
+"103 277 CURVE",
+"136 173 LINE",
+"190 0 LINE",
+"250 0 LINE",
+"279 83 LINE",
+"316 183 LINE",
+"357 292 LINE",
+"370 329 OFFCURVE",
+"384 366 OFFCURVE",
+"397 401 CURVE SMOOTH",
+"467 586 LINE"
+);
+}
+);
+width = 467;
+}
+);
+unicode = 0667;
+},
+{
+glyphname = uni0668;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"83 0 LINE",
+"108 71 OFFCURVE",
+"132 143 OFFCURVE",
+"160 227 CURVE SMOOTH",
+"197 342 LINE",
+"237 460 LINE",
+"239 460 LINE",
+"261 391 LINE",
+"286 313 LINE",
+"313 230 LINE",
+"389 0 LINE",
+"472 0 LINE",
+"461 30 OFFCURVE",
+"449 62 OFFCURVE",
+"437 97 CURVE SMOOTH",
+"400 202 LINE SMOOTH",
+"376 270 OFFCURVE",
+"352 344 OFFCURVE",
+"329 413 CURVE SMOOTH",
+"297 507 LINE",
+"288 536 OFFCURVE",
+"279 563 OFFCURVE",
+"271 586 CURVE",
+"212 586 LINE",
+"184 504 LINE",
+"148 403 LINE",
+"110 294 LINE",
+"35 84 LINE",
+"5 0 LINE"
+);
+}
+);
+width = 472;
+}
+);
+unicode = 0668;
+},
+{
+glyphname = uni0669;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"377 0 LINE",
+"342 401 LINE SMOOTH",
+"330 537 OFFCURVE",
+"275 599 OFFCURVE",
+"179 599 CURVE SMOOTH",
+"135 599 OFFCURVE",
+"97 579 OFFCURVE",
+"64 539 CURVE SMOOTH",
+"31 500 OFFCURVE",
+"15 456 OFFCURVE",
+"15 408 CURVE SMOOTH",
+"15 316 OFFCURVE",
+"74 260 OFFCURVE",
+"177 260 CURVE SMOOTH",
+"210 260 OFFCURVE",
+"250 269 OFFCURVE",
+"281 286 CURVE",
+"305 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"275 352 LINE",
+"243 337 OFFCURVE",
+"217 332 OFFCURVE",
+"184 332 CURVE SMOOTH",
+"115 332 OFFCURVE",
+"84 363 OFFCURVE",
+"84 415 CURVE SMOOTH",
+"84 480 OFFCURVE",
+"130 529 OFFCURVE",
+"179 529 CURVE SMOOTH",
+"244 529 OFFCURVE",
+"267 487 OFFCURVE",
+"272 398 CURVE SMOOTH"
+);
+}
+);
+width = 420;
+}
+);
+unicode = 0669;
+},
+{
+glyphname = uni066A;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"366 586 LINE",
+"63 0 LINE",
+"137 0 LINE",
+"439 586 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"68 493 OFFCURVE",
+"97 470 OFFCURVE",
+"129 470 CURVE SMOOTH",
+"161 470 OFFCURVE",
+"187 496 OFFCURVE",
+"187 529 CURVE SMOOTH",
+"187 560 OFFCURVE",
+"157 586 OFFCURVE",
+"126 586 CURVE SMOOTH",
+"98 586 OFFCURVE",
+"68 560 OFFCURVE",
+"68 529 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"310 14 OFFCURVE",
+"340 -10 OFFCURVE",
+"372 -10 CURVE SMOOTH",
+"403 -10 OFFCURVE",
+"429 16 OFFCURVE",
+"429 49 CURVE SMOOTH",
+"429 80 OFFCURVE",
+"398 106 OFFCURVE",
+"369 106 CURVE SMOOTH",
+"341 106 OFFCURVE",
+"310 81 OFFCURVE",
+"310 49 CURVE SMOOTH"
+);
+}
+);
+width = 478;
+}
+);
+unicode = 066A;
+},
+{
+glyphname = uni066B;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"111 116 LINE",
+"84 -4 LINE",
+"69 -71 LINE",
+"55 -129 LINE",
+"116 -129 LINE",
+"153 -16 LINE SMOOTH",
+"168 30 OFFCURVE",
+"180 70 OFFCURVE",
+"190 105 CURVE",
+"183 116 LINE"
+);
+}
+);
+width = 262;
+}
+);
+unicode = 066B;
+},
+{
+glyphname = uni066C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"109 586 LINE",
+"83 465 LINE",
+"67 399 LINE SMOOTH",
+"62 377 OFFCURVE",
+"58 358 OFFCURVE",
+"53 341 CURVE",
+"114 341 LINE",
+"125 370 OFFCURVE",
+"137 407 OFFCURVE",
+"152 453 CURVE SMOOTH",
+"167 500 OFFCURVE",
+"179 540 OFFCURVE",
+"188 575 CURVE",
+"181 586 LINE"
+);
+}
+);
+width = 262;
+}
+);
+unicode = 066C;
+},
+{
+glyphname = period;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"192 95 OFFCURVE",
+"169 118 OFFCURVE",
+"132 118 CURVE SMOOTH",
+"95 118 OFFCURVE",
+"74 95 OFFCURVE",
+"74 52 CURVE SMOOTH",
+"74 5 OFFCURVE",
+"99 -14 OFFCURVE",
+"132 -14 CURVE SMOOTH",
+"169 -14 OFFCURVE",
+"192 9 OFFCURVE",
+"192 52 CURVE SMOOTH"
+);
+}
+);
+width = 266;
+}
+);
+unicode = 002E;
+},
+{
+glyphname = uni060C;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"143 0 LINE",
+"169 121 LINE",
+"185 187 LINE SMOOTH",
+"190 209 OFFCURVE",
+"194 228 OFFCURVE",
+"199 245 CURVE",
+"138 245 LINE",
+"127 216 OFFCURVE",
+"115 179 OFFCURVE",
+"100 132 CURVE SMOOTH",
+"85 86 OFFCURVE",
+"73 46 OFFCURVE",
+"63 11 CURVE",
+"71 0 LINE"
+);
+}
+);
+width = 277;
+}
+);
+unicode = 060C;
+},
+{
+glyphname = uni061B;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"187 311 LINE",
+"202 398 OFFCURVE",
+"218 477 OFFCURVE",
+"239 556 CURVE",
+"178 556 LINE",
+"141 475 OFFCURVE",
+"119 399 OFFCURVE",
+"99 322 CURVE",
+"106 311 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 95 OFFCURVE",
+"178 118 OFFCURVE",
+"141 118 CURVE SMOOTH",
+"104 118 OFFCURVE",
+"83 95 OFFCURVE",
+"83 52 CURVE SMOOTH",
+"83 5 OFFCURVE",
+"108 -14 OFFCURVE",
+"141 -14 CURVE SMOOTH",
+"177 -14 OFFCURVE",
+"201 9 OFFCURVE",
+"201 52 CURVE SMOOTH"
+);
+}
+);
+width = 284;
+}
+);
+unicode = 061B;
+},
+{
+glyphname = colon;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"201 95 OFFCURVE",
+"178 118 OFFCURVE",
+"141 118 CURVE SMOOTH",
+"104 118 OFFCURVE",
+"83 95 OFFCURVE",
+"83 52 CURVE SMOOTH",
+"83 5 OFFCURVE",
+"108 -14 OFFCURVE",
+"141 -14 CURVE SMOOTH",
+"177 -14 OFFCURVE",
+"201 9 OFFCURVE",
+"201 52 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 410 OFFCURVE",
+"181 432 OFFCURVE",
+"141 432 CURVE SMOOTH",
+"102 432 OFFCURVE",
+"83 410 OFFCURVE",
+"83 366 CURVE SMOOTH",
+"83 319 OFFCURVE",
+"108 300 OFFCURVE",
+"141 300 CURVE SMOOTH",
+"177 300 OFFCURVE",
+"201 322 OFFCURVE",
+"201 366 CURVE SMOOTH"
+);
+}
+);
+width = 284;
+}
+);
+unicode = 003A;
+},
+{
+glyphname = uni061F;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 197 LINE",
+"262 223 LINE SMOOTH",
+"262 278 OFFCURVE",
+"239 318 OFFCURVE",
+"184 358 CURVE SMOOTH",
+"129 399 OFFCURVE",
+"108 428 OFFCURVE",
+"108 464 CURVE SMOOTH",
+"108 512 OFFCURVE",
+"149 546 OFFCURVE",
+"212 546 CURVE SMOOTH",
+"257 546 OFFCURVE",
+"297 535 OFFCURVE",
+"336 516 CURVE",
+"365 577 LINE",
+"312 604 OFFCURVE",
+"262 617 OFFCURVE",
+"209 617 CURVE SMOOTH",
+"157 617 OFFCURVE",
+"114 602 OFFCURVE",
+"81 573 CURVE SMOOTH",
+"48 544 OFFCURVE",
+"32 506 OFFCURVE",
+"32 461 CURVE SMOOTH",
+"32 396 OFFCURVE",
+"66 357 OFFCURVE",
+"141 304 CURVE SMOOTH",
+"178 278 OFFCURVE",
+"197 248 OFFCURVE",
+"197 213 CURVE SMOOTH",
+"197 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"174 13 OFFCURVE",
+"194 -8 OFFCURVE",
+"227 -8 CURVE SMOOTH",
+"258 -8 OFFCURVE",
+"280 9 OFFCURVE",
+"280 52 CURVE SMOOTH",
+"280 92 OFFCURVE",
+"262 112 OFFCURVE",
+"227 112 CURVE SMOOTH",
+"194 112 OFFCURVE",
+"174 91 OFFCURVE",
+"174 52 CURVE SMOOTH"
+);
+}
+);
+width = 379;
+}
+);
+unicode = 061F;
+},
+{
+glyphname = exclam;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"190 607 LINE",
+"95 607 LINE",
+"117 197 LINE",
+"168 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 91 OFFCURVE",
+"175 112 OFFCURVE",
+"142 112 CURVE SMOOTH",
+"107 112 OFFCURVE",
+"89 92 OFFCURVE",
+"89 52 CURVE SMOOTH",
+"89 9 OFFCURVE",
+"111 -8 OFFCURVE",
+"142 -8 CURVE SMOOTH",
+"175 -8 OFFCURVE",
+"195 13 OFFCURVE",
+"195 52 CURVE SMOOTH"
+);
+}
+);
+width = 284;
+}
+);
+unicode = 0021;
+},
+{
+glyphname = parenleft;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"187 689 LINE",
+"91 576 OFFCURVE",
+"40 422 OFFCURVE",
+"40 250 CURVE SMOOTH",
+"40 78 OFFCURVE",
+"91 -71 OFFCURVE",
+"187 -183 CURVE",
+"265 -183 LINE",
+"174 -59 OFFCURVE",
+"125 97 OFFCURVE",
+"125 250 CURVE SMOOTH",
+"125 410 OFFCURVE",
+"171 564 OFFCURVE",
+"266 689 CURVE",
+"187 689 LINE"
+);
+}
+);
+width = 296;
+}
+);
+unicode = 0028;
+},
+{
+glyphname = parenright;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"109 -183 LINE",
+"205 -72 OFFCURVE",
+"256 77 OFFCURVE",
+"256 250 CURVE SMOOTH",
+"256 418 OFFCURVE",
+"206 574 OFFCURVE",
+"109 689 CURVE",
+"30 689 LINE",
+"125 564 OFFCURVE",
+"171 410 OFFCURVE",
+"171 250 CURVE SMOOTH",
+"171 95 OFFCURVE",
+"122 -60 OFFCURVE",
+"31 -183 CURVE",
+"109 -183 LINE"
+);
+}
+);
+width = 296;
+}
+);
+unicode = 0029;
+},
+{
+glyphname = bracketleft;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"301 -91 LINE",
+"155 -91 LINE",
+"155 627 LINE",
+"301 627 LINE",
+"301 693 LINE",
+"78 693 LINE",
+"78 -158 LINE",
+"301 -158 LINE"
+);
+}
+);
+width = 326;
+}
+);
+unicode = 005B;
+},
+{
+glyphname = bracketright;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"24 -158 LINE",
+"248 -158 LINE",
+"248 693 LINE",
+"24 693 LINE",
+"24 627 LINE",
+"170 627 LINE",
+"170 -91 LINE",
+"24 -91 LINE"
+);
+}
+);
+width = 326;
+}
+);
+unicode = 005D;
+},
+{
+glyphname = parenleft.alt;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"78 931 LINE",
+"78 416 LINE",
+"129 416 LINE",
+"129 880 LINE",
+"563 880 LINE",
+"563 931 LINE"
+);
+}
+);
+width = 539;
+}
+);
+},
+{
+glyphname = parenright.alt;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-24 931 LINE",
+"-24 880 LINE",
+"410 880 LINE",
+"410 416 LINE",
+"461 416 LINE",
+"461 931 LINE"
+);
+}
+);
+width = 539;
+}
+);
+},
+{
+glyphname = guillemotleft;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"40 197 LINE",
+"207 -1 LINE",
+"265 33 LINE",
+"124 205 LINE",
+"265 375 LINE",
+"207 409 LINE",
+"40 210 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"233 197 LINE",
+"401 -1 LINE",
+"458 33 LINE",
+"318 205 LINE",
+"458 375 LINE",
+"401 409 LINE",
+"233 210 LINE"
+);
+}
+);
+width = 497;
+}
+);
+unicode = 00AB;
+},
+{
+glyphname = guillemotright;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"457 210 LINE",
+"289 409 LINE",
+"232 375 LINE",
+"372 205 LINE",
+"232 33 LINE",
+"289 -1 LINE",
+"457 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"264 210 LINE",
+"96 409 LINE",
+"39 375 LINE",
+"179 205 LINE",
+"39 33 LINE",
+"96 -1 LINE",
+"264 197 LINE"
+);
+}
+);
+width = 497;
+}
+);
+unicode = 00BB;
+},
+{
+glyphname = asterisk;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"174 625 LINE",
+"186 485 LINE",
+"45 520 LINE",
+"34 453 LINE",
+"167 439 LINE",
+"84 321 LINE",
+"149 286 LINE",
+"209 414 LINE",
+"274 286 LINE",
+"338 321 LINE",
+"253 439 LINE",
+"387 453 LINE",
+"377 520 LINE",
+"234 485 LINE",
+"246 625 LINE"
+);
+}
+);
+width = 421;
+}
+);
+unicode = 002A;
+},
+{
+glyphname = plus;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"318 534 LINE",
+"254 534 LINE",
+"254 336 LINE",
+"63 336 LINE",
+"63 271 LINE",
+"254 271 LINE",
+"254 74 LINE",
+"318 74 LINE",
+"318 271 LINE",
+"509 271 LINE",
+"509 336 LINE",
+"318 336 LINE"
+);
+}
+);
+width = 573;
+}
+);
+unicode = 002B;
+},
+{
+glyphname = equal;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"502 367 LINE",
+"502 430 LINE",
+"71 430 LINE",
+"71 367 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"502 177 LINE",
+"502 241 LINE",
+"71 241 LINE",
+"71 177 LINE"
+);
+}
+);
+width = 573;
+}
+);
+unicode = 003D;
+},
+{
+glyphname = slash;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"348 693 LINE",
+"44 -123 LINE",
+"113 -123 LINE",
+"417 693 LINE"
+);
+}
+);
+width = 460;
+}
+);
+unicode = 002F;
+},
+{
+glyphname = backslash;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"11 714 LINE",
+"277 0 LINE",
+"358 0 LINE",
+"91 714 LINE"
+);
+}
+);
+width = 367;
+}
+);
+unicode = 005C;
+},
+{
+glyphname = hyphen;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"281 231 LINE",
+"281 305 LINE",
+"41 305 LINE",
+"41 231 LINE"
+);
+}
+);
+width = 322;
+}
+);
+unicode = 002D;
+},
+{
+glyphname = degree;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"330 502 OFFCURVE",
+"317 535 OFFCURVE",
+"290 560 CURVE SMOOTH",
+"263 586 OFFCURVE",
+"231 599 OFFCURVE",
+"193 599 CURVE SMOOTH",
+"156 599 OFFCURVE",
+"123 586 OFFCURVE",
+"96 559 CURVE SMOOTH",
+"69 532 OFFCURVE",
+"56 500 OFFCURVE",
+"56 462 CURVE SMOOTH",
+"56 383 OFFCURVE",
+"114 326 OFFCURVE",
+"193 326 CURVE SMOOTH",
+"230 326 OFFCURVE",
+"262 339 OFFCURVE",
+"289 366 CURVE SMOOTH",
+"316 393 OFFCURVE",
+"330 425 OFFCURVE",
+"330 462 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 414 OFFCURVE",
+"241 376 OFFCURVE",
+"193 376 CURVE SMOOTH",
+"144 376 OFFCURVE",
+"107 414 OFFCURVE",
+"107 462 CURVE SMOOTH",
+"107 513 OFFCURVE",
+"144 548 OFFCURVE",
+"193 548 CURVE SMOOTH",
+"241 548 OFFCURVE",
+"279 513 OFFCURVE",
+"279 462 CURVE SMOOTH"
+);
+}
+);
+width = 428;
+}
+);
+unicode = 00B0;
+},
+{
+glyphname = uni25CC;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"522 297 LINE",
+"518 336 OFFCURVE",
+"503 373 OFFCURVE",
+"476 408 CURVE",
+"454 385 LINE",
+"472 360 OFFCURVE",
+"484 330 OFFCURVE",
+"491 297 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"437 447 LINE",
+"402 472 OFFCURVE",
+"366 487 OFFCURVE",
+"328 491 CURVE",
+"328 458 LINE",
+"359 455 OFFCURVE",
+"388 443 OFFCURVE",
+"415 424 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 244 LINE",
+"486 214 OFFCURVE",
+"474 185 OFFCURVE",
+"455 158 CURVE",
+"478 135 LINE",
+"503 170 OFFCURVE",
+"518 206 OFFCURVE",
+"522 244 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"274 491 LINE",
+"235 485 OFFCURVE",
+"199 470 OFFCURVE",
+"166 445 CURVE",
+"188 422 LINE",
+"213 441 OFFCURVE",
+"242 453 OFFCURVE",
+"274 458 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"128 407 LINE",
+"103 374 OFFCURVE",
+"88 337 OFFCURVE",
+"84 297 CURVE",
+"115 297 LINE",
+"119 328 OFFCURVE",
+"131 357 OFFCURVE",
+"150 384 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"414 120 LINE",
+"388 100 OFFCURVE",
+"359 88 OFFCURVE",
+"328 83 CURVE",
+"328 51 LINE",
+"368 56 OFFCURVE",
+"404 72 OFFCURVE",
+"437 97 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"152 158 LINE",
+"133 184 OFFCURVE",
+"120 213 OFFCURVE",
+"115 244 CURVE",
+"83 244 LINE",
+"88 205 OFFCURVE",
+"104 169 OFFCURVE",
+"129 136 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"274 85 LINE",
+"242 89 OFFCURVE",
+"213 100 OFFCURVE",
+"188 119 CURVE",
+"165 97 LINE",
+"200 72 OFFCURVE",
+"236 57 OFFCURVE",
+"274 53 CURVE"
+);
+}
+);
+width = 605;
+}
+);
+unicode = 25CC;
+},
+{
+glyphname = uni2670;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"131 511 LINE",
+"88 479 LINE",
+"141 391 LINE",
+"88 302 LINE",
+"131 268 LINE",
+"197 353 LINE",
+"411 353 LINE",
+"411 -47 LINE",
+"321 -114 LINE",
+"357 -157 LINE",
+"446 -104 LINE",
+"534 -157 LINE",
+"573 -114 LINE",
+"484 -47 LINE",
+"484 353 LINE",
+"697 353 LINE",
+"764 268 LINE",
+"807 299 LINE",
+"753 388 LINE",
+"807 476 LINE",
+"764 511 LINE",
+"697 426 LINE",
+"484 426 LINE",
+"484 648 LINE",
+"573 714 LINE",
+"538 757 LINE",
+"449 704 LINE",
+"360 757 LINE",
+"321 714 LINE",
+"411 647 LINE",
+"411 426 LINE",
+"197 426 LINE"
+);
+}
+);
+width = 895;
+}
+);
+unicode = 2670;
+},
+{
+glyphname = uni2671;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"170 353 LINE",
+"401 353 LINE",
+"401 -75 LINE",
+"323 -102 LINE",
+"323 -125 LINE",
+"342 -141 OFFCURVE",
+"392 -157 OFFCURVE",
+"436 -157 CURVE SMOOTH",
+"477 -157 OFFCURVE",
+"531 -142 OFFCURVE",
+"552 -125 CURVE",
+"552 -102 LINE",
+"474 -74 LINE",
+"474 353 LINE",
+"705 353 LINE",
+"732 274 LINE",
+"756 274 LINE",
+"772 294 OFFCURVE",
+"787 344 OFFCURVE",
+"787 387 CURVE SMOOTH",
+"787 430 OFFCURVE",
+"773 481 OFFCURVE",
+"756 504 CURVE",
+"732 504 LINE",
+"705 426 LINE",
+"474 426 LINE",
+"474 675 LINE",
+"552 703 LINE",
+"552 726 LINE",
+"531 743 OFFCURVE",
+"482 757 OFFCURVE",
+"439 757 CURVE SMOOTH",
+"396 757 OFFCURVE",
+"342 742 OFFCURVE",
+"323 726 CURVE",
+"323 703 LINE",
+"401 675 LINE",
+"401 426 LINE",
+"170 426 LINE",
+"143 504 LINE",
+"119 504 LINE",
+"102 483 OFFCURVE",
+"88 434 OFFCURVE",
+"88 391 CURVE SMOOTH",
+"88 348 OFFCURVE",
+"103 294 OFFCURVE",
+"119 274 CURVE",
+"143 274 LINE"
+);
+}
+);
+width = 875;
+}
+);
+unicode = 2671;
+},
+{
+glyphname = uni072Auni0308.Isol;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{203, -72}";
+}
+);
+components = (
+{
+name = uni0716;
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 115, 494}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 284, 494}";
+}
+);
+layerId = UUID0;
+width = 539;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+glyphname = uni072Auni0308.Fina;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{202, -72}";
+}
+);
+components = (
+{
+name = uni0716.Fina;
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 284, 494}";
+},
+{
+name = Dot1;
+transform = "{1, 0, 0, 1, 115, 494}";
+}
+);
+layerId = UUID0;
+width = 531;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+glyphname = uni0713.FinaWide;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{881, -232}";
+}
+);
+components = (
+{
+name = uni0713.Fina;
+},
+{
+name = Stretch;
+transform = "{1, 0, 0, 1, 945, 0}";
+}
+);
+layerId = UUID0;
+width = 1213;
+}
+);
+},
+{
+glyphname = uni0713.MediWide;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{516, -230}";
+}
+);
+components = (
+{
+name = uni0713.Medi;
+},
+{
+name = Stretch;
+transform = "{1, 0, 0, 1, 571, 0}";
+}
+);
+layerId = UUID0;
+width = 840;
+}
+);
+},
+{
+glyphname = uni0714.FinaWide;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{603, -146}";
+}
+);
+components = (
+{
+name = uni0713.Fina;
+},
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, 208, 339}";
+},
+{
+name = Stretch;
+transform = "{1, 0, 0, 1, 945, 0}";
+}
+);
+layerId = UUID0;
+width = 1213;
+}
+);
+},
+{
+glyphname = uni0714.MediWide;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{248, -157}";
+}
+);
+components = (
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, -165, 339}";
+},
+{
+name = uni0713.Medi;
+},
+{
+name = Stretch;
+transform = "{1, 0, 0, 1, 571, 0}";
+}
+);
+layerId = UUID0;
+width = 840;
+}
+);
+},
+{
+glyphname = uni072E.FinaWide;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{603, -146}";
+}
+);
+components = (
+{
+name = uni072E.Fina;
+},
+{
+name = Stretch;
+transform = "{1, 0, 0, 1, 945, 0}";
+}
+);
+layerId = UUID0;
+width = 1213;
+}
+);
+},
+{
+glyphname = uni072E.MediWide;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{248, -157}";
+}
+);
+components = (
+{
+name = uni072E.Medi;
+},
+{
+name = Stretch;
+transform = "{1, 0, 0, 1, 571, 0}";
+}
+);
+layerId = UUID0;
+width = 840;
+}
+);
+},
+{
+glyphname = uni0713.FinaWide2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{881, -232}";
+}
+);
+components = (
+{
+name = uni0713.Fina;
+},
+{
+name = Stretch2;
+transform = "{1, 0, 0, 1, 945, 0}";
+}
+);
+layerId = UUID0;
+width = 1335;
+}
+);
+},
+{
+glyphname = uni0713.MediWide2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{516, -230}";
+}
+);
+components = (
+{
+name = uni0713.Medi;
+},
+{
+name = Stretch2;
+transform = "{1, 0, 0, 1, 571, 0}";
+}
+);
+layerId = UUID0;
+width = 962;
+}
+);
+},
+{
+glyphname = uni0714.FinaWide2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{604, -144}";
+}
+);
+components = (
+{
+name = uni0713.Fina;
+},
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, 208, 339}";
+},
+{
+name = Stretch2;
+transform = "{1, 0, 0, 1, 945, 0}";
+}
+);
+layerId = UUID0;
+width = 1335;
+}
+);
+},
+{
+glyphname = uni0714.MediWide2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{248, -157}";
+}
+);
+components = (
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, -165, 339}";
+},
+{
+name = uni0713.Medi;
+},
+{
+name = Stretch2;
+transform = "{1, 0, 0, 1, 571, 0}";
+}
+);
+layerId = UUID0;
+width = 962;
+}
+);
+},
+{
+glyphname = uni072E.FinaWide2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{603, -146}";
+}
+);
+components = (
+{
+name = uni072E.Fina;
+},
+{
+name = Stretch2;
+transform = "{1, 0, 0, 1, 945, 0}";
+}
+);
+layerId = UUID0;
+width = 1335;
+}
+);
+},
+{
+glyphname = uni072E.MediWide2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{248, -157}";
+}
+);
+components = (
+{
+name = uni072E.Medi;
+},
+{
+name = Stretch2;
+transform = "{1, 0, 0, 1, 571, 0}";
+}
+);
+layerId = UUID0;
+width = 962;
+}
+);
+},
+{
+glyphname = uni0710.Fina1wideY;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{429, -49}";
+}
+);
+components = (
+{
+name = uni0710.Fina1;
+},
+{
+name = Stretch4;
+transform = "{1, 0, 0, 1, 848, 0}";
+},
+{
+name = Stretch4;
+transform = "{1, 0, 0, 1, 935, 0}";
+}
+);
+layerId = UUID0;
+width = 1064;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+glyphname = uni0710.Fina1wideX;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{429, -49}";
+}
+);
+components = (
+{
+name = uni0710.Fina1;
+},
+{
+name = Stretch4;
+transform = "{1, 0, 0, 1, 857, 0}";
+}
+);
+layerId = UUID0;
+width = 987;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+glyphname = uni0710.Medi2wideY;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{431, -49}";
+}
+);
+components = (
+{
+name = uni0710.Fina1;
+},
+{
+name = Stretch4;
+transform = "{1, 0, 0, 1, 848, 0}";
+},
+{
+name = Stretch4;
+transform = "{1, 0, 0, 1, 935, 0}";
+}
+);
+layerId = UUID0;
+width = 1064;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+glyphname = uni0710.Medi2wideX;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{430, -49}";
+}
+);
+components = (
+{
+name = uni0710.Fina1;
+},
+{
+name = Stretch4;
+transform = "{1, 0, 0, 1, 857, 0}";
+}
+);
+layerId = UUID0;
+width = 987;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+glyphname = uni071B.MediLongG;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{626, -443}";
+}
+);
+components = (
+{
+name = uni071B.Medi;
+transform = "{1, 0, 0, 1, 166, 0}";
+},
+{
+name = Stretch;
+}
+);
+layerId = UUID0;
+width = 777;
+}
+);
+},
+{
+glyphname = uni071B.InitLongG;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{627, -443}";
+}
+);
+components = (
+{
+name = uni071B.Init;
+transform = "{1, 0, 0, 1, 166, 0}";
+},
+{
+name = Stretch;
+}
+);
+layerId = UUID0;
+width = 854;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+glyphname = uni071C.MediLongG;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{625, -443}";
+}
+);
+components = (
+{
+name = uni071B.Medi;
+transform = "{1, 0, 0, 1, 166, 0}";
+},
+{
+name = Stretch;
+},
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, 357, 33}";
+}
+);
+layerId = UUID0;
+width = 777;
+}
+);
+},
+{
+glyphname = uni071C.InitLongG;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{626, -444}";
+}
+);
+components = (
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, 357, 33}";
+},
+{
+name = uni071B.Init;
+transform = "{1, 0, 0, 1, 166, 0}";
+},
+{
+name = Stretch;
+}
+);
+layerId = UUID0;
+width = 854;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+glyphname = uni0713.MediLong;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{826, -420}";
+}
+);
+components = (
+{
+name = uni0713.Medi;
+transform = "{1, 0, 0, 1, 32, 0}";
+},
+{
+name = Stretch3;
+}
+);
+layerId = UUID0;
+width = 603;
+}
+);
+},
+{
+glyphname = uni0713.InitLong;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{826, -420}";
+}
+);
+components = (
+{
+name = uni0713.Init;
+transform = "{1, 0, 0, 1, 32, 0}";
+},
+{
+name = Stretch3;
+}
+);
+layerId = UUID0;
+width = 750;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+glyphname = uni0714.MediLong;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{568, -287}";
+}
+);
+components = (
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, -133, 339}";
+},
+{
+name = uni0713.Medi;
+transform = "{1, 0, 0, 1, 32, 0}";
+},
+{
+name = Stretch3;
+}
+);
+layerId = UUID0;
+width = 603;
+}
+);
+},
+{
+glyphname = uni0714.InitLong;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{569, -287}";
+}
+);
+components = (
+{
+name = DotEncl;
+transform = "{1, 0, 0, 1, -133, 339}";
+},
+{
+name = uni0713.Init;
+transform = "{1, 0, 0, 1, 32, 0}";
+},
+{
+name = Stretch3;
+}
+);
+layerId = UUID0;
+width = 750;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+glyphname = uni072E.MediLong;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{569, -287}";
+}
+);
+components = (
+{
+name = uni072E.Medi;
+transform = "{1, 0, 0, 1, 32, 0}";
+},
+{
+name = Stretch3;
+}
+);
+layerId = UUID0;
+width = 603;
+}
+);
+},
+{
+glyphname = uni072E.InitLong;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{569, -287}";
+}
+);
+components = (
+{
+name = uni072E.Init;
+transform = "{1, 0, 0, 1, 32, 0}";
+},
+{
+name = Stretch3;
+}
+);
+layerId = UUID0;
+width = 750;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+glyphname = uni0720.MediB;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{239, -98}";
+}
+);
+components = (
+{
+name = uni0720.Medi;
+transform = "{1, 0, 0, 1, 46, 0}";
+},
+{
+name = Stretch5;
+}
+);
+layerId = UUID0;
+width = 384;
+}
+);
+},
+{
+glyphname = uni0720.InitB;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{215, -98}";
+}
+);
+components = (
+{
+name = uni0720.Init;
+transform = "{1, 0, 0, 1, 46, 0}";
+},
+{
+name = Stretch5;
+}
+);
+layerId = UUID0;
+width = 387;
+}
+);
+leftKerningGroup = uni0720;
+},
+{
+glyphname = uni0722.InitB;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{208, -97}";
+}
+);
+components = (
+{
+name = uni0722.Init;
+transform = "{1, 0, 0, 1, 76, 0}";
+},
+{
+name = Stretch5;
+}
+);
+layerId = UUID0;
+width = 367;
+}
+);
+leftKerningGroup = uni0722.Init;
+},
+{
+glyphname = uni0722.MediB;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{225, -97}";
+}
+);
+components = (
+{
+name = uni0722.Medi;
+transform = "{1, 0, 0, 1, 76, 0}";
+},
+{
+name = Stretch5;
+}
+);
+layerId = UUID0;
+width = 372;
+}
+);
+},
+{
+glyphname = uni071D.InitB;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{199, -97}";
+}
+);
+components = (
+{
+name = uni071D.Init;
+transform = "{1, 0, 0, 1, 64, 0}";
+},
+{
+name = Stretch5;
+}
+);
+layerId = UUID0;
+width = 342;
+}
+);
+},
+{
+glyphname = uni071D.MediB;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{217, -98}";
+}
+);
+components = (
+{
+name = uni071D.Medi;
+transform = "{1, 0, 0, 1, 64, 0}";
+},
+{
+name = Stretch5;
+}
+);
+layerId = UUID0;
+width = 374;
+}
+);
+},
+{
+glyphname = uni074F.MediB;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{246, -98}";
+}
+);
+components = (
+{
+name = uni074F.Medi;
+transform = "{1, 0, 0, 1, 55, 0}";
+},
+{
+name = Stretch5;
+transform = "{1, 0, 0, 1, 6, 0}";
+}
+);
+layerId = UUID0;
+width = 405;
+}
+);
+},
+{
+glyphname = uni074F.InitB;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{203, -98}";
+}
+);
+components = (
+{
+name = uni074F.Init;
+transform = "{1, 0, 0, 1, 56, 0}";
+},
+{
+name = Stretch5;
+transform = "{1, 0, 0, 1, 7, 0}";
+}
+);
+layerId = UUID0;
+width = 395;
+}
+);
+},
+{
+glyphname = uni0722.FinaSoft;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{102, -397}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"272 76 LINE",
+"220 76 OFFCURVE",
+"172 72 OFFCURVE",
+"128 63 CURVE SMOOTH",
+"85 54 OFFCURVE",
+"63 32 OFFCURVE",
+"63 -5 CURVE SMOOTH",
+"63 -48 OFFCURVE",
+"90 -112 OFFCURVE",
+"143 -197 CURVE SMOOTH",
+"197 -283 OFFCURVE",
+"257 -365 OFFCURVE",
+"322 -442 CURVE",
+"381 -400 LINE",
+"330 -336 OFFCURVE",
+"279 -264 OFFCURVE",
+"228 -184 CURVE SMOOTH",
+"177 -105 OFFCURVE",
+"147 -48 OFFCURVE",
+"138 -13 CURVE",
+"145 -10 OFFCURVE",
+"164 -7 OFFCURVE",
+"195 -4 CURVE SMOOTH",
+"226 -1 OFFCURVE",
+"257 0 OFFCURVE",
+"288 0 CURVE SMOOTH",
+"340 0 LINE",
+"340 76 LINE",
+"272 76 LINE"
+);
+}
+);
+width = 340;
+}
+);
+},
+{
+glyphname = uni0732.above;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, 10, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = uni0732.below;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot2slant;
+transform = "{1, 0, 0, 1, -9, -130}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = Dot1;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"52 96 OFFCURVE",
+"33 116 OFFCURVE",
+"0 116 CURVE SMOOTH",
+"-31 116 OFFCURVE",
+"-49 96 OFFCURVE",
+"-49 59 CURVE SMOOTH",
+"-49 19 OFFCURVE",
+"-28 3 OFFCURVE",
+"0 3 CURVE SMOOTH",
+"32 3 OFFCURVE",
+"52 23 OFFCURVE",
+"52 59 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = Dot2slant;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"37 111 OFFCURVE",
+"30 123 OFFCURVE",
+"14 123 CURVE SMOOTH",
+"1 123 OFFCURVE",
+"-11 112 OFFCURVE",
+"-21 89 CURVE",
+"-32 67 OFFCURVE",
+"-37 49 OFFCURVE",
+"-37 36 CURVE SMOOTH",
+"-37 20 OFFCURVE",
+"-31 8 OFFCURVE",
+"-14 8 CURVE SMOOTH",
+"-1 8 OFFCURVE",
+"10 19 OFFCURVE",
+"21 42 CURVE SMOOTH",
+"32 65 OFFCURVE",
+"37 83 OFFCURVE",
+"37 95 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = Dot3;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"37 70 OFFCURVE",
+"20 83 OFFCURVE",
+"0 83 CURVE SMOOTH",
+"-21 83 OFFCURVE",
+"-38 70 OFFCURVE",
+"-38 42 CURVE SMOOTH",
+"-38 13 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"20 0 OFFCURVE",
+"37 13 OFFCURVE",
+"37 42 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = DotEncl;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"293 -102 OFFCURVE",
+"273 -88 OFFCURVE",
+"250 -88 CURVE SMOOTH",
+"225 -88 OFFCURVE",
+"207 -102 OFFCURVE",
+"207 -135 CURVE SMOOTH",
+"207 -168 OFFCURVE",
+"225 -182 OFFCURVE",
+"250 -182 CURVE SMOOTH",
+"273 -182 OFFCURVE",
+"293 -168 OFFCURVE",
+"293 -135 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = Stretch;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"269 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"269 0 LINE"
+);
+}
+);
+width = 269;
+}
+);
+},
+{
+glyphname = Stretch2;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"391 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"391 0 LINE"
+);
+}
+);
+width = 391;
+}
+);
+},
+{
+glyphname = Stretch3;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"32 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"32 0 LINE"
+);
+}
+);
+width = 32;
+}
+);
+},
+{
+glyphname = Stretch4;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"129 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"129 0 LINE"
+);
+}
+);
+width = 129;
+}
+);
+},
+{
+glyphname = Stretch5;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"76 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"76 0 LINE"
+);
+}
+);
+width = 76;
+}
+);
+},
+{
+glyphname = uni070F.blank;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+glyphname = SAM4in;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-215 815 LINE",
+"20 815 LINE",
+"20 850 LINE",
+"-215 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM8in;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-410 815 LINE",
+"20 815 LINE",
+"20 850 LINE",
+"-410 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM4out;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-20 815 LINE",
+"215 815 LINE",
+"215 850 LINE",
+"-20 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM12out;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-20 815 LINE",
+"605 815 LINE",
+"605 850 LINE",
+"-20 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM18out;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-20 815 LINE",
+"972 815 LINE",
+"972 850 LINE",
+"-20 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM4xin;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-215 815 LINE",
+"-68 815 LINE",
+"-68 850 LINE",
+"-215 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM8xin;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-410 815 LINE",
+"-68 815 LINE",
+"-68 850 LINE",
+"-410 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM4xout;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"59 815 LINE",
+"215 815 LINE",
+"215 850 LINE",
+"59 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM12xout;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"59 815 LINE",
+"605 815 LINE",
+"605 850 LINE",
+"59 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = SAM18xout;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"59 815 LINE",
+"972 815 LINE",
+"972 850 LINE",
+"59 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = nbspace;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+width = 260;
+}
+);
+unicode = 00A0;
+},
+{
+color = 5;
+glyphname = H;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{368, 0}";
+},
+{
+name = mark1;
+position = "{371, 714}";
+},
+{
+name = mark2;
+position = "{721, 714}";
+},
+{
+name = mark3;
+position = "{371, 357}";
+}
+);
+hints = (
+{
+place = "{97, 90}";
+},
+{
+place = "{553, 90}";
+},
+{
+horizontal = 1;
+place = "{0, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{333, 79}";
+},
+{
+horizontal = 1;
+place = "{714, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"643 0 LINE",
+"643 714 LINE",
+"553 714 LINE",
+"553 412 LINE",
+"187 412 LINE",
+"187 714 LINE",
+"97 714 LINE",
+"97 0 LINE",
+"187 0 LINE",
+"187 333 LINE",
+"553 333 LINE",
+"553 0 LINE"
+);
+}
+);
+width = 741;
+}
+);
+unicode = 0048;
+},
+{
+color = 5;
+glyphname = O;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{392, 0}";
+},
+{
+name = mark1;
+position = "{391, 714}";
+},
+{
+name = mark2;
+position = "{761, 714}";
+},
+{
+name = mark3;
+position = "{391, 357}";
+}
+);
+hints = (
+{
+place = "{61, 95}";
+},
+{
+place = "{625, 95}";
+},
+{
+horizontal = 1;
+place = "{-10, 78}";
+},
+{
+horizontal = 1;
+place = "{646, 79}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"720 580 OFFCURVE",
+"606 725 OFFCURVE",
+"392 725 CURVE SMOOTH",
+"168 725 OFFCURVE",
+"61 578 OFFCURVE",
+"61 359 CURVE SMOOTH",
+"61 138 OFFCURVE",
+"168 -10 OFFCURVE",
+"391 -10 CURVE SMOOTH",
+"606 -10 OFFCURVE",
+"720 137 OFFCURVE",
+"720 358 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 538 OFFCURVE",
+"230 646 OFFCURVE",
+"392 646 CURVE SMOOTH",
+"553 646 OFFCURVE",
+"625 538 OFFCURVE",
+"625 358 CURVE SMOOTH",
+"625 178 OFFCURVE",
+"553 68 OFFCURVE",
+"391 68 CURVE SMOOTH",
+"230 68 OFFCURVE",
+"156 178 OFFCURVE",
+"156 358 CURVE SMOOTH"
+);
+}
+);
+width = 781;
+}
+);
+unicode = 004F;
+},
+{
+color = 5;
+glyphname = e;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{301, 0}";
+},
+{
+name = mark1;
+position = "{285, 536}";
+},
+{
+name = mark2;
+position = "{544, 536}";
+},
+{
+name = mark3;
+position = "{0, 0}";
+}
+);
+hints = (
+{
+place = "{55, 91}";
+},
+{
+place = "{421, 92}";
+},
+{
+horizontal = 1;
+place = "{-10, 75}";
+},
+{
+horizontal = 1;
+place = "{251, 70}";
+},
+{
+horizontal = 1;
+place = "{474, 72}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"150 546 OFFCURVE",
+"55 440 OFFCURVE",
+"55 264 CURVE SMOOTH",
+"55 85 OFFCURVE",
+"160 -10 OFFCURVE",
+"313 -10 CURVE SMOOTH",
+"386 -10 OFFCURVE",
+"434 1 OFFCURVE",
+"489 25 CURVE",
+"489 102 LINE",
+"433 78 OFFCURVE",
+"385 65 OFFCURVE",
+"317 65 CURVE SMOOTH",
+"210 65 OFFCURVE",
+"149 130 OFFCURVE",
+"146 251 CURVE",
+"513 251 LINE",
+"513 304 LINE SMOOTH",
+"513 450 OFFCURVE",
+"429 546 OFFCURVE",
+"292 546 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"380 474 OFFCURVE",
+"420 412 OFFCURVE",
+"421 321 CURVE",
+"148 321 LINE",
+"157 417 OFFCURVE",
+"207 474 OFFCURVE",
+"291 474 CURVE SMOOTH"
+);
+}
+);
+width = 564;
+}
+);
+unicode = 0065;
+},
+{
+color = 5;
+glyphname = n;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{309, 0}";
+},
+{
+name = mark1;
+position = "{309, 536}";
+},
+{
+name = mark2;
+position = "{562, 536}";
+},
+{
+name = mark3;
+position = "{0, 0}";
+}
+);
+hints = (
+{
+place = "{85, 88}";
+},
+{
+place = "{450, 87}";
+},
+{
+horizontal = 1;
+place = "{0, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{472, 74}";
+},
+{
+horizontal = 1;
+place = "{536, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"275 546 OFFCURVE",
+"209 519 OFFCURVE",
+"174 463 CURVE",
+"169 463 LINE",
+"156 536 LINE",
+"85 536 LINE",
+"85 0 LINE",
+"173 0 LINE",
+"173 278 LINE SMOOTH",
+"173 403 OFFCURVE",
+"211 472 OFFCURVE",
+"330 472 CURVE SMOOTH",
+"412 472 OFFCURVE",
+"450 429 OFFCURVE",
+"450 343 CURVE SMOOTH",
+"450 0 LINE",
+"537 0 LINE",
+"537 349 LINE SMOOTH",
+"537 487 OFFCURVE",
+"471 546 OFFCURVE",
+"343 546 CURVE SMOOTH"
+);
+}
+);
+width = 618;
+}
+);
+unicode = 006E;
+},
+{
+color = 5;
+glyphname = o;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{301, 0}";
+},
+{
+name = mark1;
+position = "{303, 536}";
+},
+{
+name = mark2;
+position = "{575, 536}";
+},
+{
+name = mark3;
+position = "{303, 268}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"531 417 OFFCURVE",
+"467 538 OFFCURVE",
+"308 538 CURVE SMOOTH",
+"161 538 OFFCURVE",
+"75 432 OFFCURVE",
+"75 264 CURVE SMOOTH",
+"75 107 OFFCURVE",
+"150 -10 OFFCURVE",
+"302 -10 CURVE SMOOTH",
+"459 -10 OFFCURVE",
+"531 109 OFFCURVE",
+"531 264 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"102 420 OFFCURVE",
+"176 513 OFFCURVE",
+"308 513 CURVE SMOOTH",
+"449 513 OFFCURVE",
+"504 402 OFFCURVE",
+"504 264 CURVE SMOOTH",
+"504 119 OFFCURVE",
+"442 15 OFFCURVE",
+"302 15 CURVE SMOOTH",
+"167 15 OFFCURVE",
+"102 117 OFFCURVE",
+"102 264 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"551 446 OFFCURVE",
+"449 546 OFFCURVE",
+"304 546 CURVE SMOOTH",
+"150 546 OFFCURVE",
+"55 446 OFFCURVE",
+"55 269 CURVE SMOOTH",
+"55 91 OFFCURVE",
+"159 -10 OFFCURVE",
+"301 -10 CURVE SMOOTH",
+"454 -10 OFFCURVE",
+"551 91 OFFCURVE",
+"551 269 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 396 OFFCURVE",
+"193 472 OFFCURVE",
+"302 472 CURVE SMOOTH",
+"411 472 OFFCURVE",
+"460 396 OFFCURVE",
+"460 269 CURVE SMOOTH",
+"460 142 OFFCURVE",
+"411 63 OFFCURVE",
+"303 63 CURVE SMOOTH",
+"194 63 OFFCURVE",
+"146 142 OFFCURVE",
+"146 269 CURVE SMOOTH"
+);
+}
+);
+};
+hints = (
+{
+place = "{55, 91}";
+},
+{
+place = "{460, 91}";
+},
+{
+horizontal = 1;
+place = "{-10, 73}";
+},
+{
+horizontal = 1;
+place = "{472, 74}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"551 446 OFFCURVE",
+"449 546 OFFCURVE",
+"304 546 CURVE SMOOTH",
+"150 546 OFFCURVE",
+"55 446 OFFCURVE",
+"55 269 CURVE SMOOTH",
+"55 91 OFFCURVE",
+"159 -10 OFFCURVE",
+"301 -10 CURVE SMOOTH",
+"454 -10 OFFCURVE",
+"551 91 OFFCURVE",
+"551 269 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 396 OFFCURVE",
+"193 472 OFFCURVE",
+"302 472 CURVE SMOOTH",
+"411 472 OFFCURVE",
+"460 396 OFFCURVE",
+"460 269 CURVE SMOOTH",
+"460 142 OFFCURVE",
+"411 63 OFFCURVE",
+"303 63 CURVE SMOOTH",
+"194 63 OFFCURVE",
+"146 142 OFFCURVE",
+"146 269 CURVE SMOOTH"
+);
+}
+);
+width = 605;
+}
+);
+unicode = 006F;
+},
+{
+color = 5;
+glyphname = z;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{242, 0}";
+},
+{
+name = mark1;
+position = "{235, 536}";
+},
+{
+name = mark2;
+position = "{430, 536}";
+},
+{
+name = mark3;
+position = "{0, 0}";
+}
+);
+hints = (
+{
+place = "{39, 392}";
+},
+{
+horizontal = 1;
+place = "{0, 68}";
+},
+{
+horizontal = 1;
+place = "{468, 68}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"431 0 LINE",
+"431 68 LINE",
+"140 68 LINE",
+"424 470 LINE",
+"424 536 LINE",
+"56 536 LINE",
+"56 468 LINE",
+"327 468 LINE",
+"39 58 LINE",
+"39 0 LINE"
+);
+}
+);
+width = 470;
+}
+);
+unicode = 007A;
+},
+{
+color = 5;
+glyphname = uni0621.loclSYRJ;
+lastChange = "2017-09-08 19:29:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{229, -98}";
+},
+{
+name = top;
+position = "{245, 466}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"290 76 LINE SMOOTH",
+"279 76 OFFCURVE",
+"268 76 OFFCURVE",
+"254 78 CURVE SMOOTH",
+"188 84 OFFCURVE",
+"150 141 OFFCURVE",
+"150 193 CURVE SMOOTH",
+"150 260 OFFCURVE",
+"198 300 OFFCURVE",
+"269 300 CURVE SMOOTH",
+"292 300 OFFCURVE",
+"318 296 OFFCURVE",
+"345 289 CURVE",
+"368 348 LINE",
+"333 364 OFFCURVE",
+"292 367 OFFCURVE",
+"261 367 CURVE SMOOTH",
+"163 367 OFFCURVE",
+"78 299 OFFCURVE",
+"78 191 CURVE SMOOTH",
+"78 161 OFFCURVE",
+"86 108 OFFCURVE",
+"139 73 CURVE",
+"139 70 LINE",
+"44 70 LINE",
+"44 7 LINE",
+"392 7 LINE",
+"392 76 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"290 76 LINE SMOOTH",
+"279 76 OFFCURVE",
+"268 76 OFFCURVE",
+"254 78 CURVE SMOOTH",
+"188 84 OFFCURVE",
+"150 141 OFFCURVE",
+"150 193 CURVE SMOOTH",
+"150 260 OFFCURVE",
+"198 300 OFFCURVE",
+"269 300 CURVE SMOOTH",
+"292 300 OFFCURVE",
+"318 296 OFFCURVE",
+"345 289 CURVE",
+"368 348 LINE",
+"333 364 OFFCURVE",
+"292 367 OFFCURVE",
+"261 367 CURVE SMOOTH",
+"163 367 OFFCURVE",
+"78 299 OFFCURVE",
+"78 191 CURVE SMOOTH",
+"78 161 OFFCURVE",
+"86 108 OFFCURVE",
+"139 73 CURVE",
+"139 70 LINE",
+"44 70 LINE",
+"44 7 LINE",
+"392 7 LINE",
+"392 76 LINE"
+);
+}
+);
+width = 462;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0621.loclSYRN;
+lastChange = "2017-09-08 19:29:26 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{238, -98}";
+}
+);
+hints = (
+{
+place = "{87, 73}";
+},
+{
+horizontal = 1;
+place = "{7, 69}";
+},
+{
+horizontal = 1;
+place = "{300, 67}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"299 76 LINE",
+"206 73 OFFCURVE",
+"166 123 OFFCURVE",
+"160 193 CURVE",
+"160 258 OFFCURVE",
+"206 300 OFFCURVE",
+"278 300 CURVE SMOOTH",
+"301 300 OFFCURVE",
+"327 296 OFFCURVE",
+"354 289 CURVE",
+"377 348 LINE",
+"342 364 OFFCURVE",
+"301 367 OFFCURVE",
+"270 367 CURVE SMOOTH",
+"219 367 OFFCURVE",
+"176 351 OFFCURVE",
+"140 318 CURVE SMOOTH",
+"105 285 OFFCURVE",
+"87 243 OFFCURVE",
+"87 191 CURVE SMOOTH",
+"87 143 OFFCURVE",
+"107 101 OFFCURVE",
+"148 73 CURVE",
+"148 70 LINE",
+"54 70 LINE",
+"54 7 LINE",
+"401 7 LINE",
+"401 76 LINE"
+);
+}
+);
+width = 471;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0728.loclSYRJ.Alt;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{135, -445}";
+},
+{
+name = top;
+position = "{148, 366}";
+}
+);
+components = (
+{
+name = uni0728.loclSYRJ;
+transform = "{1, 0, 0, 1, 21, 0}";
+}
+);
+layerId = UUID0;
+width = 279;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0712.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{749, 439}";
+},
+{
+name = RU;
+position = "{747, -104}";
+},
+{
+name = bottom;
+position = "{436, -98}";
+},
+{
+name = top;
+position = "{496, 512}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"886 0 LINE",
+"886 76 LINE",
+"872 76 LINE SMOOTH",
+"853 76 OFFCURVE",
+"828 76 OFFCURVE",
+"804 74 CURVE",
+"803 78 LINE",
+"817 95 OFFCURVE",
+"823 122 OFFCURVE",
+"823 146 CURVE SMOOTH",
+"823 233 OFFCURVE",
+"767 305 OFFCURVE",
+"686 356 CURVE SMOOTH",
+"627 393 OFFCURVE",
+"562 414 OFFCURVE",
+"481 414 CURVE SMOOTH",
+"444 414 OFFCURVE",
+"375 402 OFFCURVE",
+"343 387 CURVE",
+"359 326 LINE",
+"397 337 OFFCURVE",
+"448 339 OFFCURVE",
+"471 339 CURVE SMOOTH",
+"607 339 OFFCURVE",
+"749 250 OFFCURVE",
+"749 134 CURVE SMOOTH",
+"749 107 OFFCURVE",
+"734 76 OFFCURVE",
+"679 76 CURVE SMOOTH",
+"282 76 LINE SMOOTH",
+"168 76 OFFCURVE",
+"127 139 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"136 0 OFFCURVE",
+"273 0 CURVE SMOOTH"
+);
+}
+);
+width = 886;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072D.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{435, -98}";
+},
+{
+name = top;
+position = "{417, 661}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"886 0 LINE",
+"886 76 LINE",
+"872 76 LINE SMOOTH",
+"853 76 OFFCURVE",
+"828 76 OFFCURVE",
+"804 74 CURVE",
+"803 78 LINE",
+"818 95 OFFCURVE",
+"823 123 OFFCURVE",
+"823 146 CURVE SMOOTH",
+"823 312 OFFCURVE",
+"643 411 OFFCURVE",
+"485 411 CURVE SMOOTH",
+"470 411 OFFCURVE",
+"454 410 OFFCURVE",
+"439 408 CURVE",
+"439 412 LINE",
+"463 434 OFFCURVE",
+"526 495 OFFCURVE",
+"549 520 CURVE SMOOTH",
+"599 574 LINE",
+"545 618 LINE",
+"343 387 LINE",
+"359 333 LINE",
+"399 338 OFFCURVE",
+"437 339 OFFCURVE",
+"461 339 CURVE SMOOTH",
+"617 339 OFFCURVE",
+"749 254 OFFCURVE",
+"749 134 CURVE SMOOTH",
+"749 107 OFFCURVE",
+"734 76 OFFCURVE",
+"679 76 CURVE SMOOTH",
+"282 76 LINE SMOOTH",
+"168 76 OFFCURVE",
+"127 139 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"136 0 OFFCURVE",
+"273 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"886 0 LINE",
+"886 76 LINE",
+"872 76 LINE SMOOTH",
+"853 76 OFFCURVE",
+"828 76 OFFCURVE",
+"804 74 CURVE",
+"803 78 LINE",
+"818 95 OFFCURVE",
+"823 123 OFFCURVE",
+"823 146 CURVE SMOOTH",
+"823 312 OFFCURVE",
+"643 411 OFFCURVE",
+"485 411 CURVE SMOOTH",
+"470 411 OFFCURVE",
+"454 410 OFFCURVE",
+"439 408 CURVE",
+"439 412 LINE",
+"463 434 OFFCURVE",
+"526 495 OFFCURVE",
+"549 520 CURVE SMOOTH",
+"599 574 LINE",
+"545 618 LINE",
+"343 387 LINE",
+"359 333 LINE",
+"399 338 OFFCURVE",
+"437 339 OFFCURVE",
+"461 339 CURVE SMOOTH",
+"617 339 OFFCURVE",
+"749 254 OFFCURVE",
+"749 134 CURVE SMOOTH",
+"749 107 OFFCURVE",
+"734 76 OFFCURVE",
+"679 76 CURVE SMOOTH",
+"282 76 LINE SMOOTH",
+"168 76 OFFCURVE",
+"127 139 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"136 0 OFFCURVE",
+"273 0 CURVE SMOOTH"
+);
+}
+);
+width = 886;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0715.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{259, 231}";
+},
+{
+name = RU;
+position = "{258, -112}";
+},
+{
+name = bottom;
+position = "{117, -419}";
+},
+{
+name = top;
+position = "{144, 315}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"96 -286 OFFCURVE",
+"116 -302 OFFCURVE",
+"145 -302 CURVE SMOOTH",
+"178 -302 OFFCURVE",
+"197 -283 OFFCURVE",
+"197 -246 CURVE SMOOTH",
+"197 -209 OFFCURVE",
+"178 -189 OFFCURVE",
+"145 -189 CURVE SMOOTH",
+"114 -189 OFFCURVE",
+"96 -209 OFFCURVE",
+"96 -246 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 282 OFFCURVE",
+"49 207 OFFCURVE",
+"49 155 CURVE SMOOTH",
+"49 106 OFFCURVE",
+"73 74 OFFCURVE",
+"122 34 CURVE SMOOTH",
+"149 12 LINE",
+"129 -19 OFFCURVE",
+"105 -55 OFFCURVE",
+"74 -87 CURVE",
+"121 -128 LINE",
+"196 -51 OFFCURVE",
+"279 44 OFFCURVE",
+"279 137 CURVE SMOOTH",
+"279 214 OFFCURVE",
+"235 282 OFFCURVE",
+"163 282 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 148, -327}";
+},
+{
+name = uni0716.loclSYRJ.Fina;
+}
+);
+layerId = UUID0;
+width = 283;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0716.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{260, 230}";
+},
+{
+name = RU;
+position = "{259, -116}";
+},
+{
+name = bottom;
+position = "{134, -247}";
+},
+{
+name = top;
+position = "{144, 315}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"4256 -162 LINE",
+"4309 -119 OFFCURVE",
+"4355 -63 OFFCURVE",
+"4378 3 CURVE",
+"4408 0 OFFCURVE",
+"4439 0 OFFCURVE",
+"4466 0 CURVE",
+"4466 76 LINE",
+"4417 76 OFFCURVE",
+"4394 84 OFFCURVE",
+"4365 127 CURVE SMOOTH",
+"4342 160 OFFCURVE",
+"4316 179 OFFCURVE",
+"4277 179 CURVE SMOOTH",
+"4232 179 OFFCURVE",
+"4198 142 OFFCURVE",
+"4198 101 CURVE SMOOTH",
+"4198 71 OFFCURVE",
+"4207 51 OFFCURVE",
+"4230 29 CURVE SMOOTH",
+"4248 12 OFFCURVE",
+"4268 -4 OFFCURVE",
+"4272 -21 CURVE",
+"4272 -42 OFFCURVE",
+"4245 -83 OFFCURVE",
+"4213 -116 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"4285 674 LINE",
+"4285 141 LINE SMOOTH",
+"4285 40 OFFCURVE",
+"4270 -29 OFFCURVE",
+"4250 -64 CURVE",
+"4310 -94 LINE",
+"4331 -67 OFFCURVE",
+"4344 -25 OFFCURVE",
+"4352 30 CURVE",
+"4354 30 LINE",
+"4373 9 OFFCURVE",
+"4405 0 OFFCURVE",
+"4456 0 CURVE",
+"4456 76 LINE",
+"4424 76 OFFCURVE",
+"4359 76 OFFCURVE",
+"4357 111 CURVE SMOOTH",
+"4357 122 OFFCURVE",
+"4358 131 OFFCURVE",
+"4358 142 CURVE SMOOTH",
+"4358 674 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"4377 90 OFFCURVE",
+"4360 132 OFFCURVE",
+"4351 152 CURVE SMOOTH",
+"4328 202 OFFCURVE",
+"4320 213 OFFCURVE",
+"4289 213 CURVE SMOOTH",
+"4260 213 OFFCURVE",
+"4251 200 OFFCURVE",
+"4239 182 CURVE SMOOTH",
+"4208 133 LINE SMOOTH",
+"4177 84 OFFCURVE",
+"4149 76 OFFCURVE",
+"4111 76 CURVE SMOOTH",
+"4090 76 OFFCURVE",
+"4072 61 OFFCURVE",
+"4072 38 CURVE SMOOTH",
+"4072 14 OFFCURVE",
+"4090 0 OFFCURVE",
+"4111 0 CURVE SMOOTH",
+"4179 0 OFFCURVE",
+"4238 22 OFFCURVE",
+"4277 69 CURVE",
+"4318 8 OFFCURVE",
+"4352 0 OFFCURVE",
+"4437 0 CURVE SMOOTH",
+"4466 0 LINE",
+"4466 76 LINE",
+"4425 76 OFFCURVE",
+"4396 80 OFFCURVE",
+"4386 83 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"3857 -155 LINE",
+"3894 -105 OFFCURVE",
+"3910 -62 OFFCURVE",
+"3933 4 CURVE",
+"3970 0 OFFCURVE",
+"4013 0 OFFCURVE",
+"4050 0 CURVE",
+"4050 76 LINE",
+"4001 76 OFFCURVE",
+"3968 78 OFFCURVE",
+"3952 83 CURVE",
+"3943 130 OFFCURVE",
+"3926 193 OFFCURVE",
+"3874 193 CURVE SMOOTH",
+"3855 193 OFFCURVE",
+"3839 185 OFFCURVE",
+"3822 160 CURVE SMOOTH",
+"3805 135 OFFCURVE",
+"3799 114 OFFCURVE",
+"3799 96 CURVE SMOOTH",
+"3799 55 OFFCURVE",
+"3812 36 OFFCURVE",
+"3866 7 CURVE",
+"3860 -26 OFFCURVE",
+"3838 -76 OFFCURVE",
+"3805 -127 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"3601 -155 LINE",
+"3632 -107 OFFCURVE",
+"3663 -48 OFFCURVE",
+"3677 4 CURVE",
+"3714 0 OFFCURVE",
+"3757 0 OFFCURVE",
+"3794 0 CURVE",
+"3794 76 LINE",
+"3745 76 OFFCURVE",
+"3705 78 OFFCURVE",
+"3689 83 CURVE",
+"3682 130 OFFCURVE",
+"3670 193 OFFCURVE",
+"3618 193 CURVE SMOOTH",
+"3599 193 OFFCURVE",
+"3583 185 OFFCURVE",
+"3566 160 CURVE SMOOTH",
+"3549 135 OFFCURVE",
+"3543 114 OFFCURVE",
+"3543 96 CURVE SMOOTH",
+"3543 55 OFFCURVE",
+"3570 28 OFFCURVE",
+"3612 15 CURVE",
+"3606 -18 OFFCURVE",
+"3582 -76 OFFCURVE",
+"3549 -127 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"3627 -137 LINE",
+"3659 -89 OFFCURVE",
+"3679 -48 OFFCURVE",
+"3692 4 CURVE",
+"3739 0 OFFCURVE",
+"3757 0 OFFCURVE",
+"3794 0 CURVE",
+"3794 76 LINE",
+"3745 76 OFFCURVE",
+"3718 78 OFFCURVE",
+"3702 83 CURVE",
+"3697 109 OFFCURVE",
+"3689 141 OFFCURVE",
+"3675 163 CURVE SMOOTH",
+"3664 182 OFFCURVE",
+"3650 191 OFFCURVE",
+"3625 191 CURVE SMOOTH",
+"3607 191 OFFCURVE",
+"3589 182 OFFCURVE",
+"3573 157 CURVE SMOOTH",
+"3556 132 OFFCURVE",
+"3551 111 OFFCURVE",
+"3551 93 CURVE SMOOTH",
+"3551 52 OFFCURVE",
+"3573 22 OFFCURVE",
+"3617 9 CURVE",
+"3612 -24 OFFCURVE",
+"3599 -65 OFFCURVE",
+"3573 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2472 -162 LINE",
+"2525 -119 OFFCURVE",
+"2571 -63 OFFCURVE",
+"2594 3 CURVE",
+"2624 0 OFFCURVE",
+"2655 0 OFFCURVE",
+"2682 0 CURVE",
+"2682 76 LINE",
+"2633 76 OFFCURVE",
+"2610 84 OFFCURVE",
+"2581 127 CURVE SMOOTH",
+"2558 160 OFFCURVE",
+"2532 179 OFFCURVE",
+"2493 179 CURVE SMOOTH",
+"2448 179 OFFCURVE",
+"2414 142 OFFCURVE",
+"2414 101 CURVE SMOOTH",
+"2414 71 OFFCURVE",
+"2423 51 OFFCURVE",
+"2446 29 CURVE SMOOTH",
+"2464 12 OFFCURVE",
+"2484 -4 OFFCURVE",
+"2488 -21 CURVE",
+"2488 -42 OFFCURVE",
+"2461 -83 OFFCURVE",
+"2429 -116 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"3070 -137 LINE",
+"3102 -89 OFFCURVE",
+"3122 -48 OFFCURVE",
+"3135 4 CURVE",
+"3182 0 OFFCURVE",
+"3200 0 OFFCURVE",
+"3237 0 CURVE",
+"3237 76 LINE",
+"3188 76 OFFCURVE",
+"3161 78 OFFCURVE",
+"3145 83 CURVE",
+"3140 109 OFFCURVE",
+"3131 141 OFFCURVE",
+"3117 163 CURVE SMOOTH",
+"3106 181 OFFCURVE",
+"3091 190 OFFCURVE",
+"3066 190 CURVE SMOOTH",
+"3048 190 OFFCURVE",
+"3030 182 OFFCURVE",
+"3013 157 CURVE SMOOTH",
+"2998 135 OFFCURVE",
+"2994 111 OFFCURVE",
+"2994 93 CURVE SMOOTH",
+"2994 52 OFFCURVE",
+"3018 23 OFFCURVE",
+"3063 8 CURVE",
+"3058 -25 OFFCURVE",
+"3042 -65 OFFCURVE",
+"3016 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"3052 -137 LINE",
+"3079 -93 OFFCURVE",
+"3106 -38 OFFCURVE",
+"3119 14 CURVE",
+"3166 2 OFFCURVE",
+"3200 0 OFFCURVE",
+"3237 0 CURVE",
+"3237 76 LINE",
+"3188 76 OFFCURVE",
+"3176 78 OFFCURVE",
+"3160 83 CURVE",
+"3146 89 OFFCURVE",
+"3136 111 OFFCURVE",
+"3114 149 CURVE SMOOTH",
+"3101 171 OFFCURVE",
+"3087 184 OFFCURVE",
+"3062 184 CURVE SMOOTH",
+"3024 184 OFFCURVE",
+"3004 147 OFFCURVE",
+"2982 63 CURVE",
+"3015 36 OFFCURVE",
+"3027 15 OFFCURVE",
+"3027 -11 CURVE SMOOTH",
+"3027 -37 OFFCURVE",
+"3016 -67 OFFCURVE",
+"2998 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2880 -137 LINE",
+"2907 -93 OFFCURVE",
+"2934 -38 OFFCURVE",
+"2947 14 CURVE",
+"2994 2 OFFCURVE",
+"3028 0 OFFCURVE",
+"3065 0 CURVE",
+"3065 76 LINE",
+"3016 76 OFFCURVE",
+"3004 78 OFFCURVE",
+"2988 83 CURVE",
+"2974 89 OFFCURVE",
+"2964 111 OFFCURVE",
+"2942 149 CURVE SMOOTH",
+"2929 171 OFFCURVE",
+"2915 184 OFFCURVE",
+"2890 184 CURVE SMOOTH",
+"2852 184 OFFCURVE",
+"2829 150 OFFCURVE",
+"2807 66 CURVE",
+"2840 39 OFFCURVE",
+"2855 15 OFFCURVE",
+"2855 -11 CURVE SMOOTH",
+"2855 -37 OFFCURVE",
+"2844 -67 OFFCURVE",
+"2826 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2144 -137 LINE",
+"2171 -93 OFFCURVE",
+"2197 -38 OFFCURVE",
+"2210 14 CURVE",
+"2257 2 OFFCURVE",
+"2291 0 OFFCURVE",
+"2328 0 CURVE",
+"2328 76 LINE",
+"2279 76 OFFCURVE",
+"2274 78 OFFCURVE",
+"2258 83 CURVE",
+"2244 89 OFFCURVE",
+"2236 92 OFFCURVE",
+"2208 148 CURVE SMOOTH",
+"2197 170 OFFCURVE",
+"2178 185 OFFCURVE",
+"2153 185 CURVE SMOOTH",
+"2127 185 OFFCURVE",
+"2108 170 OFFCURVE",
+"2092 134 CURVE SMOOTH",
+"2084 116 OFFCURVE",
+"2075 88 OFFCURVE",
+"2075 71 CURVE",
+"2108 44 OFFCURVE",
+"2124 15 OFFCURVE",
+"2124 -11 CURVE SMOOTH",
+"2124 -37 OFFCURVE",
+"2113 -67 OFFCURVE",
+"2095 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1788 -137 LINE",
+"1819 -92 OFFCURVE",
+"1848 -34 OFFCURVE",
+"1856 21 CURVE",
+"1884 5 OFFCURVE",
+"1925 0 OFFCURVE",
+"1938 0 CURVE",
+"1938 76 LINE",
+"1933 76 OFFCURVE",
+"1918 79 OFFCURVE",
+"1907 83 CURVE SMOOTH",
+"1886 91 OFFCURVE",
+"1880 99 OFFCURVE",
+"1853 145 CURVE SMOOTH",
+"1839 168 OFFCURVE",
+"1820 181 OFFCURVE",
+"1795 181 CURVE SMOOTH",
+"1750 181 OFFCURVE",
+"1726 133 OFFCURVE",
+"1724 85 CURVE",
+"1765 48 OFFCURVE",
+"1774 15 OFFCURVE",
+"1774 -11 CURVE SMOOTH",
+"1774 -37 OFFCURVE",
+"1762 -67 OFFCURVE",
+"1739 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1466 -137 LINE",
+"1497 -92 OFFCURVE",
+"1526 -34 OFFCURVE",
+"1534 21 CURVE",
+"1562 5 OFFCURVE",
+"1603 0 OFFCURVE",
+"1616 0 CURVE",
+"1616 76 LINE",
+"1611 76 OFFCURVE",
+"1596 79 OFFCURVE",
+"1585 83 CURVE SMOOTH",
+"1564 91 OFFCURVE",
+"1558 99 OFFCURVE",
+"1531 145 CURVE SMOOTH",
+"1517 168 OFFCURVE",
+"1498 181 OFFCURVE",
+"1473 181 CURVE SMOOTH",
+"1428 181 OFFCURVE",
+"1404 133 OFFCURVE",
+"1402 85 CURVE",
+"1443 48 OFFCURVE",
+"1452 15 OFFCURVE",
+"1452 -11 CURVE SMOOTH",
+"1452 -37 OFFCURVE",
+"1440 -67 OFFCURVE",
+"1417 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1466 -145 LINE",
+"1511 -100 OFFCURVE",
+"1539 -43 OFFCURVE",
+"1554 4 CURVE",
+"1583 1 OFFCURVE",
+"1653 0 OFFCURVE",
+"1680 0 CURVE SMOOTH",
+"1755 0 LINE",
+"1755 76 LINE",
+"1685 76 LINE SMOOTH",
+"1592 76 OFFCURVE",
+"1585 79 OFFCURVE",
+"1555 124 CURVE SMOOTH",
+"1530 162 OFFCURVE",
+"1510 178 OFFCURVE",
+"1472 178 CURVE SMOOTH",
+"1430 178 OFFCURVE",
+"1399 141 OFFCURVE",
+"1399 100 CURVE SMOOTH",
+"1399 48 OFFCURVE",
+"1438 26 OFFCURVE",
+"1479 9 CURVE",
+"1478 -13 OFFCURVE",
+"1453 -67 OFFCURVE",
+"1422 -109 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1111 -145 LINE",
+"1156 -100 OFFCURVE",
+"1184 -42 OFFCURVE",
+"1199 5 CURVE",
+"1221 2 OFFCURVE",
+"1245 0 OFFCURVE",
+"1261 0 CURVE",
+"1261 76 LINE",
+"1239 76 OFFCURVE",
+"1230 79 OFFCURVE",
+"1200 124 CURVE SMOOTH",
+"1175 162 OFFCURVE",
+"1155 178 OFFCURVE",
+"1117 178 CURVE SMOOTH",
+"1075 178 OFFCURVE",
+"1044 141 OFFCURVE",
+"1044 100 CURVE SMOOTH",
+"1044 48 OFFCURVE",
+"1083 27 OFFCURVE",
+"1124 10 CURVE",
+"1123 -12 OFFCURVE",
+"1098 -67 OFFCURVE",
+"1067 -109 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"827 -145 LINE",
+"872 -100 OFFCURVE",
+"900 -41 OFFCURVE",
+"915 6 CURVE",
+"939 3 OFFCURVE",
+"1014 0 OFFCURVE",
+"1041 0 CURVE SMOOTH",
+"1116 0 LINE",
+"1116 76 LINE",
+"1046 76 LINE SMOOTH",
+"1018 76 OFFCURVE",
+"941 78 OFFCURVE",
+"929 86 CURVE",
+"909 171 OFFCURVE",
+"872 192 OFFCURVE",
+"834 192 CURVE SMOOTH",
+"792 192 OFFCURVE",
+"761 153 OFFCURVE",
+"761 110 CURVE SMOOTH",
+"761 55 OFFCURVE",
+"799 30 OFFCURVE",
+"840 12 CURVE",
+"839 -11 OFFCURVE",
+"814 -67 OFFCURVE",
+"783 -109 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 135 OFFCURVE",
+"459 113 OFFCURVE",
+"459 82 CURVE SMOOTH",
+"459 76 OFFCURVE",
+"459 66 OFFCURVE",
+"457 55 CURVE",
+"426 57 OFFCURVE",
+"394 65 OFFCURVE",
+"394 100 CURVE SMOOTH",
+"394 121 OFFCURVE",
+"407 135 OFFCURVE",
+"424 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"375 192 OFFCURVE",
+"344 153 OFFCURVE",
+"344 110 CURVE SMOOTH",
+"344 55 OFFCURVE",
+"382 30 OFFCURVE",
+"423 12 CURVE",
+"422 -11 OFFCURVE",
+"397 -67 OFFCURVE",
+"366 -109 CURVE",
+"410 -145 LINE",
+"455 -100 OFFCURVE",
+"483 -41 OFFCURVE",
+"498 6 CURVE",
+"522 2 OFFCURVE",
+"551 0 OFFCURVE",
+"560 0 CURVE",
+"560 76 LINE",
+"551 76 OFFCURVE",
+"528 78 OFFCURVE",
+"512 84 CURVE",
+"510 95 OFFCURVE",
+"507 106 OFFCURVE",
+"504 115 CURVE SMOOTH",
+"484 176 OFFCURVE",
+"450 192 OFFCURVE",
+"417 192 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 198 OFFCURVE",
+"81 161 OFFCURVE",
+"76 118 CURVE SMOOTH",
+"70 63 OFFCURVE",
+"107 35 OFFCURVE",
+"146 14 CURVE",
+"144 -8 OFFCURVE",
+"115 -62 OFFCURVE",
+"81 -102 CURVE",
+"125 -139 LINE",
+"169 -101 OFFCURVE",
+"204 -40 OFFCURVE",
+"222 6 CURVE",
+"245 1 OFFCURVE",
+"274 0 OFFCURVE",
+"283 0 CURVE",
+"283 76 LINE",
+"274 76 OFFCURVE",
+"255 77 OFFCURVE",
+"241 83 CURVE",
+"239 95 OFFCURVE",
+"238 102 OFFCURVE",
+"236 112 CURVE SMOOTH",
+"224 173 OFFCURVE",
+"192 192 OFFCURVE",
+"159 195 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"115 203 OFFCURVE",
+"80 162 OFFCURVE",
+"80 114 CURVE SMOOTH",
+"80 68 OFFCURVE",
+"101 39 OFFCURVE",
+"146 14 CURVE",
+"141 -11 OFFCURVE",
+"115 -62 OFFCURVE",
+"81 -102 CURVE",
+"125 -139 LINE",
+"167 -99 OFFCURVE",
+"202 -41 OFFCURVE",
+"221 4 CURVE",
+"244 1 OFFCURVE",
+"274 0 OFFCURVE",
+"283 0 CURVE",
+"283 76 LINE",
+"274 76 OFFCURVE",
+"255 77 OFFCURVE",
+"241 83 CURVE",
+"242 96 OFFCURVE",
+"242 111 OFFCURVE",
+"240 121 CURVE SMOOTH",
+"232 170 OFFCURVE",
+"205 203 OFFCURVE",
+"159 203 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"81 162 OFFCURVE",
+"81 114 CURVE SMOOTH",
+"81 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"271 0 OFFCURVE",
+"280 0 CURVE",
+"280 76 LINE",
+"271 76 OFFCURVE",
+"251 77 OFFCURVE",
+"237 83 CURVE",
+"238 92 OFFCURVE",
+"238 96 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+}
+);
+width = 280;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072F.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{282, 241}";
+},
+{
+name = RU;
+position = "{280, -112}";
+},
+{
+name = bottom;
+position = "{182, -393}";
+},
+{
+name = top;
+position = "{157, 316}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, -1, -169}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 77, -333}";
+},
+{
+name = uni0716.loclSYRJ.Fina;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = UUID0;
+width = 346;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0725.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{415, -98}";
+},
+{
+name = top;
+position = "{317, 525}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"477 -17 OFFCURVE",
+"510 39 OFFCURVE",
+"520 82 CURVE",
+"522 82 LINE",
+"565 33 OFFCURVE",
+"603 0 OFFCURVE",
+"659 0 CURVE",
+"659 76 LINE",
+"638 76 OFFCURVE",
+"620 87 OFFCURVE",
+"600 109 CURVE SMOOTH",
+"314 436 LINE",
+"257 384 LINE",
+"457 156 LINE",
+"464 148 OFFCURVE",
+"469 136 OFFCURVE",
+"469 123 CURVE SMOOTH",
+"469 90 OFFCURVE",
+"440 59 OFFCURVE",
+"394 59 CURVE SMOOTH",
+"357 59 OFFCURVE",
+"329 88 OFFCURVE",
+"298 124 CURVE SMOOTH",
+"57 397 LINE",
+"0 346 LINE",
+"232 82 LINE SMOOTH",
+"296 9 OFFCURVE",
+"339 -17 OFFCURVE",
+"390 -17 CURVE SMOOTH"
+);
+}
+);
+width = 659;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074F.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{324, -98}";
+},
+{
+name = top;
+position = "{323, 584}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"425 0 LINE",
+"504 0 OFFCURVE",
+"542 14 OFFCURVE",
+"558 43 CURVE",
+"584 16 OFFCURVE",
+"616 0 OFFCURVE",
+"659 0 CURVE",
+"659 76 LINE",
+"629 76 OFFCURVE",
+"608 98 OFFCURVE",
+"593 123 CURVE",
+"524 229 LINE",
+"526 231 LINE",
+"576 233 OFFCURVE",
+"616 269 OFFCURVE",
+"616 327 CURVE SMOOTH",
+"616 388 OFFCURVE",
+"574 421 OFFCURVE",
+"520 421 CURVE SMOOTH",
+"482 421 OFFCURVE",
+"453 405 OFFCURVE",
+"437 372 CURVE",
+"433 372 LINE",
+"351 500 LINE",
+"287 458 LINE",
+"516 100 LINE",
+"504 76 OFFCURVE",
+"456 76 OFFCURVE",
+"436 76 CURVE SMOOTH",
+"291 76 LINE SMOOTH",
+"167 76 OFFCURVE",
+"127 101 OFFCURVE",
+"125 182 CURVE",
+"61 178 LINE",
+"59 172 OFFCURVE",
+"59 156 OFFCURVE",
+"59 152 CURVE SMOOTH",
+"59 37 OFFCURVE",
+"134 0 OFFCURVE",
+"287 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 293 OFFCURVE",
+"548 274 OFFCURVE",
+"520 274 CURVE SMOOTH",
+"492 274 OFFCURVE",
+"471 293 OFFCURVE",
+"471 326 CURVE SMOOTH",
+"471 358 OFFCURVE",
+"490 377 OFFCURVE",
+"520 377 CURVE SMOOTH",
+"547 377 OFFCURVE",
+"568 358 OFFCURVE",
+"568 326 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"425 0 LINE",
+"504 0 OFFCURVE",
+"542 14 OFFCURVE",
+"558 43 CURVE",
+"584 16 OFFCURVE",
+"616 0 OFFCURVE",
+"659 0 CURVE",
+"659 76 LINE",
+"629 76 OFFCURVE",
+"608 98 OFFCURVE",
+"593 123 CURVE",
+"524 229 LINE",
+"526 231 LINE",
+"576 233 OFFCURVE",
+"616 269 OFFCURVE",
+"616 327 CURVE SMOOTH",
+"616 388 OFFCURVE",
+"574 421 OFFCURVE",
+"520 421 CURVE SMOOTH",
+"482 421 OFFCURVE",
+"453 405 OFFCURVE",
+"437 372 CURVE",
+"433 372 LINE",
+"351 500 LINE",
+"287 458 LINE",
+"516 100 LINE",
+"504 76 OFFCURVE",
+"456 76 OFFCURVE",
+"436 76 CURVE SMOOTH",
+"294 76 LINE SMOOTH",
+"170 76 OFFCURVE",
+"127 101 OFFCURVE",
+"125 182 CURVE",
+"61 178 LINE",
+"59 172 OFFCURVE",
+"59 163 OFFCURVE",
+"59 159 CURVE SMOOTH",
+"59 44 OFFCURVE",
+"133 0 OFFCURVE",
+"280 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 293 OFFCURVE",
+"548 274 OFFCURVE",
+"520 274 CURVE SMOOTH",
+"492 274 OFFCURVE",
+"471 293 OFFCURVE",
+"471 326 CURVE SMOOTH",
+"471 358 OFFCURVE",
+"490 377 OFFCURVE",
+"520 377 CURVE SMOOTH",
+"547 377 OFFCURVE",
+"568 358 OFFCURVE",
+"568 326 CURVE SMOOTH"
+);
+}
+);
+width = 659;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0713.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{507, 161}";
+},
+{
+name = RU;
+position = "{693, -477}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{391, 357}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"523 -328 LINE SMOOTH",
+"584 -373 OFFCURVE",
+"634 -391 OFFCURVE",
+"683 -391 CURVE SMOOTH",
+"794 -391 OFFCURVE",
+"843 -319 OFFCURVE",
+"843 -259 CURVE SMOOTH",
+"843 -220 OFFCURVE",
+"828 -189 OFFCURVE",
+"787 -159 CURVE SMOOTH",
+"645 -53 LINE SMOOTH",
+"629 -41 OFFCURVE",
+"567 1 OFFCURVE",
+"556 7 CURVE",
+"556 10 LINE",
+"586 5 OFFCURVE",
+"626 0 OFFCURVE",
+"642 0 CURVE SMOOTH",
+"647 0 LINE",
+"647 76 LINE",
+"473 76 LINE",
+"389 139 LINE",
+"344 76 LINE",
+"744 -220 LINE SMOOTH",
+"759 -231 OFFCURVE",
+"767 -244 OFFCURVE",
+"767 -259 CURVE SMOOTH",
+"767 -292 OFFCURVE",
+"731 -315 OFFCURVE",
+"685 -315 CURVE SMOOTH",
+"642 -315 OFFCURVE",
+"610 -296 OFFCURVE",
+"580 -273 CURVE SMOOTH",
+"214 0 LINE",
+"157 42 OFFCURVE",
+"132 85 OFFCURVE",
+"132 138 CURVE SMOOTH",
+"132 161 OFFCURVE",
+"137 178 OFFCURVE",
+"147 199 CURVE",
+"91 234 LINE",
+"70 207 OFFCURVE",
+"59 169 OFFCURVE",
+"59 130 CURVE SMOOTH",
+"59 60 OFFCURVE",
+"93 -5 OFFCURVE",
+"165 -60 CURVE"
+);
+}
+);
+width = 647;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0714.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{508, 161}";
+},
+{
+name = RU;
+position = "{693, -478}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{391, 357}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 210, 39}";
+},
+{
+name = uni0713.loclSYRJ.Fina;
+}
+);
+layerId = UUID0;
+width = 647;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072E.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{548, 392}";
+},
+{
+name = RU;
+position = "{693, -477}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{227, 402}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"647 76 LINE",
+"614 76 LINE SMOOTH",
+"587 76 OFFCURVE",
+"522 74 OFFCURVE",
+"496 72 CURVE",
+"496 79 LINE",
+"551 90 OFFCURVE",
+"593 132 OFFCURVE",
+"593 193 CURVE SMOOTH",
+"593 250 OFFCURVE",
+"547 284 OFFCURVE",
+"491 327 CURVE SMOOTH",
+"440 365 LINE",
+"396 306 LINE",
+"448 267 LINE SMOOTH",
+"492 233 OFFCURVE",
+"518 215 OFFCURVE",
+"518 185 CURVE SMOOTH",
+"518 138 OFFCURVE",
+"473 124 OFFCURVE",
+"438 124 CURVE SMOOTH",
+"422 124 OFFCURVE",
+"406 127 OFFCURVE",
+"386 142 CURVE SMOOTH",
+"366 156 LINE",
+"321 93 LINE",
+"744 -220 LINE SMOOTH",
+"759 -231 OFFCURVE",
+"767 -244 OFFCURVE",
+"767 -259 CURVE SMOOTH",
+"767 -292 OFFCURVE",
+"731 -315 OFFCURVE",
+"685 -315 CURVE SMOOTH",
+"642 -315 OFFCURVE",
+"610 -296 OFFCURVE",
+"580 -273 CURVE SMOOTH",
+"214 0 LINE",
+"157 42 OFFCURVE",
+"132 85 OFFCURVE",
+"132 138 CURVE SMOOTH",
+"132 161 OFFCURVE",
+"137 178 OFFCURVE",
+"147 199 CURVE",
+"91 234 LINE",
+"70 207 OFFCURVE",
+"59 169 OFFCURVE",
+"59 130 CURVE SMOOTH",
+"59 60 OFFCURVE",
+"92 -5 OFFCURVE",
+"165 -60 CURVE SMOOTH",
+"523 -328 LINE SMOOTH",
+"584 -373 OFFCURVE",
+"634 -391 OFFCURVE",
+"683 -391 CURVE SMOOTH",
+"794 -391 OFFCURVE",
+"843 -319 OFFCURVE",
+"843 -259 CURVE SMOOTH",
+"843 -220 OFFCURVE",
+"828 -189 OFFCURVE",
+"787 -159 CURVE SMOOTH",
+"645 -53 LINE SMOOTH",
+"629 -41 OFFCURVE",
+"567 1 OFFCURVE",
+"556 7 CURVE",
+"556 11 LINE",
+"580 5 OFFCURVE",
+"625 0 OFFCURVE",
+"642 0 CURVE SMOOTH",
+"647 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"647 76 LINE",
+"614 76 LINE SMOOTH",
+"590 76 OFFCURVE",
+"535 75 OFFCURVE",
+"505 73 CURVE",
+"496 72 LINE",
+"496 79 LINE",
+"504 81 LINE SMOOTH",
+"556 94 OFFCURVE",
+"593 135 OFFCURVE",
+"593 193 CURVE SMOOTH",
+"593 250 OFFCURVE",
+"548 285 OFFCURVE",
+"491 327 CURVE SMOOTH",
+"440 365 LINE",
+"396 306 LINE",
+"448 267 LINE SMOOTH",
+"494 233 OFFCURVE",
+"518 214 OFFCURVE",
+"518 185 CURVE SMOOTH",
+"518 138 OFFCURVE",
+"473 124 OFFCURVE",
+"438 124 CURVE SMOOTH",
+"422 124 OFFCURVE",
+"406 127 OFFCURVE",
+"386 142 CURVE SMOOTH",
+"366 156 LINE",
+"321 93 LINE",
+"744 -220 LINE SMOOTH",
+"759 -231 OFFCURVE",
+"767 -244 OFFCURVE",
+"767 -259 CURVE SMOOTH",
+"767 -292 OFFCURVE",
+"731 -315 OFFCURVE",
+"685 -315 CURVE SMOOTH",
+"642 -315 OFFCURVE",
+"610 -296 OFFCURVE",
+"580 -273 CURVE SMOOTH",
+"214 0 LINE",
+"157 42 OFFCURVE",
+"132 85 OFFCURVE",
+"132 138 CURVE SMOOTH",
+"132 161 OFFCURVE",
+"137 178 OFFCURVE",
+"147 199 CURVE",
+"91 234 LINE",
+"70 207 OFFCURVE",
+"59 169 OFFCURVE",
+"59 130 CURVE SMOOTH",
+"59 60 OFFCURVE",
+"92 -5 OFFCURVE",
+"165 -60 CURVE SMOOTH",
+"523 -328 LINE SMOOTH",
+"584 -373 OFFCURVE",
+"634 -391 OFFCURVE",
+"683 -391 CURVE SMOOTH",
+"794 -391 OFFCURVE",
+"843 -319 OFFCURVE",
+"843 -259 CURVE SMOOTH",
+"843 -220 OFFCURVE",
+"828 -189 OFFCURVE",
+"787 -159 CURVE SMOOTH",
+"645 -53 LINE SMOOTH",
+"629 -41 OFFCURVE",
+"567 1 OFFCURVE",
+"556 7 CURVE",
+"556 11 LINE",
+"580 5 OFFCURVE",
+"625 0 OFFCURVE",
+"642 0 CURVE SMOOTH",
+"647 0 LINE"
+);
+}
+);
+width = 647;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0717.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{334, -98}";
+},
+{
+name = top;
+position = "{342, 506}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"139 417 OFFCURVE",
+"45 337 OFFCURVE",
+"45 211 CURVE SMOOTH",
+"45 87 OFFCURVE",
+"132 0 OFFCURVE",
+"260 0 CURVE SMOOTH",
+"372 0 OFFCURVE",
+"456 62 OFFCURVE",
+"477 158 CURVE",
+"508 195 OFFCURVE",
+"544 244 OFFCURVE",
+"562 279 CURVE",
+"566 280 LINE",
+"570 266 OFFCURVE",
+"575 229 OFFCURVE",
+"575 189 CURVE SMOOTH",
+"575 121 OFFCURVE",
+"564 43 OFFCURVE",
+"556 4 CURVE",
+"620 -7 LINE",
+"624 8 OFFCURVE",
+"628 23 OFFCURVE",
+"631 39 CURVE",
+"634 39 LINE",
+"652 15 OFFCURVE",
+"683 0 OFFCURVE",
+"742 0 CURVE",
+"742 76 LINE",
+"711 76 OFFCURVE",
+"645 81 OFFCURVE",
+"641 113 CURVE",
+"643 141 OFFCURVE",
+"644 169 OFFCURVE",
+"644 201 CURVE SMOOTH",
+"644 261 OFFCURVE",
+"630 346 OFFCURVE",
+"606 399 CURVE",
+"549 387 LINE",
+"527 344 OFFCURVE",
+"501 295 OFFCURVE",
+"475 260 CURVE",
+"472 260 LINE",
+"449 354 OFFCURVE",
+"366 417 OFFCURVE",
+"251 417 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 76 OFFCURVE",
+"117 137 OFFCURVE",
+"117 216 CURVE SMOOTH",
+"117 294 OFFCURVE",
+"178 344 OFFCURVE",
+"251 344 CURVE SMOOTH",
+"348 344 OFFCURVE",
+"409 286 OFFCURVE",
+"409 208 CURVE SMOOTH",
+"409 119 OFFCURVE",
+"343 76 OFFCURVE",
+"270 76 CURVE SMOOTH"
+);
+}
+);
+width = 742;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071A.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{398, -98}";
+},
+{
+name = top;
+position = "{526, 366}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"2372 -4 LINE",
+"2335 -4 OFFCURVE",
+"2313 2 OFFCURVE",
+"2304 6 CURVE",
+"2296 16 OFFCURVE",
+"2285 45 OFFCURVE",
+"2275 73 CURVE SMOOTH",
+"2251 136 OFFCURVE",
+"2241 161 OFFCURVE",
+"2208 161 CURVE SMOOTH",
+"2173 161 OFFCURVE",
+"2163 142 OFFCURVE",
+"2133 70 CURVE SMOOTH",
+"2117 29 OFFCURVE",
+"2102 9 OFFCURVE",
+"2089 9 CURVE SMOOTH",
+"2087 9 LINE SMOOTH",
+"2074 9 OFFCURVE",
+"2066 33 OFFCURVE",
+"2055 67 CURVE SMOOTH",
+"2035 128 OFFCURVE",
+"2023 161 OFFCURVE",
+"1987 161 CURVE SMOOTH",
+"1962 161 OFFCURVE",
+"1949 148 OFFCURVE",
+"1940 128 CURVE SMOOTH",
+"1919 84 OFFCURVE",
+"1904 47 OFFCURVE",
+"1886 24 CURVE SMOOTH",
+"1863 -3 OFFCURVE",
+"1829 -12 OFFCURVE",
+"1801 -12 CURVE SMOOTH",
+"1713 -12 OFFCURVE",
+"1686 52 OFFCURVE",
+"1684 133 CURVE",
+"1620 129 LINE",
+"1618 123 OFFCURVE",
+"1618 107 OFFCURVE",
+"1618 103 CURVE SMOOTH",
+"1618 -12 OFFCURVE",
+"1671 -87 OFFCURVE",
+"1802 -87 CURVE SMOOTH",
+"1848 -87 OFFCURVE",
+"1910 -80 OFFCURVE",
+"1971 -32 CURVE",
+"2007 -70 OFFCURVE",
+"2049 -80 OFFCURVE",
+"2081 -80 CURVE SMOOTH",
+"2120 -80 OFFCURVE",
+"2161 -69 OFFCURVE",
+"2199 -32 CURVE",
+"2233 -66 OFFCURVE",
+"2273 -80 OFFCURVE",
+"2372 -80 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1801 -80 LINE",
+"1869 -80 OFFCURVE",
+"1922 -60 OFFCURVE",
+"1966 -10 CURVE",
+"2009 -64 OFFCURVE",
+"2039 -80 OFFCURVE",
+"2073 -80 CURVE SMOOTH",
+"2115 -80 OFFCURVE",
+"2143 -64 OFFCURVE",
+"2182 -10 CURVE",
+"2222 -63 OFFCURVE",
+"2252 -80 OFFCURVE",
+"2337 -80 CURVE SMOOTH",
+"2372 -80 LINE",
+"2372 -4 LINE",
+"2331 -4 OFFCURVE",
+"2303 0 OFFCURVE",
+"2293 2 CURVE",
+"2284 9 OFFCURVE",
+"2259 49 OFFCURVE",
+"2248 69 CURVE SMOOTH",
+"2221 116 OFFCURVE",
+"2212 123 OFFCURVE",
+"2188 123 CURVE SMOOTH",
+"2167 123 OFFCURVE",
+"2155 111 OFFCURVE",
+"2144 92 CURVE SMOOTH",
+"2121 51 LINE SMOOTH",
+"2103 20 OFFCURVE",
+"2094 5 OFFCURVE",
+"2085 2 CURVE",
+"2076 2 LINE",
+"2067 7 OFFCURVE",
+"2058 19 OFFCURVE",
+"2028 69 CURVE SMOOTH",
+"2000 115 OFFCURVE",
+"1990 123 OFFCURVE",
+"1968 123 CURVE SMOOTH",
+"1947 123 OFFCURVE",
+"1938 115 OFFCURVE",
+"1926 97 CURVE SMOOTH",
+"1899 56 LINE SMOOTH",
+"1869 11 OFFCURVE",
+"1839 -4 OFFCURVE",
+"1801 -4 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1727 -11 OFFCURVE",
+"1700 52 OFFCURVE",
+"1698 133 CURVE",
+"1634 129 LINE",
+"1632 123 OFFCURVE",
+"1632 107 OFFCURVE",
+"1632 103 CURVE SMOOTH",
+"1632 -12 OFFCURVE",
+"1685 -87 OFFCURVE",
+"1816 -87 CURVE SMOOTH",
+"1884 -87 OFFCURVE",
+"1937 -60 OFFCURVE",
+"1981 -10 CURVE",
+"2024 -64 OFFCURVE",
+"2054 -80 OFFCURVE",
+"2088 -80 CURVE SMOOTH",
+"2130 -80 OFFCURVE",
+"2158 -64 OFFCURVE",
+"2197 -10 CURVE",
+"2237 -63 OFFCURVE",
+"2267 -80 OFFCURVE",
+"2352 -80 CURVE SMOOTH",
+"2397 -80 LINE",
+"2397 -4 LINE",
+"2356 -4 OFFCURVE",
+"2318 0 OFFCURVE",
+"2308 2 CURVE",
+"2299 9 OFFCURVE",
+"2274 49 OFFCURVE",
+"2263 69 CURVE SMOOTH",
+"2236 116 OFFCURVE",
+"2227 124 OFFCURVE",
+"2203 124 CURVE SMOOTH",
+"2182 124 OFFCURVE",
+"2170 111 OFFCURVE",
+"2159 92 CURVE SMOOTH",
+"2136 51 LINE SMOOTH",
+"2118 20 OFFCURVE",
+"2109 5 OFFCURVE",
+"2100 2 CURVE",
+"2091 2 LINE",
+"2082 7 OFFCURVE",
+"2073 19 OFFCURVE",
+"2043 69 CURVE SMOOTH",
+"2015 115 OFFCURVE",
+"2005 124 OFFCURVE",
+"1983 124 CURVE SMOOTH",
+"1962 124 OFFCURVE",
+"1952 115 OFFCURVE",
+"1940 97 CURVE SMOOTH",
+"1913 56 LINE SMOOTH",
+"1883 11 OFFCURVE",
+"1854 -11 OFFCURVE",
+"1815 -11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1128 204 OFFCURVE",
+"1118 195 OFFCURVE",
+"1106 177 CURVE SMOOTH",
+"1079 136 LINE SMOOTH",
+"1049 91 OFFCURVE",
+"1024 69 OFFCURVE",
+"975 69 CURVE SMOOTH",
+"893 69 OFFCURVE",
+"866 122 OFFCURVE",
+"864 203 CURVE",
+"800 199 LINE",
+"798 193 OFFCURVE",
+"798 177 OFFCURVE",
+"798 173 CURVE SMOOTH",
+"798 58 OFFCURVE",
+"860 -7 OFFCURVE",
+"982 -7 CURVE SMOOTH",
+"1050 -7 OFFCURVE",
+"1103 20 OFFCURVE",
+"1147 70 CURVE",
+"1190 16 OFFCURVE",
+"1219 0 OFFCURVE",
+"1276 0 CURVE SMOOTH",
+"1329 0 OFFCURVE",
+"1379 23 OFFCURVE",
+"1408 60 CURVE SMOOTH",
+"1425 82 OFFCURVE",
+"1435 108 OFFCURVE",
+"1435 138 CURVE SMOOTH",
+"1435 176 OFFCURVE",
+"1423 210 OFFCURVE",
+"1392 210 CURVE SMOOTH",
+"1373 210 OFFCURVE",
+"1360 200 OFFCURVE",
+"1346 174 CURVE SMOOTH",
+"1333 150 OFFCURVE",
+"1300 90 OFFCURVE",
+"1286 77 CURVE",
+"1260 77 LINE",
+"1251 82 OFFCURVE",
+"1239 99 OFFCURVE",
+"1209 149 CURVE SMOOTH",
+"1181 195 OFFCURVE",
+"1171 204 OFFCURVE",
+"1149 204 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1128 204 OFFCURVE",
+"1118 195 OFFCURVE",
+"1106 177 CURVE SMOOTH",
+"1079 136 LINE SMOOTH",
+"1049 91 OFFCURVE",
+"1024 69 OFFCURVE",
+"975 69 CURVE SMOOTH",
+"893 69 OFFCURVE",
+"866 122 OFFCURVE",
+"864 203 CURVE",
+"800 199 LINE",
+"798 193 OFFCURVE",
+"798 177 OFFCURVE",
+"798 173 CURVE SMOOTH",
+"798 58 OFFCURVE",
+"860 -7 OFFCURVE",
+"982 -7 CURVE SMOOTH",
+"1050 -7 OFFCURVE",
+"1103 20 OFFCURVE",
+"1147 70 CURVE",
+"1190 16 OFFCURVE",
+"1219 0 OFFCURVE",
+"1276 0 CURVE SMOOTH",
+"1329 0 OFFCURVE",
+"1379 23 OFFCURVE",
+"1408 60 CURVE SMOOTH",
+"1425 82 OFFCURVE",
+"1435 108 OFFCURVE",
+"1435 138 CURVE SMOOTH",
+"1435 176 OFFCURVE",
+"1423 210 OFFCURVE",
+"1392 210 CURVE SMOOTH",
+"1373 210 OFFCURVE",
+"1360 200 OFFCURVE",
+"1346 174 CURVE SMOOTH",
+"1333 150 OFFCURVE",
+"1300 90 OFFCURVE",
+"1286 77 CURVE",
+"1260 77 LINE",
+"1251 82 OFFCURVE",
+"1239 99 OFFCURVE",
+"1209 149 CURVE SMOOTH",
+"1181 195 OFFCURVE",
+"1171 204 OFFCURVE",
+"1149 204 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 0 OFFCURVE",
+"572 10 OFFCURVE",
+"600 41 CURVE SMOOTH",
+"608 49 OFFCURVE",
+"616 59 OFFCURVE",
+"624 70 CURVE",
+"664 17 OFFCURVE",
+"694 0 OFFCURVE",
+"779 0 CURVE SMOOTH",
+"784 0 LINE",
+"784 76 LINE",
+"774 76 OFFCURVE",
+"745 78 OFFCURVE",
+"735 82 CURVE",
+"726 89 OFFCURVE",
+"701 129 OFFCURVE",
+"690 149 CURVE SMOOTH",
+"663 196 OFFCURVE",
+"654 203 OFFCURVE",
+"630 203 CURVE SMOOTH",
+"609 203 OFFCURVE",
+"597 191 OFFCURVE",
+"586 172 CURVE SMOOTH",
+"563 131 LINE SMOOTH",
+"545 100 OFFCURVE",
+"534 82 OFFCURVE",
+"525 82 CURVE SMOOTH",
+"519 82 LINE SMOOTH",
+"508 82 OFFCURVE",
+"501 92 OFFCURVE",
+"468 147 CURVE SMOOTH",
+"440 193 OFFCURVE",
+"432 203 OFFCURVE",
+"410 203 CURVE SMOOTH",
+"389 203 OFFCURVE",
+"381 195 OFFCURVE",
+"368 177 CURVE SMOOTH",
+"339 137 LINE SMOOTH",
+"324 117 OFFCURVE",
+"310 100 OFFCURVE",
+"293 91 CURVE SMOOTH",
+"274 80 OFFCURVE",
+"253 76 OFFCURVE",
+"233 76 CURVE SMOOTH",
+"212 76 OFFCURVE",
+"194 61 OFFCURVE",
+"194 38 CURVE SMOOTH",
+"194 14 OFFCURVE",
+"212 0 OFFCURVE",
+"233 0 CURVE SMOOTH",
+"263 0 OFFCURVE",
+"292 4 OFFCURVE",
+"318 12 CURVE SMOOTH",
+"341 19 OFFCURVE",
+"361 30 OFFCURVE",
+"380 44 CURVE SMOOTH",
+"390 52 OFFCURVE",
+"399 60 OFFCURVE",
+"408 70 CURVE",
+"450 10 OFFCURVE",
+"481 0 OFFCURVE",
+"515 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 0 OFFCURVE",
+"572 10 OFFCURVE",
+"600 41 CURVE SMOOTH",
+"608 49 OFFCURVE",
+"616 59 OFFCURVE",
+"624 70 CURVE",
+"664 17 OFFCURVE",
+"694 0 OFFCURVE",
+"779 0 CURVE SMOOTH",
+"784 0 LINE",
+"784 76 LINE",
+"774 76 OFFCURVE",
+"745 78 OFFCURVE",
+"735 82 CURVE",
+"726 89 OFFCURVE",
+"701 129 OFFCURVE",
+"690 149 CURVE SMOOTH",
+"663 196 OFFCURVE",
+"654 203 OFFCURVE",
+"630 203 CURVE SMOOTH",
+"609 203 OFFCURVE",
+"597 191 OFFCURVE",
+"586 172 CURVE SMOOTH",
+"563 131 LINE SMOOTH",
+"545 100 OFFCURVE",
+"534 82 OFFCURVE",
+"525 82 CURVE SMOOTH",
+"519 82 LINE SMOOTH",
+"508 82 OFFCURVE",
+"501 92 OFFCURVE",
+"468 147 CURVE SMOOTH",
+"440 193 OFFCURVE",
+"432 203 OFFCURVE",
+"410 203 CURVE SMOOTH",
+"389 203 OFFCURVE",
+"381 195 OFFCURVE",
+"368 177 CURVE SMOOTH",
+"339 137 LINE SMOOTH",
+"324 117 OFFCURVE",
+"310 100 OFFCURVE",
+"293 91 CURVE SMOOTH",
+"274 80 OFFCURVE",
+"253 76 OFFCURVE",
+"233 76 CURVE SMOOTH",
+"212 76 OFFCURVE",
+"194 61 OFFCURVE",
+"194 38 CURVE SMOOTH",
+"194 14 OFFCURVE",
+"212 0 OFFCURVE",
+"233 0 CURVE SMOOTH",
+"263 0 OFFCURVE",
+"292 4 OFFCURVE",
+"318 12 CURVE SMOOTH",
+"341 19 OFFCURVE",
+"361 30 OFFCURVE",
+"380 44 CURVE SMOOTH",
+"390 52 OFFCURVE",
+"399 60 OFFCURVE",
+"408 70 CURVE",
+"450 10 OFFCURVE",
+"481 0 OFFCURVE",
+"515 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"154 69 OFFCURVE",
+"127 122 OFFCURVE",
+"125 203 CURVE",
+"61 199 LINE",
+"59 193 OFFCURVE",
+"59 177 OFFCURVE",
+"59 173 CURVE SMOOTH",
+"59 58 OFFCURVE",
+"121 -7 OFFCURVE",
+"243 -7 CURVE SMOOTH",
+"311 -7 OFFCURVE",
+"364 20 OFFCURVE",
+"408 70 CURVE",
+"451 16 OFFCURVE",
+"481 0 OFFCURVE",
+"515 0 CURVE SMOOTH",
+"547 0 OFFCURVE",
+"571 9 OFFCURVE",
+"598 38 CURVE SMOOTH",
+"606 47 OFFCURVE",
+"615 58 OFFCURVE",
+"624 70 CURVE",
+"664 17 OFFCURVE",
+"694 0 OFFCURVE",
+"779 0 CURVE SMOOTH",
+"784 0 LINE",
+"784 76 LINE",
+"774 76 OFFCURVE",
+"745 78 OFFCURVE",
+"735 82 CURVE",
+"726 89 OFFCURVE",
+"701 129 OFFCURVE",
+"690 149 CURVE SMOOTH",
+"663 196 OFFCURVE",
+"654 203 OFFCURVE",
+"630 203 CURVE SMOOTH",
+"609 203 OFFCURVE",
+"597 191 OFFCURVE",
+"586 172 CURVE SMOOTH",
+"563 131 LINE SMOOTH",
+"545 100 OFFCURVE",
+"534 82 OFFCURVE",
+"525 82 CURVE SMOOTH",
+"519 82 LINE SMOOTH",
+"508 82 OFFCURVE",
+"501 92 OFFCURVE",
+"468 147 CURVE SMOOTH",
+"440 193 OFFCURVE",
+"432 203 OFFCURVE",
+"410 203 CURVE SMOOTH",
+"389 203 OFFCURVE",
+"380 195 OFFCURVE",
+"368 177 CURVE SMOOTH",
+"340 136 LINE SMOOTH",
+"310 91 OFFCURVE",
+"285 69 OFFCURVE",
+"236 69 CURVE SMOOTH"
+);
+}
+);
+width = 784;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071F.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{500, 279}";
+},
+{
+name = RU;
+position = "{494, -65}";
+},
+{
+name = bottom;
+position = "{392, -243}";
+},
+{
+name = top;
+position = "{262, 377}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1278 -137 LINE",
+"1305 -93 OFFCURVE",
+"1331 -38 OFFCURVE",
+"1344 14 CURVE",
+"1391 2 OFFCURVE",
+"1425 0 OFFCURVE",
+"1462 0 CURVE",
+"1462 76 LINE",
+"1413 76 OFFCURVE",
+"1408 78 OFFCURVE",
+"1392 83 CURVE",
+"1378 89 OFFCURVE",
+"1370 92 OFFCURVE",
+"1342 148 CURVE SMOOTH",
+"1331 170 OFFCURVE",
+"1312 185 OFFCURVE",
+"1287 185 CURVE SMOOTH",
+"1261 185 OFFCURVE",
+"1242 170 OFFCURVE",
+"1226 134 CURVE SMOOTH",
+"1218 116 OFFCURVE",
+"1209 88 OFFCURVE",
+"1209 71 CURVE",
+"1242 44 OFFCURVE",
+"1258 15 OFFCURVE",
+"1258 -11 CURVE SMOOTH",
+"1258 -37 OFFCURVE",
+"1247 -67 OFFCURVE",
+"1229 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1278 -137 LINE",
+"1305 -93 OFFCURVE",
+"1331 -38 OFFCURVE",
+"1344 14 CURVE",
+"1391 2 OFFCURVE",
+"1425 0 OFFCURVE",
+"1462 0 CURVE",
+"1462 76 LINE",
+"1413 76 OFFCURVE",
+"1408 78 OFFCURVE",
+"1392 83 CURVE",
+"1378 89 OFFCURVE",
+"1370 92 OFFCURVE",
+"1342 148 CURVE SMOOTH",
+"1331 170 OFFCURVE",
+"1312 185 OFFCURVE",
+"1287 185 CURVE SMOOTH",
+"1261 185 OFFCURVE",
+"1242 170 OFFCURVE",
+"1226 134 CURVE SMOOTH",
+"1218 116 OFFCURVE",
+"1209 88 OFFCURVE",
+"1209 71 CURVE",
+"1242 44 OFFCURVE",
+"1258 15 OFFCURVE",
+"1258 -11 CURVE SMOOTH",
+"1258 -37 OFFCURVE",
+"1247 -67 OFFCURVE",
+"1229 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 204 LINE",
+"520 199 OFFCURVE",
+"519 187 OFFCURVE",
+"519 183 CURVE SMOOTH",
+"519 76 OFFCURVE",
+"607 9 OFFCURVE",
+"734 1 CURVE",
+"542 -369 LINE",
+"609 -399 LINE",
+"816 0 LINE",
+"875 8 OFFCURVE",
+"926 30 OFFCURVE",
+"926 114 CURVE SMOOTH",
+"926 162 OFFCURVE",
+"910 203 OFFCURVE",
+"871 203 CURVE SMOOTH",
+"835 203 OFFCURVE",
+"816 169 OFFCURVE",
+"778 96 CURVE SMOOTH",
+"766 73 LINE",
+"761 73 LINE SMOOTH",
+"663 73 OFFCURVE",
+"590 120 OFFCURVE",
+"586 208 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 204 LINE",
+"520 199 OFFCURVE",
+"519 187 OFFCURVE",
+"519 183 CURVE SMOOTH",
+"519 76 OFFCURVE",
+"610 8 OFFCURVE",
+"733 -1 CURVE",
+"542 -369 LINE",
+"609 -399 LINE",
+"816 0 LINE",
+"1039 0 LINE",
+"1039 76 LINE",
+"930 76 LINE",
+"926 127 OFFCURVE",
+"919 185 OFFCURVE",
+"863 185 CURVE SMOOTH",
+"824 185 OFFCURVE",
+"799 140 OFFCURVE",
+"770 81 CURVE SMOOTH",
+"766 73 LINE",
+"760 73 LINE SMOOTH",
+"657 73 OFFCURVE",
+"590 120 OFFCURVE",
+"586 208 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"61 204 LINE",
+"60 199 OFFCURVE",
+"59 187 OFFCURVE",
+"59 183 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"150 8 OFFCURVE",
+"273 -1 CURVE",
+"82 -369 LINE",
+"143 -399 LINE",
+"353 0 LINE",
+"579 0 LINE",
+"579 76 LINE",
+"462 76 LINE",
+"464 85 OFFCURVE",
+"466 100 OFFCURVE",
+"466 114 CURVE SMOOTH",
+"466 162 OFFCURVE",
+"450 203 OFFCURVE",
+"411 203 CURVE SMOOTH",
+"375 203 OFFCURVE",
+"356 169 OFFCURVE",
+"318 96 CURVE SMOOTH",
+"306 73 LINE",
+"300 73 LINE SMOOTH",
+"197 73 OFFCURVE",
+"130 120 OFFCURVE",
+"126 208 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"61 194 LINE",
+"60 189 OFFCURVE",
+"59 177 OFFCURVE",
+"59 173 CURVE SMOOTH",
+"59 66 OFFCURVE",
+"150 8 OFFCURVE",
+"273 -1 CURVE",
+"82 -369 LINE",
+"143 -399 LINE",
+"353 0 LINE",
+"549 0 LINE",
+"549 76 LINE",
+"460 76 LINE",
+"463 85 OFFCURVE",
+"466 104 OFFCURVE",
+"466 118 CURVE SMOOTH",
+"466 161 OFFCURVE",
+"450 203 OFFCURVE",
+"411 203 CURVE SMOOTH",
+"375 203 OFFCURVE",
+"356 169 OFFCURVE",
+"318 96 CURVE SMOOTH",
+"306 73 LINE",
+"300 73 LINE SMOOTH",
+"197 73 OFFCURVE",
+"130 110 OFFCURVE",
+"126 198 CURVE"
+);
+}
+);
+width = 549;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074E.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{411, -98}";
+},
+{
+name = top;
+position = "{361, 667}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"531 613 LINE",
+"601 584 LINE SMOOTH",
+"652 563 OFFCURVE",
+"669 538 OFFCURVE",
+"669 508 CURVE SMOOTH",
+"669 470 OFFCURVE",
+"642 454 OFFCURVE",
+"612 450 CURVE",
+"573 471 OFFCURVE",
+"522 486 OFFCURVE",
+"458 486 CURVE",
+"444 416 LINE",
+"472 414 LINE SMOOTH",
+"572 404 OFFCURVE",
+"697 339 OFFCURVE",
+"697 195 CURVE SMOOTH",
+"697 83 OFFCURVE",
+"613 76 OFFCURVE",
+"523 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"851 0 LINE",
+"851 76 LINE",
+"789 76 LINE SMOOTH",
+"774 76 OFFCURVE",
+"757 76 OFFCURVE",
+"739 75 CURVE",
+"739 78 LINE",
+"758 105 OFFCURVE",
+"769 141 OFFCURVE",
+"769 188 CURVE SMOOTH",
+"769 290 OFFCURVE",
+"729 359 OFFCURVE",
+"669 406 CURVE",
+"669 409 LINE",
+"718 427 OFFCURVE",
+"745 469 OFFCURVE",
+"745 521 CURVE SMOOTH",
+"745 581 OFFCURVE",
+"696 623 OFFCURVE",
+"631 649 CURVE SMOOTH",
+"561 678 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"531 613 LINE",
+"601 584 LINE SMOOTH",
+"652 563 OFFCURVE",
+"669 538 OFFCURVE",
+"669 508 CURVE SMOOTH",
+"669 470 OFFCURVE",
+"642 454 OFFCURVE",
+"612 450 CURVE",
+"573 471 OFFCURVE",
+"522 486 OFFCURVE",
+"458 486 CURVE",
+"444 416 LINE",
+"472 414 LINE SMOOTH",
+"572 404 OFFCURVE",
+"697 339 OFFCURVE",
+"697 195 CURVE SMOOTH",
+"697 83 OFFCURVE",
+"613 76 OFFCURVE",
+"523 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"851 0 LINE",
+"851 76 LINE",
+"789 76 LINE SMOOTH",
+"774 76 OFFCURVE",
+"757 76 OFFCURVE",
+"739 75 CURVE",
+"739 78 LINE",
+"758 105 OFFCURVE",
+"769 141 OFFCURVE",
+"769 188 CURVE SMOOTH",
+"769 290 OFFCURVE",
+"729 359 OFFCURVE",
+"669 406 CURVE",
+"669 409 LINE",
+"718 427 OFFCURVE",
+"745 469 OFFCURVE",
+"745 521 CURVE SMOOTH",
+"745 581 OFFCURVE",
+"696 623 OFFCURVE",
+"631 649 CURVE SMOOTH",
+"561 678 LINE"
+);
+}
+);
+width = 851;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{423, -98}";
+},
+{
+name = top;
+position = "{126, 736}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"511 -17 OFFCURVE",
+"548 40 OFFCURVE",
+"557 82 CURVE",
+"560 82 LINE",
+"603 29 OFFCURVE",
+"643 0 OFFCURVE",
+"696 0 CURVE",
+"696 76 LINE",
+"675 76 OFFCURVE",
+"656 87 OFFCURVE",
+"637 109 CURVE SMOOTH",
+"125 693 LINE",
+"68 642 LINE",
+"493 158 LINE SMOOTH",
+"500 149 OFFCURVE",
+"505 137 OFFCURVE",
+"505 123 CURVE SMOOTH",
+"505 90 OFFCURVE",
+"477 59 OFFCURVE",
+"431 59 CURVE SMOOTH",
+"390 59 OFFCURVE",
+"361 88 OFFCURVE",
+"330 124 CURVE SMOOTH",
+"-136 654 LINE",
+"-193 603 LINE",
+"264 82 LINE SMOOTH",
+"328 9 OFFCURVE",
+"376 -17 OFFCURVE",
+"427 -17 CURVE SMOOTH"
+);
+}
+);
+width = 696;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0721.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{423, -98}";
+},
+{
+name = top;
+position = "{352, 519}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"634 76 LINE",
+"612 76 OFFCURVE",
+"561 74 OFFCURVE",
+"542 72 CURVE",
+"542 77 LINE",
+"576 108 OFFCURVE",
+"595 152 OFFCURVE",
+"595 209 CURVE SMOOTH",
+"595 330 OFFCURVE",
+"517 422 OFFCURVE",
+"375 422 CURVE SMOOTH",
+"292 422 OFFCURVE",
+"215 380 OFFCURVE",
+"189 301 CURVE",
+"184 301 LINE",
+"155 375 OFFCURVE",
+"121 433 OFFCURVE",
+"109 448 CURVE",
+"49 406 LINE",
+"127 264 OFFCURVE",
+"172 158 OFFCURVE",
+"172 -22 CURVE SMOOTH",
+"172 -176 OFFCURVE",
+"130 -310 OFFCURVE",
+"101 -381 CURVE",
+"171 -399 LINE",
+"221 -288 OFFCURVE",
+"243 -171 OFFCURVE",
+"243 -55 CURVE SMOOTH",
+"243 -7 OFFCURVE",
+"237 35 OFFCURVE",
+"229 69 CURVE",
+"234 71 LINE",
+"271 24 OFFCURVE",
+"328 0 OFFCURVE",
+"422 0 CURVE SMOOTH",
+"658 0 LINE",
+"658 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"277 74 OFFCURVE",
+"222 165 OFFCURVE",
+"222 224 CURVE SMOOTH",
+"222 296 OFFCURVE",
+"287 349 OFFCURVE",
+"375 349 CURVE SMOOTH",
+"472 349 OFFCURVE",
+"521 294 OFFCURVE",
+"521 210 CURVE SMOOTH",
+"521 116 OFFCURVE",
+"459 74 OFFCURVE",
+"383 74 CURVE SMOOTH"
+);
+}
+);
+width = 658;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{186, -412}";
+},
+{
+name = top;
+position = "{188, 268}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"2969 0 LINE",
+"2969 76 LINE",
+"2865 76 LINE SMOOTH",
+"2826 76 OFFCURVE",
+"2811 51 OFFCURVE",
+"2811 -4 CURVE SMOOTH",
+"2811 -123 OFFCURVE",
+"2887 -274 OFFCURVE",
+"3016 -399 CURVE",
+"3074 -353 LINE",
+"2927 -195 OFFCURVE",
+"2887 -76 OFFCURVE",
+"2887 -8 CURVE SMOOTH",
+"2887 -6 OFFCURVE",
+"2887 -2 OFFCURVE",
+"2888 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"3067 -361 LINE",
+"2933 -177 OFFCURVE",
+"2820 -6 OFFCURVE",
+"2734 159 CURVE",
+"2669 121 LINE",
+"2728 -18 OFFCURVE",
+"2923 -295 OFFCURVE",
+"3005 -399 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2752 -137 LINE",
+"2779 -93 OFFCURVE",
+"2806 -38 OFFCURVE",
+"2819 14 CURVE",
+"2866 2 OFFCURVE",
+"2900 0 OFFCURVE",
+"2937 0 CURVE SMOOTH",
+"2977 0 LINE",
+"2977 76 LINE",
+"2937 76 LINE SMOOTH",
+"2888 76 OFFCURVE",
+"2876 78 OFFCURVE",
+"2860 83 CURVE",
+"2846 89 OFFCURVE",
+"2836 111 OFFCURVE",
+"2814 149 CURVE SMOOTH",
+"2801 171 OFFCURVE",
+"2787 184 OFFCURVE",
+"2762 184 CURVE SMOOTH",
+"2724 184 OFFCURVE",
+"2704 147 OFFCURVE",
+"2682 63 CURVE",
+"2715 36 OFFCURVE",
+"2727 15 OFFCURVE",
+"2727 -11 CURVE SMOOTH",
+"2727 -37 OFFCURVE",
+"2716 -67 OFFCURVE",
+"2698 -111 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2734 159 LINE",
+"2820 -6 OFFCURVE",
+"2933 -177 OFFCURVE",
+"3067 -361 CURVE",
+"3005 -399 LINE",
+"2923 -295 OFFCURVE",
+"2746 -41 OFFCURVE",
+"2687 82 CURVE",
+"2706 147 OFFCURVE",
+"2724 184 OFFCURVE",
+"2762 184 CURVE SMOOTH",
+"2787 184 OFFCURVE",
+"2801 171 OFFCURVE",
+"2814 149 CURVE SMOOTH",
+"2836 111 OFFCURVE",
+"2846 89 OFFCURVE",
+"2860 83 CURVE",
+"2876 78 OFFCURVE",
+"2888 76 OFFCURVE",
+"2937 76 CURVE SMOOTH",
+"2977 76 LINE",
+"2977 0 LINE",
+"2937 0 LINE SMOOTH",
+"2900 0 OFFCURVE",
+"2866 2 OFFCURVE",
+"2819 14 CURVE",
+"2806 6 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2446 12 LINE",
+"2498 -76 OFFCURVE",
+"2608 -243 OFFCURVE",
+"2697 -361 CURVE",
+"2635 -399 LINE",
+"2553 -295 OFFCURVE",
+"2375 -38 OFFCURVE",
+"2325 67 CURVE",
+"2341 122 OFFCURVE",
+"2356 153 OFFCURVE",
+"2389 153 CURVE SMOOTH",
+"2410 153 OFFCURVE",
+"2421 142 OFFCURVE",
+"2435 125 CURVE SMOOTH",
+"2461 93 OFFCURVE",
+"2466 86 OFFCURVE",
+"2473 83 CURVE SMOOTH",
+"2489 78 OFFCURVE",
+"2518 76 OFFCURVE",
+"2567 76 CURVE SMOOTH",
+"2607 76 LINE",
+"2607 0 LINE",
+"2567 0 LINE SMOOTH",
+"2530 0 OFFCURVE",
+"2476 3 OFFCURVE",
+"2449 14 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2441 -5 LINE",
+"2493 -93 OFFCURVE",
+"2603 -260 OFFCURVE",
+"2692 -378 CURVE",
+"2630 -416 LINE",
+"2548 -312 OFFCURVE",
+"2370 -55 OFFCURVE",
+"2320 50 CURVE",
+"2338 126 OFFCURVE",
+"2356 152 OFFCURVE",
+"2389 152 CURVE SMOOTH",
+"2410 152 OFFCURVE",
+"2423 142 OFFCURVE",
+"2437 125 CURVE SMOOTH",
+"2463 93 OFFCURVE",
+"2468 86 OFFCURVE",
+"2475 83 CURVE SMOOTH",
+"2491 78 OFFCURVE",
+"2518 76 OFFCURVE",
+"2567 76 CURVE SMOOTH",
+"2607 76 LINE",
+"2607 0 LINE",
+"2567 0 LINE SMOOTH",
+"2530 0 OFFCURVE",
+"2476 3 OFFCURVE",
+"2449 14 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2117 10 LINE",
+"2169 -78 OFFCURVE",
+"2289 -260 OFFCURVE",
+"2378 -378 CURVE",
+"2319 -416 LINE",
+"2237 -312 OFFCURVE",
+"2056 -52 OFFCURVE",
+"2006 53 CURVE",
+"2012 72 OFFCURVE",
+"2017 88 OFFCURVE",
+"2022 101 CURVE SMOOTH",
+"2038 139 OFFCURVE",
+"2053 152 OFFCURVE",
+"2078 152 CURVE SMOOTH",
+"2099 152 OFFCURVE",
+"2112 142 OFFCURVE",
+"2126 125 CURVE SMOOTH",
+"2152 93 OFFCURVE",
+"2155 86 OFFCURVE",
+"2162 83 CURVE SMOOTH",
+"2178 78 OFFCURVE",
+"2205 76 OFFCURVE",
+"2254 76 CURVE SMOOTH",
+"2294 76 LINE",
+"2294 0 LINE",
+"2225 0 LINE SMOOTH",
+"2181 0 OFFCURVE",
+"2151 4 OFFCURVE",
+"2123 18 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1659 10 LINE",
+"1711 -78 OFFCURVE",
+"1831 -260 OFFCURVE",
+"1920 -378 CURVE",
+"1861 -416 LINE",
+"1779 -312 OFFCURVE",
+"1602 -56 OFFCURVE",
+"1552 49 CURVE",
+"1555 69 OFFCURVE",
+"1560 88 OFFCURVE",
+"1565 101 CURVE SMOOTH",
+"1578 139 OFFCURVE",
+"1595 153 OFFCURVE",
+"1620 153 CURVE SMOOTH",
+"1641 153 OFFCURVE",
+"1654 142 OFFCURVE",
+"1668 125 CURVE SMOOTH",
+"1694 93 OFFCURVE",
+"1697 86 OFFCURVE",
+"1704 83 CURVE SMOOTH",
+"1720 78 OFFCURVE",
+"1747 76 OFFCURVE",
+"1796 76 CURVE SMOOTH",
+"1836 76 LINE",
+"1836 0 LINE",
+"1767 0 LINE SMOOTH",
+"1723 0 OFFCURVE",
+"1693 4 OFFCURVE",
+"1665 18 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1590 -378 LINE",
+"1501 -260 OFFCURVE",
+"1381 -78 OFFCURVE",
+"1329 10 CURVE",
+"1333 18 LINE",
+"1361 4 OFFCURVE",
+"1391 0 OFFCURVE",
+"1435 0 CURVE SMOOTH",
+"1504 0 LINE",
+"1504 76 LINE",
+"1464 76 LINE SMOOTH",
+"1415 76 OFFCURVE",
+"1394 79 OFFCURVE",
+"1378 84 CURVE SMOOTH",
+"1371 87 OFFCURVE",
+"1362 95 OFFCURVE",
+"1334 125 CURVE SMOOTH",
+"1315 145 OFFCURVE",
+"1304 154 OFFCURVE",
+"1280 154 CURVE SMOOTH",
+"1245 154 OFFCURVE",
+"1220 107 OFFCURVE",
+"1220 69 CURVE SMOOTH",
+"1220 53 OFFCURVE",
+"1226 31 OFFCURVE",
+"1243 1 CURVE SMOOTH",
+"1302 -101 OFFCURVE",
+"1449 -312 OFFCURVE",
+"1531 -416 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"932 -367 LINE",
+"829 -251 OFFCURVE",
+"686 -53 OFFCURVE",
+"636 14 CURVE",
+"640 19 LINE",
+"652 18 OFFCURVE",
+"671 0 OFFCURVE",
+"700 0 CURVE SMOOTH",
+"828 0 LINE",
+"828 185 LINE",
+"743 185 LINE SMOOTH",
+"722 185 OFFCURVE",
+"690 185 OFFCURVE",
+"667 189 CURVE",
+"651 197 OFFCURVE",
+"642 203 OFFCURVE",
+"612 227 CURVE SMOOTH",
+"585 249 OFFCURVE",
+"564 254 OFFCURVE",
+"532 254 CURVE SMOOTH",
+"460 254 OFFCURVE",
+"427 185 OFFCURVE",
+"427 105 CURVE SMOOTH",
+"427 58 OFFCURVE",
+"449 -6 OFFCURVE",
+"483 -52 CURVE",
+"564 -178 OFFCURVE",
+"719 -362 OFFCURVE",
+"810 -455 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"892 -367 LINE",
+"803 -249 OFFCURVE",
+"683 -66 OFFCURVE",
+"631 22 CURVE",
+"638 26 LINE",
+"666 4 OFFCURVE",
+"716 0 OFFCURVE",
+"765 0 CURVE SMOOTH",
+"774 0 LINE",
+"774 76 LINE",
+"764 76 LINE SMOOTH",
+"715 76 OFFCURVE",
+"708 77 OFFCURVE",
+"692 83 CURVE SMOOTH",
+"685 86 OFFCURVE",
+"670 93 OFFCURVE",
+"642 120 CURVE SMOOTH",
+"622 140 OFFCURVE",
+"610 144 OFFCURVE",
+"591 144 CURVE SMOOTH",
+"556 144 OFFCURVE",
+"541 106 OFFCURVE",
+"541 68 CURVE SMOOTH",
+"541 52 OFFCURVE",
+"546 17 OFFCURVE",
+"563 -13 CURVE SMOOTH",
+"622 -115 OFFCURVE",
+"751 -301 OFFCURVE",
+"833 -405 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 -367 LINE",
+"305 -249 OFFCURVE",
+"170 -66 OFFCURVE",
+"109 22 CURVE",
+"116 26 LINE",
+"144 4 OFFCURVE",
+"194 0 OFFCURVE",
+"243 0 CURVE SMOOTH",
+"252 0 LINE",
+"252 76 LINE",
+"242 76 LINE SMOOTH",
+"193 76 OFFCURVE",
+"186 77 OFFCURVE",
+"170 83 CURVE SMOOTH",
+"163 86 OFFCURVE",
+"148 92 OFFCURVE",
+"120 119 CURVE SMOOTH",
+"100 139 OFFCURVE",
+"88 143 OFFCURVE",
+"69 143 CURVE SMOOTH",
+"35 143 OFFCURVE",
+"20 108 OFFCURVE",
+"20 70 CURVE SMOOTH",
+"20 45 OFFCURVE",
+"32 7 OFFCURVE",
+"52 -23 CURVE SMOOTH",
+"121 -125 OFFCURVE",
+"258 -301 OFFCURVE",
+"351 -405 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"406 -367 LINE",
+"305 -249 OFFCURVE",
+"168 -63 OFFCURVE",
+"107 25 CURVE",
+"114 29 LINE",
+"145 4 OFFCURVE",
+"194 0 OFFCURVE",
+"243 0 CURVE SMOOTH",
+"252 0 LINE",
+"252 76 LINE",
+"242 76 LINE",
+"193 76 OFFCURVE",
+"186 77 OFFCURVE",
+"170 83 CURVE SMOOTH",
+"163 86 OFFCURVE",
+"148 92 OFFCURVE",
+"120 119 CURVE SMOOTH",
+"100 139 OFFCURVE",
+"88 143 OFFCURVE",
+"69 143 CURVE SMOOTH",
+"35 143 OFFCURVE",
+"20 108 OFFCURVE",
+"20 70 CURVE SMOOTH",
+"20 45 OFFCURVE",
+"32 7 OFFCURVE",
+"52 -23 CURVE SMOOTH",
+"121 -125 OFFCURVE",
+"258 -301 OFFCURVE",
+"351 -405 CURVE"
+);
+}
+);
+width = 252;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0726.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{743, 547}";
+},
+{
+name = RU;
+position = "{700, -104}";
+},
+{
+name = bottom;
+position = "{416, -98}";
+},
+{
+name = top;
+position = "{501, 633}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"851 0 LINE",
+"851 76 LINE",
+"780 76 LINE SMOOTH",
+"761 76 OFFCURVE",
+"736 76 OFFCURVE",
+"712 74 CURVE",
+"711 78 LINE",
+"750 108 OFFCURVE",
+"769 157 OFFCURVE",
+"769 217 CURVE SMOOTH",
+"769 401 OFFCURVE",
+"632 533 OFFCURVE",
+"503 533 CURVE SMOOTH",
+"397 533 OFFCURVE",
+"303 464 OFFCURVE",
+"303 349 CURVE SMOOTH",
+"303 229 OFFCURVE",
+"400 187 OFFCURVE",
+"500 187 CURVE SMOOTH",
+"567 187 OFFCURVE",
+"642 215 OFFCURVE",
+"690 264 CURVE",
+"693 264 LINE",
+"696 248 OFFCURVE",
+"697 231 OFFCURVE",
+"697 214 CURVE SMOOTH",
+"697 103 OFFCURVE",
+"613 76 OFFCURVE",
+"523 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"422 260 OFFCURVE",
+"376 293 OFFCURVE",
+"376 356 CURVE SMOOTH",
+"376 416 OFFCURVE",
+"431 457 OFFCURVE",
+"503 457 CURVE SMOOTH",
+"572 457 OFFCURVE",
+"637 410 OFFCURVE",
+"672 333 CURVE",
+"631 285 OFFCURVE",
+"562 260 OFFCURVE",
+"502 260 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"851 0 LINE",
+"851 76 LINE",
+"780 76 LINE SMOOTH",
+"761 76 OFFCURVE",
+"736 76 OFFCURVE",
+"712 74 CURVE",
+"711 78 LINE",
+"750 108 OFFCURVE",
+"769 157 OFFCURVE",
+"769 217 CURVE SMOOTH",
+"769 401 OFFCURVE",
+"632 533 OFFCURVE",
+"503 533 CURVE SMOOTH",
+"397 533 OFFCURVE",
+"303 464 OFFCURVE",
+"303 349 CURVE SMOOTH",
+"303 229 OFFCURVE",
+"400 187 OFFCURVE",
+"500 187 CURVE SMOOTH",
+"567 187 OFFCURVE",
+"642 215 OFFCURVE",
+"690 264 CURVE",
+"693 264 LINE",
+"696 248 OFFCURVE",
+"697 231 OFFCURVE",
+"697 214 CURVE SMOOTH",
+"697 103 OFFCURVE",
+"613 76 OFFCURVE",
+"523 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"183 76 OFFCURVE",
+"125 137 OFFCURVE",
+"125 216 CURVE SMOOTH",
+"125 220 LINE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"422 260 OFFCURVE",
+"376 293 OFFCURVE",
+"376 356 CURVE SMOOTH",
+"376 416 OFFCURVE",
+"431 457 OFFCURVE",
+"503 457 CURVE SMOOTH",
+"572 457 OFFCURVE",
+"637 410 OFFCURVE",
+"672 333 CURVE",
+"631 285 OFFCURVE",
+"562 260 OFFCURVE",
+"502 260 CURVE SMOOTH"
+);
+}
+);
+width = 851;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0729.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{438, -98}";
+},
+{
+name = top;
+position = "{565, 515}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"436 417 OFFCURVE",
+"336 341 OFFCURVE",
+"336 214 CURVE SMOOTH",
+"336 158 OFFCURVE",
+"354 115 OFFCURVE",
+"395 78 CURVE",
+"395 74 LINE",
+"374 76 OFFCURVE",
+"350 76 OFFCURVE",
+"334 76 CURVE SMOOTH",
+"287 76 LINE SMOOTH",
+"173 76 OFFCURVE",
+"127 125 OFFCURVE",
+"127 198 CURVE SMOOTH",
+"127 206 LINE",
+"61 202 LINE",
+"60 196 OFFCURVE",
+"59 175 OFFCURVE",
+"59 171 CURVE SMOOTH",
+"59 62 OFFCURVE",
+"142 0 OFFCURVE",
+"278 0 CURVE SMOOTH",
+"846 0 LINE",
+"846 76 LINE",
+"814 76 LINE SMOOTH",
+"791 76 OFFCURVE",
+"751 75 OFFCURVE",
+"729 74 CURVE",
+"729 77 LINE",
+"759 106 OFFCURVE",
+"783 158 OFFCURVE",
+"783 210 CURVE SMOOTH",
+"783 331 OFFCURVE",
+"691 417 OFFCURVE",
+"549 417 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 76 OFFCURVE",
+"409 138 OFFCURVE",
+"409 218 CURVE SMOOTH",
+"409 296 OFFCURVE",
+"473 344 OFFCURVE",
+"549 344 CURVE SMOOTH",
+"646 344 OFFCURVE",
+"710 286 OFFCURVE",
+"710 207 CURVE SMOOTH",
+"710 119 OFFCURVE",
+"644 76 OFFCURVE",
+"569 76 CURVE SMOOTH"
+);
+}
+);
+width = 846;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0727.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{508, -98}";
+},
+{
+name = top;
+position = "{563, 622}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"851 76 LINE",
+"713 76 LINE SMOOTH",
+"562 76 OFFCURVE",
+"395 77 OFFCURVE",
+"395 259 CURVE SMOOTH",
+"395 369 OFFCURVE",
+"484 442 OFFCURVE",
+"574 442 CURVE SMOOTH",
+"666 442 OFFCURVE",
+"714 401 OFFCURVE",
+"714 340 CURVE SMOOTH",
+"714 290 OFFCURVE",
+"679 260 OFFCURVE",
+"626 260 CURVE SMOOTH",
+"593 260 OFFCURVE",
+"556 279 OFFCURVE",
+"551 324 CURVE",
+"491 317 LINE",
+"491 243 OFFCURVE",
+"551 194 OFFCURVE",
+"629 194 CURVE SMOOTH",
+"726 194 OFFCURVE",
+"785 262 OFFCURVE",
+"785 342 CURVE SMOOTH",
+"785 436 OFFCURVE",
+"706 518 OFFCURVE",
+"571 518 CURVE SMOOTH",
+"442 518 OFFCURVE",
+"321 401 OFFCURVE",
+"321 253 CURVE SMOOTH",
+"321 164 OFFCURVE",
+"351 110 OFFCURVE",
+"405 77 CURVE",
+"404 74 LINE",
+"381 75 OFFCURVE",
+"357 76 OFFCURVE",
+"336 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"851 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"851 76 LINE",
+"713 76 LINE SMOOTH",
+"562 76 OFFCURVE",
+"395 77 OFFCURVE",
+"395 259 CURVE SMOOTH",
+"395 369 OFFCURVE",
+"484 442 OFFCURVE",
+"574 442 CURVE SMOOTH",
+"666 442 OFFCURVE",
+"714 401 OFFCURVE",
+"714 340 CURVE SMOOTH",
+"714 290 OFFCURVE",
+"679 260 OFFCURVE",
+"626 260 CURVE SMOOTH",
+"593 260 OFFCURVE",
+"556 279 OFFCURVE",
+"551 324 CURVE",
+"491 317 LINE",
+"491 243 OFFCURVE",
+"551 194 OFFCURVE",
+"629 194 CURVE SMOOTH",
+"726 194 OFFCURVE",
+"785 262 OFFCURVE",
+"785 342 CURVE SMOOTH",
+"785 436 OFFCURVE",
+"706 518 OFFCURVE",
+"571 518 CURVE SMOOTH",
+"442 518 OFFCURVE",
+"321 401 OFFCURVE",
+"321 253 CURVE SMOOTH",
+"321 164 OFFCURVE",
+"351 110 OFFCURVE",
+"405 77 CURVE",
+"404 74 LINE",
+"381 75 OFFCURVE",
+"357 76 OFFCURVE",
+"336 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"851 0 LINE"
+);
+}
+);
+width = 851;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072A.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{283, 401}";
+},
+{
+name = RU;
+position = "{258, -113}";
+},
+{
+name = bottom;
+position = "{133, -247}";
+},
+{
+name = top;
+position = "{157, 450}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 164, 286}";
+},
+{
+name = uni0716.loclSYRJ.Fina;
+}
+);
+layerId = UUID0;
+width = 283;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0728.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{37, -443}";
+},
+{
+name = top;
+position = "{127, 365}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"741 195 LINE",
+"760 167 OFFCURVE",
+"765 140 OFFCURVE",
+"765 116 CURVE SMOOTH",
+"765 46 OFFCURVE",
+"712 13 OFFCURVE",
+"712 -63 CURVE SMOOTH",
+"712 -87 OFFCURVE",
+"721 -112 OFFCURVE",
+"733 -134 CURVE SMOOTH",
+"747 -160 OFFCURVE",
+"774 -210 OFFCURVE",
+"774 -248 CURVE SMOOTH",
+"774 -281 OFFCURVE",
+"755 -308 OFFCURVE",
+"692 -308 CURVE SMOOTH",
+"624 -308 OFFCURVE",
+"541 -268 OFFCURVE",
+"491 -231 CURVE",
+"452 -284 LINE",
+"517 -343 OFFCURVE",
+"615 -381 OFFCURVE",
+"689 -381 CURVE SMOOTH",
+"785 -381 OFFCURVE",
+"846 -333 OFFCURVE",
+"846 -249 CURVE SMOOTH",
+"846 -210 OFFCURVE",
+"832 -171 OFFCURVE",
+"815 -135 CURVE SMOOTH",
+"796 -96 OFFCURVE",
+"785 -74 OFFCURVE",
+"785 -51 CURVE SMOOTH",
+"785 -21 OFFCURVE",
+"802 18 OFFCURVE",
+"816 42 CURVE",
+"820 42 LINE",
+"842 5 OFFCURVE",
+"878 0 OFFCURVE",
+"901 0 CURVE",
+"901 76 LINE",
+"882 76 OFFCURVE",
+"855 87 OFFCURVE",
+"837 115 CURVE",
+"837 119 OFFCURVE",
+"838 123 OFFCURVE",
+"838 127 CURVE SMOOTH",
+"838 160 OFFCURVE",
+"829 195 OFFCURVE",
+"803 231 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"316 195 LINE",
+"335 167 OFFCURVE",
+"340 140 OFFCURVE",
+"340 116 CURVE SMOOTH",
+"340 85 OFFCURVE",
+"329 60 OFFCURVE",
+"316 34 CURVE SMOOTH",
+"302 6 OFFCURVE",
+"287 -23 OFFCURVE",
+"287 -63 CURVE SMOOTH",
+"287 -87 OFFCURVE",
+"296 -112 OFFCURVE",
+"308 -134 CURVE SMOOTH",
+"322 -160 OFFCURVE",
+"349 -210 OFFCURVE",
+"349 -248 CURVE SMOOTH",
+"349 -281 OFFCURVE",
+"330 -308 OFFCURVE",
+"267 -308 CURVE SMOOTH",
+"199 -308 OFFCURVE",
+"116 -268 OFFCURVE",
+"66 -231 CURVE",
+"27 -284 LINE",
+"92 -343 OFFCURVE",
+"190 -381 OFFCURVE",
+"264 -381 CURVE SMOOTH",
+"360 -381 OFFCURVE",
+"421 -333 OFFCURVE",
+"421 -249 CURVE SMOOTH",
+"421 -210 OFFCURVE",
+"407 -171 OFFCURVE",
+"390 -135 CURVE SMOOTH",
+"371 -96 OFFCURVE",
+"360 -74 OFFCURVE",
+"360 -51 CURVE SMOOTH",
+"360 -34 OFFCURVE",
+"366 -14 OFFCURVE",
+"373 5 CURVE SMOOTH",
+"379 19 OFFCURVE",
+"383 27 OFFCURVE",
+"389 38 CURVE",
+"393 38 LINE",
+"407 14 OFFCURVE",
+"439 0 OFFCURVE",
+"476 0 CURVE",
+"476 76 LINE",
+"454 76 OFFCURVE",
+"419 83 OFFCURVE",
+"411 110 CURVE",
+"412 114 OFFCURVE",
+"413 123 OFFCURVE",
+"413 127 CURVE SMOOTH",
+"413 160 OFFCURVE",
+"404 195 OFFCURVE",
+"378 231 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"395 38 LINE",
+"399 38 LINE",
+"413 14 OFFCURVE",
+"445 0 OFFCURVE",
+"482 0 CURVE",
+"482 76 LINE",
+"460 76 OFFCURVE",
+"423 83 OFFCURVE",
+"417 113 CURVE",
+"417 143 OFFCURVE",
+"411 182 OFFCURVE",
+"387 216 CURVE",
+"324 179 LINE",
+"341 146 OFFCURVE",
+"344 126 OFFCURVE",
+"344 102 CURVE SMOOTH",
+"344 80 OFFCURVE",
+"334 52 OFFCURVE",
+"323 27 CURVE SMOOTH",
+"306 -12 OFFCURVE",
+"298 -34 OFFCURVE",
+"298 -73 CURVE SMOOTH",
+"298 -97 OFFCURVE",
+"306 -127 OFFCURVE",
+"320 -156 CURVE SMOOTH",
+"345 -208 OFFCURVE",
+"349 -227 OFFCURVE",
+"349 -247 CURVE SMOOTH",
+"349 -280 OFFCURVE",
+"327 -308 OFFCURVE",
+"264 -308 CURVE SMOOTH",
+"196 -308 OFFCURVE",
+"116 -268 OFFCURVE",
+"66 -231 CURVE",
+"27 -284 LINE",
+"92 -343 OFFCURVE",
+"191 -381 OFFCURVE",
+"265 -381 CURVE SMOOTH",
+"361 -381 OFFCURVE",
+"421 -326 OFFCURVE",
+"421 -245 CURVE SMOOTH",
+"421 -213 OFFCURVE",
+"413 -180 OFFCURVE",
+"395 -143 CURVE SMOOTH",
+"376 -104 OFFCURVE",
+"370 -83 OFFCURVE",
+"370 -60 CURVE SMOOTH",
+"370 -33 OFFCURVE",
+"377 -16 OFFCURVE",
+"389 11 CURVE SMOOTH",
+"395 24 OFFCURVE",
+"401 39 OFFCURVE",
+"406 54 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"395 38 LINE",
+"399 38 LINE",
+"413 14 OFFCURVE",
+"445 0 OFFCURVE",
+"482 0 CURVE",
+"482 76 LINE",
+"460 76 OFFCURVE",
+"423 86 OFFCURVE",
+"416 129 CURVE",
+"415 152 OFFCURVE",
+"408 183 OFFCURVE",
+"387 216 CURVE",
+"324 179 LINE",
+"341 146 OFFCURVE",
+"344 126 OFFCURVE",
+"344 102 CURVE SMOOTH",
+"344 80 OFFCURVE",
+"334 52 OFFCURVE",
+"323 27 CURVE SMOOTH",
+"306 -12 OFFCURVE",
+"298 -34 OFFCURVE",
+"298 -73 CURVE SMOOTH",
+"298 -97 OFFCURVE",
+"306 -127 OFFCURVE",
+"320 -156 CURVE SMOOTH",
+"345 -208 OFFCURVE",
+"349 -227 OFFCURVE",
+"349 -247 CURVE SMOOTH",
+"349 -280 OFFCURVE",
+"327 -308 OFFCURVE",
+"264 -308 CURVE SMOOTH",
+"196 -308 OFFCURVE",
+"116 -268 OFFCURVE",
+"66 -231 CURVE",
+"27 -284 LINE",
+"92 -343 OFFCURVE",
+"191 -381 OFFCURVE",
+"265 -381 CURVE SMOOTH",
+"361 -381 OFFCURVE",
+"421 -326 OFFCURVE",
+"421 -245 CURVE SMOOTH",
+"421 -213 OFFCURVE",
+"413 -180 OFFCURVE",
+"395 -143 CURVE SMOOTH",
+"376 -104 OFFCURVE",
+"370 -83 OFFCURVE",
+"370 -60 CURVE SMOOTH",
+"370 -33 OFFCURVE",
+"377 -16 OFFCURVE",
+"389 11 CURVE SMOOTH",
+"395 24 OFFCURVE",
+"401 39 OFFCURVE",
+"406 54 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"177 36 LINE",
+"181 36 LINE",
+"195 12 OFFCURVE",
+"223 0 OFFCURVE",
+"260 0 CURVE",
+"260 76 LINE",
+"238 76 OFFCURVE",
+"201 86 OFFCURVE",
+"194 129 CURVE",
+"193 152 OFFCURVE",
+"186 183 OFFCURVE",
+"165 216 CURVE",
+"102 179 LINE",
+"119 146 OFFCURVE",
+"122 126 OFFCURVE",
+"122 102 CURVE SMOOTH",
+"122 80 OFFCURVE",
+"112 52 OFFCURVE",
+"101 27 CURVE SMOOTH",
+"84 -12 OFFCURVE",
+"76 -34 OFFCURVE",
+"76 -73 CURVE SMOOTH",
+"76 -97 OFFCURVE",
+"84 -127 OFFCURVE",
+"98 -156 CURVE SMOOTH",
+"123 -208 OFFCURVE",
+"127 -227 OFFCURVE",
+"127 -247 CURVE SMOOTH",
+"127 -280 OFFCURVE",
+"105 -308 OFFCURVE",
+"42 -308 CURVE SMOOTH",
+"-26 -308 OFFCURVE",
+"-106 -268 OFFCURVE",
+"-156 -231 CURVE",
+"-195 -284 LINE",
+"-130 -343 OFFCURVE",
+"-31 -381 OFFCURVE",
+"43 -381 CURVE SMOOTH",
+"139 -381 OFFCURVE",
+"199 -326 OFFCURVE",
+"199 -245 CURVE SMOOTH",
+"199 -213 OFFCURVE",
+"191 -180 OFFCURVE",
+"173 -143 CURVE SMOOTH",
+"154 -104 OFFCURVE",
+"148 -83 OFFCURVE",
+"148 -60 CURVE SMOOTH",
+"148 -33 OFFCURVE",
+"155 -16 OFFCURVE",
+"167 11 CURVE SMOOTH",
+"173 24 OFFCURVE",
+"179 39 OFFCURVE",
+"184 54 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"181 36 LINE",
+"195 12 OFFCURVE",
+"223 0 OFFCURVE",
+"260 0 CURVE",
+"260 76 LINE",
+"238 76 OFFCURVE",
+"201 86 OFFCURVE",
+"194 129 CURVE",
+"193 152 OFFCURVE",
+"186 183 OFFCURVE",
+"165 216 CURVE",
+"102 179 LINE",
+"119 146 OFFCURVE",
+"122 126 OFFCURVE",
+"122 102 CURVE SMOOTH",
+"122 80 OFFCURVE",
+"112 52 OFFCURVE",
+"101 27 CURVE SMOOTH",
+"84 -12 OFFCURVE",
+"76 -34 OFFCURVE",
+"76 -73 CURVE SMOOTH",
+"76 -97 OFFCURVE",
+"84 -127 OFFCURVE",
+"98 -156 CURVE SMOOTH",
+"123 -208 OFFCURVE",
+"127 -227 OFFCURVE",
+"127 -247 CURVE SMOOTH",
+"127 -280 OFFCURVE",
+"105 -308 OFFCURVE",
+"42 -308 CURVE SMOOTH",
+"-26 -308 OFFCURVE",
+"-106 -268 OFFCURVE",
+"-156 -231 CURVE",
+"-195 -284 LINE",
+"-130 -343 OFFCURVE",
+"-31 -381 OFFCURVE",
+"43 -381 CURVE SMOOTH",
+"139 -381 OFFCURVE",
+"199 -326 OFFCURVE",
+"199 -245 CURVE SMOOTH",
+"199 -213 OFFCURVE",
+"191 -180 OFFCURVE",
+"173 -143 CURVE SMOOTH",
+"154 -104 OFFCURVE",
+"148 -83 OFFCURVE",
+"148 -60 CURVE SMOOTH",
+"148 -33 OFFCURVE",
+"155 -16 OFFCURVE",
+"167 11 CURVE SMOOTH",
+"171 20 OFFCURVE",
+"174 27 OFFCURVE",
+"177 36 CURVE"
+);
+}
+);
+width = 260;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0723.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{551, -98}";
+},
+{
+name = top;
+position = "{682, 477}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"767 403 OFFCURVE",
+"711 376 OFFCURVE",
+"682 320 CURVE",
+"679 320 LINE",
+"647 370 OFFCURVE",
+"592 399 OFFCURVE",
+"521 399 CURVE SMOOTH",
+"423 399 OFFCURVE",
+"336 335 OFFCURVE",
+"336 212 CURVE SMOOTH",
+"336 156 OFFCURVE",
+"352 113 OFFCURVE",
+"385 78 CURVE",
+"385 74 LINE",
+"364 76 OFFCURVE",
+"339 76 OFFCURVE",
+"324 76 CURVE SMOOTH",
+"287 76 LINE SMOOTH",
+"173 76 OFFCURVE",
+"127 125 OFFCURVE",
+"127 198 CURVE SMOOTH",
+"127 206 LINE",
+"61 202 LINE",
+"60 196 OFFCURVE",
+"59 175 OFFCURVE",
+"59 171 CURVE SMOOTH",
+"59 62 OFFCURVE",
+"142 0 OFFCURVE",
+"278 0 CURVE SMOOTH",
+"529 0 LINE",
+"686 0 LINE",
+"811 0 LINE",
+"1089 0 LINE",
+"1089 76 LINE",
+"1024 76 LINE SMOOTH",
+"1007 76 OFFCURVE",
+"985 76 OFFCURVE",
+"963 74 CURVE",
+"963 78 LINE",
+"995 105 OFFCURVE",
+"1016 156 OFFCURVE",
+"1016 208 CURVE SMOOTH",
+"1016 327 OFFCURVE",
+"941 403 OFFCURVE",
+"827 403 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 76 OFFCURVE",
+"407 138 OFFCURVE",
+"407 216 CURVE SMOOTH",
+"407 292 OFFCURVE",
+"462 326 OFFCURVE",
+"522 326 CURVE SMOOTH",
+"609 326 OFFCURVE",
+"652 266 OFFCURVE",
+"652 168 CURVE SMOOTH",
+"652 81 OFFCURVE",
+"587 76 OFFCURVE",
+"534 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"761 76 OFFCURVE",
+"708 95 OFFCURVE",
+"708 202 CURVE SMOOTH",
+"708 295 OFFCURVE",
+"773 330 OFFCURVE",
+"827 330 CURVE SMOOTH",
+"903 330 OFFCURVE",
+"945 285 OFFCURVE",
+"945 209 CURVE SMOOTH",
+"945 110 OFFCURVE",
+"875 76 OFFCURVE",
+"812 76 CURVE SMOOTH"
+);
+}
+);
+width = 1089;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0724.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{383, -244}";
+},
+{
+name = top;
+position = "{404, 477}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"489 403 OFFCURVE",
+"434 375 OFFCURVE",
+"405 320 CURVE",
+"401 320 LINE",
+"370 370 OFFCURVE",
+"315 399 OFFCURVE",
+"244 399 CURVE SMOOTH",
+"146 399 OFFCURVE",
+"59 335 OFFCURVE",
+"59 212 CURVE SMOOTH",
+"59 91 OFFCURVE",
+"129 0 OFFCURVE",
+"283 0 CURVE SMOOTH",
+"367 0 LINE",
+"363 -57 OFFCURVE",
+"357 -118 OFFCURVE",
+"355 -159 CURVE",
+"421 -159 LINE",
+"427 -114 OFFCURVE",
+"433 -59 OFFCURVE",
+"437 0 CURVE",
+"535 0 LINE",
+"812 0 LINE",
+"812 76 LINE",
+"747 76 LINE SMOOTH",
+"730 76 OFFCURVE",
+"708 76 OFFCURVE",
+"686 74 CURVE",
+"686 78 LINE",
+"718 105 OFFCURVE",
+"739 156 OFFCURVE",
+"739 208 CURVE SMOOTH",
+"739 327 OFFCURVE",
+"664 403 OFFCURVE",
+"549 403 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 71 OFFCURVE",
+"130 138 OFFCURVE",
+"130 216 CURVE SMOOTH",
+"130 292 OFFCURVE",
+"185 326 OFFCURVE",
+"245 326 CURVE SMOOTH",
+"332 326 OFFCURVE",
+"375 266 OFFCURVE",
+"375 168 CURVE SMOOTH",
+"375 81 OFFCURVE",
+"310 71 OFFCURVE",
+"256 71 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"484 71 OFFCURVE",
+"431 95 OFFCURVE",
+"431 202 CURVE SMOOTH",
+"431 295 OFFCURVE",
+"496 330 OFFCURVE",
+"550 330 CURVE SMOOTH",
+"625 330 OFFCURVE",
+"668 285 OFFCURVE",
+"668 209 CURVE SMOOTH",
+"668 110 OFFCURVE",
+"597 71 OFFCURVE",
+"535 71 CURVE SMOOTH"
+);
+}
+);
+width = 812;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072B.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{459, -98}";
+},
+{
+name = top;
+position = "{478, 452}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"2521 76 OFFCURVE",
+"2489 139 OFFCURVE",
+"2489 213 CURVE SMOOTH",
+"2489 220 LINE",
+"2423 216 LINE",
+"2422 211 OFFCURVE",
+"2421 189 OFFCURVE",
+"2421 186 CURVE SMOOTH",
+"2421 71 OFFCURVE",
+"2495 0 OFFCURVE",
+"2612 0 CURVE SMOOTH",
+"2672 0 OFFCURVE",
+"2739 10 OFFCURVE",
+"2818 41 CURVE",
+"2883 11 OFFCURVE",
+"2965 0 OFFCURVE",
+"3025 0 CURVE SMOOTH",
+"3049 0 LINE",
+"3049 76 LINE",
+"3046 76 LINE SMOOTH",
+"2992 76 OFFCURVE",
+"2954 91 OFFCURVE",
+"2929 116 CURVE",
+"2951 140 OFFCURVE",
+"2966 165 OFFCURVE",
+"2966 210 CURVE SMOOTH",
+"2966 296 OFFCURVE",
+"2896 351 OFFCURVE",
+"2822 351 CURVE SMOOTH",
+"2724 351 OFFCURVE",
+"2665 292 OFFCURVE",
+"2665 200 CURVE SMOOTH",
+"2665 167 OFFCURVE",
+"2674 141 OFFCURVE",
+"2693 114 CURVE",
+"2685 85 OFFCURVE",
+"2643 76 OFFCURVE",
+"2612 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"3496 296 OFFCURVE",
+"3445 238 OFFCURVE",
+"3412 79 CURVE",
+"3401 77 OFFCURVE",
+"3373 76 OFFCURVE",
+"3353 76 CURVE SMOOTH",
+"3332 76 OFFCURVE",
+"3314 61 OFFCURVE",
+"3314 38 CURVE SMOOTH",
+"3314 14 OFFCURVE",
+"3332 0 OFFCURVE",
+"3353 0 CURVE SMOOTH",
+"3549 0 LINE SMOOTH",
+"3637 0 OFFCURVE",
+"3709 3 OFFCURVE",
+"3745 36 CURVE",
+"3748 36 LINE",
+"3785 8 OFFCURVE",
+"3832 0 OFFCURVE",
+"3884 0 CURVE",
+"3884 76 LINE",
+"3839 76 OFFCURVE",
+"3805 81 OFFCURVE",
+"3754 147 CURVE SMOOTH",
+"3744 160 LINE SMOOTH",
+"3695 224 OFFCURVE",
+"3650 296 OFFCURVE",
+"3573 296 CURVE SMOOTH",
+"3496 296 OFFCURVE",
+"3445 238 OFFCURVE",
+"3412 79 CURVE",
+"3401 77 OFFCURVE",
+"3373 76 OFFCURVE",
+"3353 76 CURVE SMOOTH",
+"3332 76 OFFCURVE",
+"3314 61 OFFCURVE",
+"3314 38 CURVE SMOOTH",
+"3314 14 OFFCURVE",
+"3332 0 OFFCURVE",
+"3353 0 CURVE SMOOTH",
+"3549 0 LINE SMOOTH",
+"3637 0 OFFCURVE",
+"3709 3 OFFCURVE",
+"3745 36 CURVE",
+"3748 36 LINE",
+"3785 8 OFFCURVE",
+"3832 0 OFFCURVE",
+"3884 0 CURVE",
+"3884 76 LINE",
+"3839 76 OFFCURVE",
+"3805 81 OFFCURVE",
+"3754 147 CURVE SMOOTH",
+"3744 160 LINE SMOOTH",
+"3695 224 OFFCURVE",
+"3650 296 OFFCURVE",
+"3573 296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"3361 0 LINE SMOOTH",
+"3244 0 OFFCURVE",
+"3170 71 OFFCURVE",
+"3170 186 CURVE SMOOTH",
+"3170 189 OFFCURVE",
+"3171 211 OFFCURVE",
+"3172 216 CURVE",
+"3238 220 LINE",
+"3238 213 LINE SMOOTH",
+"3238 139 OFFCURVE",
+"3270 76 OFFCURVE",
+"3361 76 CURVE SMOOTH",
+"3368 76 OFFCURVE",
+"3401 77 OFFCURVE",
+"3412 79 CURVE",
+"3445 238 OFFCURVE",
+"3496 296 OFFCURVE",
+"3573 296 CURVE SMOOTH",
+"3650 296 OFFCURVE",
+"3695 224 OFFCURVE",
+"3744 160 CURVE SMOOTH",
+"3754 147 LINE SMOOTH",
+"3805 81 OFFCURVE",
+"3839 76 OFFCURVE",
+"3884 76 CURVE",
+"3884 0 LINE",
+"3832 0 OFFCURVE",
+"3785 8 OFFCURVE",
+"3748 36 CURVE",
+"3745 36 LINE",
+"3709 3 OFFCURVE",
+"3637 0 OFFCURVE",
+"3549 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"2770 0 LINE SMOOTH",
+"2858 0 OFFCURVE",
+"2930 3 OFFCURVE",
+"2966 36 CURVE",
+"2969 36 LINE",
+"3006 8 OFFCURVE",
+"3053 0 OFFCURVE",
+"3085 0 CURVE",
+"3085 76 LINE",
+"3054 76 OFFCURVE",
+"3029 82 OFFCURVE",
+"2991 127 CURVE SMOOTH",
+"2933 194 LINE SMOOTH",
+"2881 254 OFFCURVE",
+"2845 290 OFFCURVE",
+"2793 290 CURVE SMOOTH",
+"2716 290 OFFCURVE",
+"2679 242 OFFCURVE",
+"2642 79 CURVE",
+"2631 77 OFFCURVE",
+"2604 76 OFFCURVE",
+"2584 76 CURVE SMOOTH",
+"2563 76 OFFCURVE",
+"2545 61 OFFCURVE",
+"2545 38 CURVE SMOOTH",
+"2545 14 OFFCURVE",
+"2563 0 OFFCURVE",
+"2584 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1938 -57 OFFCURVE",
+"1904 -105 OFFCURVE",
+"1867 -268 CURVE",
+"1856 -270 OFFCURVE",
+"1776 -271 OFFCURVE",
+"1756 -271 CURVE SMOOTH",
+"1735 -271 OFFCURVE",
+"1717 -286 OFFCURVE",
+"1717 -309 CURVE SMOOTH",
+"1717 -333 OFFCURVE",
+"1735 -347 OFFCURVE",
+"1756 -347 CURVE SMOOTH",
+"1992 -347 LINE SMOOTH",
+"2080 -347 OFFCURVE",
+"2152 -344 OFFCURVE",
+"2188 -311 CURVE",
+"2191 -311 LINE",
+"2228 -339 OFFCURVE",
+"2265 -347 OFFCURVE",
+"2287 -347 CURVE",
+"2287 -271 LINE",
+"2278 -271 OFFCURVE",
+"2251 -265 OFFCURVE",
+"2213 -220 CURVE SMOOTH",
+"2155 -153 LINE SMOOTH",
+"2103 -93 OFFCURVE",
+"2067 -57 OFFCURVE",
+"2015 -57 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1992 -314 LINE SMOOTH",
+"2080 -314 OFFCURVE",
+"2152 -311 OFFCURVE",
+"2188 -278 CURVE",
+"2191 -278 LINE",
+"2228 -306 OFFCURVE",
+"2265 -314 OFFCURVE",
+"2287 -314 CURVE",
+"2287 -238 LINE",
+"2278 -238 OFFCURVE",
+"2251 -232 OFFCURVE",
+"2213 -187 CURVE SMOOTH",
+"2155 -120 LINE SMOOTH",
+"2103 -60 OFFCURVE",
+"2067 -24 OFFCURVE",
+"2015 -24 CURVE SMOOTH",
+"1938 -24 OFFCURVE",
+"1903 -73 OFFCURVE",
+"1866 -238 CURVE",
+"1821 -238 LINE SMOOTH",
+"1730 -238 OFFCURVE",
+"1691 -179 OFFCURVE",
+"1691 -101 CURVE SMOOTH",
+"1691 -94 LINE",
+"1625 -98 LINE",
+"1624 -103 OFFCURVE",
+"1623 -125 OFFCURVE",
+"1623 -128 CURVE SMOOTH",
+"1623 -243 OFFCURVE",
+"1691 -314 OFFCURVE",
+"1844 -314 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1938 290 OFFCURVE",
+"1888 230 OFFCURVE",
+"1882 79 CURVE",
+"1871 77 OFFCURVE",
+"1776 76 OFFCURVE",
+"1756 76 CURVE SMOOTH",
+"1735 76 OFFCURVE",
+"1717 61 OFFCURVE",
+"1717 38 CURVE SMOOTH",
+"1717 14 OFFCURVE",
+"1735 0 OFFCURVE",
+"1756 0 CURVE SMOOTH",
+"1992 0 LINE SMOOTH",
+"2080 0 OFFCURVE",
+"2152 3 OFFCURVE",
+"2188 36 CURVE",
+"2191 36 LINE",
+"2228 8 OFFCURVE",
+"2265 0 OFFCURVE",
+"2287 0 CURVE",
+"2287 76 LINE",
+"2278 76 OFFCURVE",
+"2251 82 OFFCURVE",
+"2213 127 CURVE SMOOTH",
+"2155 194 LINE SMOOTH",
+"2103 254 OFFCURVE",
+"2067 290 OFFCURVE",
+"2015 290 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1938 290 OFFCURVE",
+"1888 230 OFFCURVE",
+"1882 79 CURVE",
+"1871 77 OFFCURVE",
+"1776 76 OFFCURVE",
+"1756 76 CURVE SMOOTH",
+"1735 76 OFFCURVE",
+"1717 61 OFFCURVE",
+"1717 38 CURVE SMOOTH",
+"1717 14 OFFCURVE",
+"1735 0 OFFCURVE",
+"1756 0 CURVE SMOOTH",
+"1992 0 LINE SMOOTH",
+"2080 0 OFFCURVE",
+"2152 3 OFFCURVE",
+"2188 36 CURVE",
+"2191 36 LINE",
+"2228 8 OFFCURVE",
+"2265 0 OFFCURVE",
+"2287 0 CURVE",
+"2287 76 LINE",
+"2278 76 OFFCURVE",
+"2251 82 OFFCURVE",
+"2213 127 CURVE SMOOTH",
+"2155 194 LINE SMOOTH",
+"2103 254 OFFCURVE",
+"2067 290 OFFCURVE",
+"2015 290 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1259 0 LINE SMOOTH",
+"1347 0 OFFCURVE",
+"1419 3 OFFCURVE",
+"1458 36 CURVE",
+"1495 8 OFFCURVE",
+"1532 0 OFFCURVE",
+"1554 0 CURVE",
+"1554 76 LINE",
+"1545 76 OFFCURVE",
+"1518 82 OFFCURVE",
+"1480 127 CURVE SMOOTH",
+"1422 194 LINE SMOOTH",
+"1370 254 OFFCURVE",
+"1334 290 OFFCURVE",
+"1282 290 CURVE SMOOTH",
+"1205 290 OFFCURVE",
+"1155 230 OFFCURVE",
+"1149 76 CURVE",
+"1088 76 LINE SMOOTH",
+"997 76 OFFCURVE",
+"958 135 OFFCURVE",
+"958 213 CURVE SMOOTH",
+"958 220 LINE",
+"892 216 LINE",
+"891 211 OFFCURVE",
+"890 189 OFFCURVE",
+"890 186 CURVE SMOOTH",
+"890 71 OFFCURVE",
+"958 0 OFFCURVE",
+"1111 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"365 295 OFFCURVE",
+"324 230 OFFCURVE",
+"318 79 CURVE",
+"307 77 OFFCURVE",
+"242 76 OFFCURVE",
+"222 76 CURVE SMOOTH",
+"201 76 OFFCURVE",
+"183 61 OFFCURVE",
+"183 38 CURVE SMOOTH",
+"183 14 OFFCURVE",
+"201 0 OFFCURVE",
+"222 0 CURVE SMOOTH",
+"428 0 LINE SMOOTH",
+"516 0 OFFCURVE",
+"578 3 OFFCURVE",
+"617 36 CURVE",
+"654 8 OFFCURVE",
+"688 0 OFFCURVE",
+"703 0 CURVE",
+"703 76 LINE",
+"694 76 OFFCURVE",
+"678 81 OFFCURVE",
+"646 121 CURVE SMOOTH",
+"588 193 LINE SMOOTH",
+"535 259 OFFCURVE",
+"494 295 OFFCURVE",
+"442 295 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"365 295 OFFCURVE",
+"324 230 OFFCURVE",
+"318 76 CURVE",
+"257 76 LINE SMOOTH",
+"166 76 OFFCURVE",
+"127 135 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"127 0 OFFCURVE",
+"280 0 CURVE SMOOTH",
+"428 0 LINE",
+"516 0 OFFCURVE",
+"578 3 OFFCURVE",
+"617 36 CURVE",
+"647 8 OFFCURVE",
+"677 0 OFFCURVE",
+"703 0 CURVE",
+"703 76 LINE",
+"694 76 OFFCURVE",
+"678 81 OFFCURVE",
+"646 121 CURVE SMOOTH",
+"588 193 LINE SMOOTH",
+"535 259 OFFCURVE",
+"494 295 OFFCURVE",
+"442 295 CURVE SMOOTH"
+);
+}
+);
+width = 703;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072C.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{390, 477}";
+},
+{
+name = RU;
+position = "{449, -85}";
+},
+{
+name = bottom;
+position = "{195, -98}";
+},
+{
+name = top;
+position = "{158, 662}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"151 53 LINE",
+"171 111 OFFCURVE",
+"197 244 OFFCURVE",
+"197 365 CURVE SMOOTH",
+"197 391 OFFCURVE",
+"196 416 OFFCURVE",
+"194 440 CURVE",
+"199 440 LINE",
+"221 400 OFFCURVE",
+"320 250 OFFCURVE",
+"369 179 CURVE",
+"448 67 OFFCURVE",
+"463 46 OFFCURVE",
+"504 19 CURVE SMOOTH",
+"528 3 OFFCURVE",
+"560 0 OFFCURVE",
+"584 0 CURVE",
+"584 76 LINE",
+"540 76 OFFCURVE",
+"517 100 OFFCURVE",
+"426 226 CURVE SMOOTH",
+"353 326 OFFCURVE",
+"245 493 OFFCURVE",
+"191 592 CURVE",
+"123 564 LINE",
+"128 515 OFFCURVE",
+"128 466 OFFCURVE",
+"128 408 CURVE SMOOTH",
+"128 264 OFFCURVE",
+"109 112 OFFCURVE",
+"68 18 CURVE",
+"82 -24 LINE",
+"109 -19 OFFCURVE",
+"170 -15 OFFCURVE",
+"212 -15 CURVE SMOOTH",
+"229 -15 OFFCURVE",
+"293 -18 OFFCURVE",
+"328 -29 CURVE",
+"348 37 LINE",
+"312 57 OFFCURVE",
+"260 61 OFFCURVE",
+"230 61 CURVE SMOOTH",
+"217 61 OFFCURVE",
+"186 58 OFFCURVE",
+"153 50 CURVE"
+);
+}
+);
+width = 584;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071B.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{326, -381}";
+},
+{
+name = top;
+position = "{281, 665}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"511 -3 OFFCURVE",
+"427 45 OFFCURVE",
+"309 94 CURVE SMOOTH",
+"301 98 OFFCURVE",
+"294 100 OFFCURVE",
+"287 104 CURVE",
+"308 175 OFFCURVE",
+"320 290 OFFCURVE",
+"320 385 CURVE SMOOTH",
+"320 400 OFFCURVE",
+"319 416 OFFCURVE",
+"317 440 CURVE",
+"322 440 LINE",
+"343 400 OFFCURVE",
+"441 249 OFFCURVE",
+"492 179 CURVE SMOOTH",
+"581 55 OFFCURVE",
+"618 0 OFFCURVE",
+"732 0 CURVE",
+"732 76 LINE",
+"661 76 OFFCURVE",
+"640 100 OFFCURVE",
+"549 226 CURVE SMOOTH",
+"476 326 OFFCURVE",
+"368 493 OFFCURVE",
+"314 592 CURVE",
+"246 564 LINE",
+"251 514 OFFCURVE",
+"251 476 OFFCURVE",
+"251 417 CURVE SMOOTH",
+"251 330 OFFCURVE",
+"242 212 OFFCURVE",
+"221 134 CURVE SMOOTH",
+"220 131 LINE",
+"175 153 OFFCURVE",
+"116 199 OFFCURVE",
+"93 232 CURVE",
+"88 232 LINE",
+"49 176 LINE",
+"84 121 OFFCURVE",
+"142 84 OFFCURVE",
+"200 57 CURVE",
+"178 -8 OFFCURVE",
+"157 -70 OFFCURVE",
+"157 -139 CURVE SMOOTH",
+"157 -249 OFFCURVE",
+"237 -316 OFFCURVE",
+"333 -316 CURVE SMOOTH",
+"435 -316 OFFCURVE",
+"511 -248 OFFCURVE",
+"511 -127 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 -200 OFFCURVE",
+"399 -243 OFFCURVE",
+"334 -243 CURVE SMOOTH",
+"267 -243 OFFCURVE",
+"228 -189 OFFCURVE",
+"228 -128 CURVE SMOOTH",
+"228 -78 OFFCURVE",
+"244 -22 OFFCURVE",
+"265 32 CURVE",
+"365 -9 OFFCURVE",
+"440 -41 OFFCURVE",
+"440 -125 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"511 8 OFFCURVE",
+"408 53 OFFCURVE",
+"287 104 CURVE",
+"293 126 OFFCURVE",
+"299 152 OFFCURVE",
+"304 180 CURVE SMOOTH",
+"315 244 OFFCURVE",
+"320 319 OFFCURVE",
+"320 385 CURVE SMOOTH",
+"320 400 OFFCURVE",
+"319 416 OFFCURVE",
+"317 440 CURVE",
+"322 440 LINE",
+"343 400 OFFCURVE",
+"441 249 OFFCURVE",
+"492 179 CURVE SMOOTH",
+"581 55 OFFCURVE",
+"618 0 OFFCURVE",
+"732 0 CURVE",
+"732 76 LINE",
+"661 76 OFFCURVE",
+"640 100 OFFCURVE",
+"549 226 CURVE SMOOTH",
+"476 326 OFFCURVE",
+"368 493 OFFCURVE",
+"314 592 CURVE",
+"246 564 LINE",
+"251 514 OFFCURVE",
+"251 476 OFFCURVE",
+"251 417 CURVE SMOOTH",
+"251 349 OFFCURVE",
+"245 273 OFFCURVE",
+"235 201 CURVE SMOOTH",
+"231 173 OFFCURVE",
+"225 150 OFFCURVE",
+"220 131 CURVE",
+"175 153 OFFCURVE",
+"116 199 OFFCURVE",
+"93 232 CURVE",
+"88 232 LINE",
+"49 176 LINE",
+"84 121 OFFCURVE",
+"142 84 OFFCURVE",
+"200 57 CURVE",
+"178 -8 OFFCURVE",
+"157 -70 OFFCURVE",
+"157 -139 CURVE SMOOTH",
+"157 -249 OFFCURVE",
+"237 -316 OFFCURVE",
+"333 -316 CURVE SMOOTH",
+"435 -316 OFFCURVE",
+"511 -248 OFFCURVE",
+"511 -127 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 -200 OFFCURVE",
+"399 -243 OFFCURVE",
+"334 -243 CURVE SMOOTH",
+"267 -243 OFFCURVE",
+"228 -189 OFFCURVE",
+"228 -128 CURVE SMOOTH",
+"228 -78 OFFCURVE",
+"244 -22 OFFCURVE",
+"265 32 CURVE",
+"365 -9 OFFCURVE",
+"440 -41 OFFCURVE",
+"440 -125 CURVE SMOOTH"
+);
+}
+);
+width = 732;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071C.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{327, -381}";
+},
+{
+name = top;
+position = "{280, 664}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"293 -143 OFFCURVE",
+"309 -157 OFFCURVE",
+"331 -157 CURVE SMOOTH",
+"351 -157 OFFCURVE",
+"368 -143 OFFCURVE",
+"368 -116 CURVE SMOOTH",
+"368 -89 OFFCURVE",
+"351 -75 OFFCURVE",
+"331 -75 CURVE SMOOTH",
+"309 -75 OFFCURVE",
+"293 -89 OFFCURVE",
+"293 -116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 8 OFFCURVE",
+"408 53 OFFCURVE",
+"287 104 CURVE",
+"293 126 OFFCURVE",
+"299 152 OFFCURVE",
+"304 180 CURVE SMOOTH",
+"315 244 OFFCURVE",
+"320 319 OFFCURVE",
+"320 385 CURVE SMOOTH",
+"320 400 OFFCURVE",
+"319 416 OFFCURVE",
+"317 440 CURVE",
+"322 440 LINE",
+"343 400 OFFCURVE",
+"441 249 OFFCURVE",
+"492 179 CURVE SMOOTH",
+"581 55 OFFCURVE",
+"618 0 OFFCURVE",
+"732 0 CURVE",
+"732 76 LINE",
+"661 76 OFFCURVE",
+"640 100 OFFCURVE",
+"549 226 CURVE SMOOTH",
+"476 326 OFFCURVE",
+"368 493 OFFCURVE",
+"314 592 CURVE",
+"246 564 LINE",
+"251 514 OFFCURVE",
+"251 476 OFFCURVE",
+"251 417 CURVE SMOOTH",
+"251 349 OFFCURVE",
+"245 273 OFFCURVE",
+"235 201 CURVE SMOOTH",
+"231 173 OFFCURVE",
+"225 150 OFFCURVE",
+"220 131 CURVE",
+"175 153 OFFCURVE",
+"116 199 OFFCURVE",
+"93 232 CURVE",
+"88 232 LINE",
+"49 176 LINE",
+"84 121 OFFCURVE",
+"142 84 OFFCURVE",
+"200 57 CURVE",
+"178 -8 OFFCURVE",
+"157 -70 OFFCURVE",
+"157 -139 CURVE SMOOTH",
+"157 -249 OFFCURVE",
+"237 -316 OFFCURVE",
+"333 -316 CURVE SMOOTH",
+"435 -316 OFFCURVE",
+"511 -248 OFFCURVE",
+"511 -127 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 -200 OFFCURVE",
+"399 -243 OFFCURVE",
+"334 -243 CURVE SMOOTH",
+"267 -243 OFFCURVE",
+"228 -189 OFFCURVE",
+"228 -128 CURVE SMOOTH",
+"228 -78 OFFCURVE",
+"244 -22 OFFCURVE",
+"265 32 CURVE",
+"365 -9 OFFCURVE",
+"440 -41 OFFCURVE",
+"440 -125 CURVE SMOOTH"
+);
+}
+);
+width = 732;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0718.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{254, -98}";
+},
+{
+name = top;
+position = "{264, 506}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"137 408 OFFCURVE",
+"45 335 OFFCURVE",
+"45 212 CURVE SMOOTH",
+"45 91 OFFCURVE",
+"127 0 OFFCURVE",
+"277 0 CURVE SMOOTH",
+"539 0 LINE",
+"539 76 LINE",
+"505 76 LINE SMOOTH",
+"483 76 OFFCURVE",
+"444 75 OFFCURVE",
+"423 74 CURVE",
+"423 77 LINE",
+"448 103 OFFCURVE",
+"468 146 OFFCURVE",
+"468 196 CURVE SMOOTH",
+"468 314 OFFCURVE",
+"377 408 OFFCURVE",
+"246 408 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"170 76 OFFCURVE",
+"118 138 OFFCURVE",
+"118 216 CURVE SMOOTH",
+"118 291 OFFCURVE",
+"177 335 OFFCURVE",
+"246 335 CURVE SMOOTH",
+"337 335 OFFCURVE",
+"395 275 OFFCURVE",
+"395 198 CURVE SMOOTH",
+"395 113 OFFCURVE",
+"334 76 OFFCURVE",
+"265 76 CURVE SMOOTH"
+);
+}
+);
+width = 539;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071D.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{271, -98}";
+},
+{
+name = top;
+position = "{318, 341}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"2111 76 LINE",
+"2080 76 OFFCURVE",
+"2052 80 OFFCURVE",
+"2042 83 CURVE",
+"2033 90 OFFCURVE",
+"2023 113 OFFCURVE",
+"2014 134 CURVE SMOOTH",
+"1991 191 OFFCURVE",
+"1975 215 OFFCURVE",
+"1944 215 CURVE SMOOTH",
+"1915 215 OFFCURVE",
+"1904 201 OFFCURVE",
+"1894 183 CURVE",
+"1875 144 OFFCURVE",
+"1864 122 OFFCURVE",
+"1847 101 CURVE SMOOTH",
+"1827 75 OFFCURVE",
+"1790 68 OFFCURVE",
+"1762 68 CURVE SMOOTH",
+"1668 68 OFFCURVE",
+"1642 127 OFFCURVE",
+"1640 208 CURVE",
+"1576 204 LINE",
+"1574 198 OFFCURVE",
+"1574 182 OFFCURVE",
+"1574 178 CURVE SMOOTH",
+"1574 64 OFFCURVE",
+"1628 -7 OFFCURVE",
+"1758 -7 CURVE SMOOTH",
+"1804 -7 OFFCURVE",
+"1875 4 OFFCURVE",
+"1929 42 CURVE",
+"1974 3 OFFCURVE",
+"2026 0 OFFCURVE",
+"2111 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1298 89 OFFCURVE",
+"1275 129 OFFCURVE",
+"1264 149 CURVE SMOOTH",
+"1237 196 OFFCURVE",
+"1226 205 OFFCURVE",
+"1200 205 CURVE SMOOTH",
+"1177 205 OFFCURVE",
+"1165 195 OFFCURVE",
+"1154 177 CURVE SMOOTH",
+"1126 132 LINE SMOOTH",
+"1097 86 OFFCURVE",
+"1069 76 OFFCURVE",
+"1031 76 CURVE SMOOTH",
+"1010 76 OFFCURVE",
+"992 61 OFFCURVE",
+"992 38 CURVE SMOOTH",
+"992 14 OFFCURVE",
+"1010 0 OFFCURVE",
+"1031 0 CURVE SMOOTH",
+"1099 0 OFFCURVE",
+"1152 20 OFFCURVE",
+"1196 70 CURVE",
+"1236 17 OFFCURVE",
+"1266 0 OFFCURVE",
+"1351 0 CURVE SMOOTH",
+"1386 0 LINE",
+"1386 76 LINE",
+"1345 76 OFFCURVE",
+"1317 80 OFFCURVE",
+"1307 82 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1298 89 OFFCURVE",
+"1275 129 OFFCURVE",
+"1264 149 CURVE SMOOTH",
+"1237 196 OFFCURVE",
+"1226 205 OFFCURVE",
+"1200 205 CURVE SMOOTH",
+"1177 205 OFFCURVE",
+"1165 195 OFFCURVE",
+"1154 177 CURVE SMOOTH",
+"1126 132 LINE SMOOTH",
+"1097 86 OFFCURVE",
+"1069 76 OFFCURVE",
+"1031 76 CURVE SMOOTH",
+"1010 76 OFFCURVE",
+"992 61 OFFCURVE",
+"992 38 CURVE SMOOTH",
+"992 14 OFFCURVE",
+"1010 0 OFFCURVE",
+"1031 0 CURVE SMOOTH",
+"1099 0 OFFCURVE",
+"1152 20 OFFCURVE",
+"1196 70 CURVE",
+"1236 17 OFFCURVE",
+"1266 0 OFFCURVE",
+"1351 0 CURVE SMOOTH",
+"1386 0 LINE",
+"1386 76 LINE",
+"1345 76 OFFCURVE",
+"1317 80 OFFCURVE",
+"1307 82 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"726 69 OFFCURVE",
+"699 132 OFFCURVE",
+"697 213 CURVE",
+"633 209 LINE",
+"631 203 OFFCURVE",
+"631 187 OFFCURVE",
+"631 183 CURVE SMOOTH",
+"631 68 OFFCURVE",
+"684 -7 OFFCURVE",
+"815 -7 CURVE SMOOTH",
+"883 -7 OFFCURVE",
+"936 20 OFFCURVE",
+"980 70 CURVE",
+"1023 16 OFFCURVE",
+"1053 0 OFFCURVE",
+"1087 0 CURVE SMOOTH",
+"1119 0 OFFCURVE",
+"1143 9 OFFCURVE",
+"1170 38 CURVE SMOOTH",
+"1178 47 OFFCURVE",
+"1187 58 OFFCURVE",
+"1196 70 CURVE",
+"1236 17 OFFCURVE",
+"1266 0 OFFCURVE",
+"1351 0 CURVE SMOOTH",
+"1356 0 LINE",
+"1356 76 LINE",
+"1346 76 OFFCURVE",
+"1317 78 OFFCURVE",
+"1307 82 CURVE",
+"1298 89 OFFCURVE",
+"1273 129 OFFCURVE",
+"1262 149 CURVE SMOOTH",
+"1235 196 OFFCURVE",
+"1226 204 OFFCURVE",
+"1202 204 CURVE SMOOTH",
+"1181 204 OFFCURVE",
+"1169 191 OFFCURVE",
+"1158 172 CURVE SMOOTH",
+"1135 131 LINE SMOOTH",
+"1117 100 OFFCURVE",
+"1108 85 OFFCURVE",
+"1099 82 CURVE",
+"1090 82 LINE",
+"1081 87 OFFCURVE",
+"1072 99 OFFCURVE",
+"1042 149 CURVE SMOOTH",
+"1014 195 OFFCURVE",
+"1004 204 OFFCURVE",
+"982 204 CURVE SMOOTH",
+"961 204 OFFCURVE",
+"951 195 OFFCURVE",
+"939 177 CURVE SMOOTH",
+"912 136 LINE SMOOTH",
+"882 91 OFFCURVE",
+"853 69 OFFCURVE",
+"814 69 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1109 70 OFFCURVE",
+"1096 69 OFFCURVE",
+"1060 69 CURVE SMOOTH",
+"957 69 OFFCURVE",
+"905 113 OFFCURVE",
+"903 198 CURVE",
+"839 194 LINE",
+"837 189 OFFCURVE",
+"837 175 OFFCURVE",
+"837 171 CURVE SMOOTH",
+"837 79 OFFCURVE",
+"891 -7 OFFCURVE",
+"1045 -7 CURVE SMOOTH",
+"1082 -7 OFFCURVE",
+"1134 -6 OFFCURVE",
+"1161 0 CURVE SMOOTH",
+"1234 16 OFFCURVE",
+"1264 56 OFFCURVE",
+"1264 114 CURVE SMOOTH",
+"1264 157 OFFCURVE",
+"1248 203 OFFCURVE",
+"1213 203 CURVE SMOOTH",
+"1194 203 OFFCURVE",
+"1178 196 OFFCURVE",
+"1166 168 CURVE SMOOTH",
+"1155 143 OFFCURVE",
+"1134 86 OFFCURVE",
+"1127 72 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 203 OFFCURVE",
+"390 193 OFFCURVE",
+"378 175 CURVE SMOOTH",
+"347 129 LINE SMOOTH",
+"334 110 OFFCURVE",
+"324 100 OFFCURVE",
+"312 91 CURVE SMOOTH",
+"294 79 OFFCURVE",
+"275 76 OFFCURVE",
+"253 76 CURVE SMOOTH",
+"232 76 OFFCURVE",
+"214 61 OFFCURVE",
+"214 38 CURVE SMOOTH",
+"214 14 OFFCURVE",
+"232 0 OFFCURVE",
+"253 0 CURVE SMOOTH",
+"284 0 OFFCURVE",
+"313 5 OFFCURVE",
+"338 14 CURVE SMOOTH",
+"359 22 OFFCURVE",
+"378 33 OFFCURVE",
+"396 48 CURVE SMOOTH",
+"404 55 OFFCURVE",
+"411 62 OFFCURVE",
+"418 70 CURVE",
+"458 17 OFFCURVE",
+"488 0 OFFCURVE",
+"573 0 CURVE SMOOTH",
+"578 0 LINE",
+"578 76 LINE",
+"561 76 OFFCURVE",
+"539 79 OFFCURVE",
+"529 82 CURVE",
+"520 89 OFFCURVE",
+"497 129 OFFCURVE",
+"486 149 CURVE SMOOTH",
+"459 196 OFFCURVE",
+"449 203 OFFCURVE",
+"423 203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 203 OFFCURVE",
+"390 193 OFFCURVE",
+"378 175 CURVE SMOOTH",
+"347 129 LINE SMOOTH",
+"334 110 OFFCURVE",
+"324 100 OFFCURVE",
+"312 91 CURVE SMOOTH",
+"294 79 OFFCURVE",
+"275 76 OFFCURVE",
+"253 76 CURVE SMOOTH",
+"232 76 OFFCURVE",
+"214 61 OFFCURVE",
+"214 38 CURVE SMOOTH",
+"214 14 OFFCURVE",
+"232 0 OFFCURVE",
+"253 0 CURVE SMOOTH",
+"284 0 OFFCURVE",
+"313 5 OFFCURVE",
+"338 14 CURVE SMOOTH",
+"359 22 OFFCURVE",
+"378 33 OFFCURVE",
+"396 48 CURVE SMOOTH",
+"404 55 OFFCURVE",
+"411 62 OFFCURVE",
+"418 70 CURVE",
+"458 17 OFFCURVE",
+"488 0 OFFCURVE",
+"573 0 CURVE SMOOTH",
+"578 0 LINE",
+"578 76 LINE",
+"561 76 OFFCURVE",
+"539 79 OFFCURVE",
+"529 82 CURVE",
+"520 89 OFFCURVE",
+"497 129 OFFCURVE",
+"486 149 CURVE SMOOTH",
+"459 196 OFFCURVE",
+"449 203 OFFCURVE",
+"423 203 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"578 76 LINE",
+"561 76 OFFCURVE",
+"539 79 OFFCURVE",
+"529 82 CURVE",
+"520 89 OFFCURVE",
+"498 129 OFFCURVE",
+"486 149 CURVE SMOOTH",
+"459 196 OFFCURVE",
+"449 203 OFFCURVE",
+"423 203 CURVE SMOOTH",
+"400 203 OFFCURVE",
+"390 193 OFFCURVE",
+"378 175 CURVE SMOOTH",
+"347 129 LINE SMOOTH",
+"314 80 OFFCURVE",
+"287 68 OFFCURVE",
+"238 68 CURVE SMOOTH",
+"152 68 OFFCURVE",
+"127 128 OFFCURVE",
+"125 198 CURVE",
+"61 194 LINE",
+"59 188 OFFCURVE",
+"59 182 OFFCURVE",
+"59 178 CURVE SMOOTH",
+"59 64 OFFCURVE",
+"106 -7 OFFCURVE",
+"241 -7 CURVE SMOOTH",
+"327 -7 OFFCURVE",
+"379 23 OFFCURVE",
+"418 70 CURVE",
+"458 17 OFFCURVE",
+"488 0 OFFCURVE",
+"573 0 CURVE SMOOTH",
+"578 0 LINE"
+);
+}
+);
+width = 578;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0719.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{107, -194}";
+},
+{
+name = top;
+position = "{134, 537}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 416 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"145 -66 OFFCURVE",
+"158 -23 OFFCURVE",
+"165 33 CURVE",
+"168 33 LINE",
+"187 11 OFFCURVE",
+"215 0 OFFCURVE",
+"269 0 CURVE",
+"269 76 LINE",
+"237 76 OFFCURVE",
+"172 76 OFFCURVE",
+"170 111 CURVE",
+"170 122 OFFCURVE",
+"171 131 OFFCURVE",
+"171 142 CURVE SMOOTH",
+"171 416 LINE"
+);
+}
+);
+width = 269;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0712.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{721, -92}";
+}
+);
+hints = (
+{
+place = "{634, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"645 0 LINE",
+"662 46 LINE",
+"664 46 LINE",
+"687 13 OFFCURVE",
+"724 0 OFFCURVE",
+"772 0 CURVE SMOOTH",
+"812 0 LINE",
+"812 76 LINE",
+"778 76 LINE",
+"719 78 OFFCURVE",
+"713 94 OFFCURVE",
+"708 170 CURVE",
+"708 426 LINE",
+"484 426 LINE SMOOTH",
+"446 426 OFFCURVE",
+"410 427 OFFCURVE",
+"375 430 CURVE SMOOTH",
+"341 433 OFFCURVE",
+"318 435 OFFCURVE",
+"306 438 CURVE",
+"306 367 LINE",
+"335 359 OFFCURVE",
+"412 353 OFFCURVE",
+"489 353 CURVE SMOOTH",
+"634 353 LINE",
+"634 164 LINE SMOOTH",
+"634 128 OFFCURVE",
+"638 99 OFFCURVE",
+"647 76 CURVE"
+);
+}
+);
+width = 812;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072D.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{392, -98}";
+}
+);
+hints = (
+{
+place = "{634, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{633, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"645 0 LINE",
+"662 46 LINE",
+"664 46 LINE",
+"688 13 OFFCURVE",
+"724 0 OFFCURVE",
+"772 0 CURVE SMOOTH",
+"812 0 LINE",
+"812 76 LINE",
+"778 76 LINE",
+"719 78 OFFCURVE",
+"713 94 OFFCURVE",
+"708 170 CURVE",
+"708 426 LINE",
+"517 426 LINE",
+"469 425 LINE SMOOTH",
+"448 425 OFFCURVE",
+"428 423 OFFCURVE",
+"420 423 CURVE",
+"420 427 LINE",
+"458 464 LINE",
+"478 484 LINE",
+"497 503 LINE",
+"575 587 LINE",
+"516 633 LINE",
+"324 414 LINE",
+"324 353 LINE",
+"634 353 LINE",
+"634 164 LINE SMOOTH",
+"634 128 OFFCURVE",
+"638 99 OFFCURVE",
+"647 76 CURVE"
+);
+}
+);
+width = 812;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0715.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{438, -76}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 259, -195}";
+},
+{
+name = uni0716.loclSYRN.Fina;
+}
+);
+layerId = UUID0;
+width = 518;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni0716.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{439, -82}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{357, 73}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"387 120 LINE",
+"391 103 OFFCURVE",
+"394 88 OFFCURVE",
+"398 76 CURVE",
+"78 76 LINE",
+"78 0 LINE",
+"393 0 LINE",
+"411 46 LINE",
+"413 46 LINE",
+"432 15 OFFCURVE",
+"462 0 OFFCURVE",
+"502 0 CURVE SMOOTH",
+"518 0 LINE",
+"518 76 LINE",
+"502 76 LINE SMOOTH",
+"483 76 OFFCURVE",
+"469 86 OFFCURVE",
+"462 121 CURVE SMOOTH",
+"441 231 LINE",
+"417 364 OFFCURVE",
+"341 430 OFFCURVE",
+"214 430 CURVE SMOOTH",
+"166 430 OFFCURVE",
+"114 417 OFFCURVE",
+"90 398 CURVE",
+"90 332 LINE",
+"119 347 OFFCURVE",
+"166 357 OFFCURVE",
+"199 357 CURVE SMOOTH",
+"302 357 OFFCURVE",
+"355 306 OFFCURVE",
+"375 191 CURVE SMOOTH"
+);
+}
+);
+width = 518;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni072F.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{436, -98}";
+}
+);
+components = (
+{
+name = uni0716.loclSYRN.Fina;
+transform = "{1, 0, 0, 1, 173, 0}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 187, -176}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 97, -12}";
+}
+);
+layerId = UUID0;
+width = 691;
+}
+);
+rightKerningGroup = uni072F;
+},
+{
+color = 7;
+glyphname = uni0725.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{329, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{515, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"534 0 LINE",
+"553 46 LINE",
+"555 46 LINE",
+"584 14 OFFCURVE",
+"610 0 OFFCURVE",
+"638 0 CURVE",
+"638 76 LINE",
+"623 76 OFFCURVE",
+"609 94 OFFCURVE",
+"564 159 CURVE SMOOTH",
+"316 515 LINE",
+"251 471 LINE",
+"493 125 LINE SMOOTH",
+"505 107 OFFCURVE",
+"519 88 OFFCURVE",
+"531 76 CURVE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH"
+);
+}
+);
+width = 638;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074F.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{324, -97}";
+}
+);
+hints = (
+{
+place = "{471, 97}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{377, 44}";
+},
+{
+horizontal = 1;
+place = "{500, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"428 0 LINE",
+"501 0 OFFCURVE",
+"541 12 OFFCURVE",
+"560 43 CURVE",
+"562 43 LINE",
+"586 15 OFFCURVE",
+"616 0 OFFCURVE",
+"659 0 CURVE",
+"659 76 LINE",
+"635 76 OFFCURVE",
+"613 90 OFFCURVE",
+"593 123 CURVE",
+"524 229 LINE",
+"526 231 LINE",
+"578 234 OFFCURVE",
+"616 271 OFFCURVE",
+"616 327 CURVE SMOOTH",
+"616 384 OFFCURVE",
+"577 421 OFFCURVE",
+"520 421 CURVE SMOOTH",
+"481 421 OFFCURVE",
+"453 404 OFFCURVE",
+"437 372 CURVE",
+"433 372 LINE",
+"351 500 LINE",
+"289 458 LINE",
+"519 100 LINE",
+"511 84 OFFCURVE",
+"486 76 OFFCURVE",
+"438 76 CURVE SMOOTH",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 358 OFFCURVE",
+"491 377 OFFCURVE",
+"520 377 CURVE SMOOTH",
+"548 377 OFFCURVE",
+"568 358 OFFCURVE",
+"568 326 CURVE SMOOTH",
+"568 293 OFFCURVE",
+"548 274 OFFCURVE",
+"520 274 CURVE SMOOTH",
+"492 274 OFFCURVE",
+"471 293 OFFCURVE",
+"471 326 CURVE SMOOTH"
+);
+}
+);
+width = 659;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{625, -91}";
+}
+);
+hints = (
+{
+place = "{779, 96}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"764 0 LINE",
+"764 76 LINE",
+"748 76 OFFCURVE",
+"740 91 OFFCURVE",
+"717 134 CURVE",
+"429 693 LINE",
+"359 659 LINE",
+"659 76 LINE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"657 0 LINE",
+"675 46 LINE",
+"677 46 LINE",
+"779 -152 LINE",
+"779 -240 LINE",
+"875 -240 LINE",
+"875 -141 LINE",
+"829 -141 LINE",
+"756 0 LINE"
+);
+}
+);
+width = 764;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0714.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{625, -91}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRN.Fina;
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 456, 139}";
+}
+);
+layerId = UUID0;
+width = 764;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{433, -98}";
+}
+);
+hints = (
+{
+place = "{630, 71}";
+},
+{
+place = "{779, 96}";
+},
+{
+horizontal = 1;
+place = "{432, 59}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"657 0 LINE",
+"675 46 LINE",
+"677 46 LINE",
+"779 -152 LINE",
+"779 -240 LINE",
+"875 -240 LINE",
+"875 -141 LINE",
+"829 -141 LINE",
+"756 0 LINE",
+"764 0 LINE",
+"764 76 LINE",
+"748 76 OFFCURVE",
+"740 91 OFFCURVE",
+"717 134 CURVE SMOOTH",
+"561 436 LINE",
+"564 437 LINE",
+"575 433 OFFCURVE",
+"588 432 OFFCURVE",
+"597 432 CURVE SMOOTH",
+"664 432 OFFCURVE",
+"701 476 OFFCURVE",
+"701 540 CURVE SMOOTH",
+"701 569 OFFCURVE",
+"690 600 OFFCURVE",
+"674 632 CURVE SMOOTH",
+"642 693 LINE",
+"579 660 LINE",
+"612 598 LINE SMOOTH",
+"624 575 OFFCURVE",
+"630 554 OFFCURVE",
+"630 537 CURVE SMOOTH",
+"630 508 OFFCURVE",
+"608 491 OFFCURVE",
+"577 491 CURVE SMOOTH",
+"542 491 OFFCURVE",
+"525 508 OFFCURVE",
+"510 535 CURVE",
+"429 693 LINE",
+"359 659 LINE",
+"659 76 LINE"
+);
+}
+);
+width = 764;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0717.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{399, -98}";
+}
+);
+hints = (
+{
+place = "{68, 74}";
+},
+{
+place = "{409, 69}";
+},
+{
+place = "{619, 68}";
+},
+{
+place = "{619, 173}";
+},
+{
+horizontal = 1;
+place = "{-1, 75}";
+},
+{
+horizontal = 1;
+place = "{354, 72}";
+},
+{
+horizontal = 1;
+place = "{434, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-30, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"792 0 LINE",
+"792 76 LINE",
+"687 76 LINE",
+"687 434 LINE",
+"678 431 OFFCURVE",
+"651 429 OFFCURVE",
+"606 428 CURVE SMOOTH",
+"561 427 OFFCURVE",
+"514 426 OFFCURVE",
+"465 426 CURVE SMOOTH",
+"224 426 LINE SMOOTH",
+"177 426 OFFCURVE",
+"140 406 OFFCURVE",
+"111 366 CURVE SMOOTH",
+"82 327 OFFCURVE",
+"68 280 OFFCURVE",
+"68 226 CURVE SMOOTH",
+"68 159 OFFCURVE",
+"86 104 OFFCURVE",
+"122 62 CURVE SMOOTH",
+"159 20 OFFCURVE",
+"207 -1 OFFCURVE",
+"267 -1 CURVE SMOOTH",
+"338 -1 OFFCURVE",
+"390 20 OFFCURVE",
+"425 63 CURVE SMOOTH",
+"460 106 OFFCURVE",
+"478 182 OFFCURVE",
+"478 290 CURVE SMOOTH",
+"478 307 OFFCURVE",
+"475 333 OFFCURVE",
+"472 353 CURVE",
+"619 356 LINE",
+"619 -30 LINE",
+"687 -30 LINE",
+"687 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"403 353 LINE",
+"407 336 OFFCURVE",
+"409 312 OFFCURVE",
+"409 292 CURVE SMOOTH",
+"409 230 OFFCURVE",
+"404 185 OFFCURVE",
+"395 157 CURVE SMOOTH",
+"386 129 OFFCURVE",
+"372 108 OFFCURVE",
+"352 94 CURVE SMOOTH",
+"332 81 OFFCURVE",
+"306 74 OFFCURVE",
+"275 74 CURVE SMOOTH",
+"188 74 OFFCURVE",
+"142 129 OFFCURVE",
+"142 233 CURVE SMOOTH",
+"142 301 OFFCURVE",
+"181 353 OFFCURVE",
+"229 353 CURVE SMOOTH"
+);
+}
+);
+width = 792;
+}
+);
+rightKerningGroup = uni0717;
+},
+{
+color = 7;
+glyphname = uni071A.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{580, -98}";
+}
+);
+hints = (
+{
+place = "{404, 59}";
+},
+{
+place = "{620, 58}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{237, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-2, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"681 147 LINE",
+"683 147 LINE",
+"758 58 LINE SMOOTH",
+"793 17 OFFCURVE",
+"821 0 OFFCURVE",
+"860 0 CURVE",
+"860 76 LINE",
+"845 76 OFFCURVE",
+"827 85 OFFCURVE",
+"799 114 CURVE SMOOTH",
+"683 237 LINE",
+"623 237 LINE",
+"617 83 LINE",
+"608 90 OFFCURVE",
+"594 103 OFFCURVE",
+"579 119 CURVE SMOOTH",
+"556 142 LINE",
+"535 164 LINE",
+"468 237 LINE",
+"408 237 LINE",
+"400 76 LINE",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"460 0 LINE",
+"466 148 LINE",
+"468 148 LINE",
+"496 116 LINE SMOOTH",
+"543 63 OFFCURVE",
+"574 30 OFFCURVE",
+"591 17 CURVE SMOOTH",
+"608 4 OFFCURVE",
+"626 -2 OFFCURVE",
+"645 -2 CURVE SMOOTH",
+"656 -2 OFFCURVE",
+"668 -1 OFFCURVE",
+"676 0 CURVE"
+);
+}
+);
+width = 860;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071F.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{610, -68}";
+}
+);
+hints = (
+{
+place = "{434, 68}";
+},
+{
+place = "{434, 181}";
+},
+{
+horizontal = 1;
+place = "{-359, 69}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{269, 75}";
+},
+{
+horizontal = 1;
+place = "{396, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"434 106 LINE SMOOTH",
+"434 31 OFFCURVE",
+"469 0 OFFCURVE",
+"536 0 CURVE SMOOTH",
+"615 0 LINE",
+"615 76 LINE",
+"547 76 LINE SMOOTH",
+"511 76 OFFCURVE",
+"502 84 OFFCURVE",
+"502 121 CURVE SMOOTH",
+"502 396 LINE",
+"434 396 LINE",
+"434 350 LINE",
+"425 348 OFFCURVE",
+"398 346 OFFCURVE",
+"353 344 CURVE SMOOTH",
+"308 343 OFFCURVE",
+"261 342 OFFCURVE",
+"212 342 CURVE SMOOTH",
+"115 342 LINE",
+"68 230 LINE",
+"125 131 OFFCURVE",
+"195 31 OFFCURVE",
+"278 -72 CURVE SMOOTH",
+"361 -175 OFFCURVE",
+"423 -249 OFFCURVE",
+"464 -293 CURVE SMOOTH",
+"505 -337 OFFCURVE",
+"553 -359 OFFCURVE",
+"606 -359 CURVE SMOOTH",
+"615 -359 OFFCURVE",
+"641 -357 OFFCURVE",
+"661 -349 CURVE",
+"651 -286 LINE",
+"648 -287 OFFCURVE",
+"642 -289 OFFCURVE",
+"637 -289 CURVE SMOOTH",
+"622 -290 LINE",
+"580 -290 OFFCURVE",
+"542 -270 OFFCURVE",
+"508 -231 CURVE SMOOTH",
+"475 -192 OFFCURVE",
+"427 -135 OFFCURVE",
+"366 -60 CURVE SMOOTH",
+"305 14 OFFCURVE",
+"254 80 OFFCURVE",
+"214 138 CURVE SMOOTH",
+"174 196 OFFCURVE",
+"154 229 OFFCURVE",
+"154 238 CURVE SMOOTH",
+"154 246 OFFCURVE",
+"158 258 OFFCURVE",
+"166 269 CURVE",
+"209 269 LINE",
+"243 270 LINE SMOOTH",
+"256 270 OFFCURVE",
+"271 270 OFFCURVE",
+"287 271 CURVE SMOOTH",
+"334 272 LINE",
+"379 274 LINE SMOOTH",
+"407 275 OFFCURVE",
+"427 276 OFFCURVE",
+"434 279 CURVE"
+);
+}
+);
+width = 615;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074E.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{392, -98}";
+}
+);
+hints = (
+{
+place = "{490, 75}";
+},
+{
+place = "{634, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{654, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"645 0 LINE",
+"662 46 LINE",
+"664 46 LINE",
+"688 13 OFFCURVE",
+"724 0 OFFCURVE",
+"772 0 CURVE SMOOTH",
+"812 0 LINE",
+"812 76 LINE",
+"778 76 LINE",
+"719 78 OFFCURVE",
+"713 94 OFFCURVE",
+"708 170 CURVE",
+"708 426 LINE",
+"600 426 LINE SMOOTH",
+"577 426 OFFCURVE",
+"555 425 OFFCURVE",
+"532 424 CURVE",
+"530 427 LINE",
+"553 442 OFFCURVE",
+"565 472 OFFCURVE",
+"565 505 CURVE SMOOTH",
+"565 562 OFFCURVE",
+"531 601 OFFCURVE",
+"451 629 CURVE SMOOTH",
+"376 654 LINE",
+"354 586 LINE",
+"421 564 LINE SMOOTH",
+"469 548 OFFCURVE",
+"490 531 OFFCURVE",
+"490 491 CURVE SMOOTH",
+"490 450 OFFCURVE",
+"471 427 OFFCURVE",
+"411 427 CURVE SMOOTH",
+"402 427 OFFCURVE",
+"384 427 OFFCURVE",
+"364 430 CURVE",
+"334 432 LINE SMOOTH",
+"323 433 OFFCURVE",
+"314 435 OFFCURVE",
+"307 436 CURVE",
+"307 364 LINE",
+"330 359 OFFCURVE",
+"400 353 OFFCURVE",
+"489 353 CURVE SMOOTH",
+"634 353 LINE",
+"634 164 LINE SMOOTH",
+"634 128 OFFCURVE",
+"638 99 OFFCURVE",
+"647 76 CURVE"
+);
+}
+);
+width = 812;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0720.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{396, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"658 0 LINE",
+"676 45 LINE",
+"678 45 LINE",
+"698 18 OFFCURVE",
+"722 0 OFFCURVE",
+"758 0 CURVE SMOOTH",
+"765 0 LINE",
+"765 76 LINE",
+"754 76 OFFCURVE",
+"744 85 OFFCURVE",
+"734 103 CURVE SMOOTH",
+"725 121 OFFCURVE",
+"719 131 OFFCURVE",
+"717 134 CURVE SMOOTH",
+"429 693 LINE",
+"358 659 LINE",
+"659 76 LINE"
+);
+}
+);
+width = 765;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0721.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{436, -99}";
+}
+);
+hints = (
+{
+place = "{563, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{-159, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"198 -159 LINE",
+"246 0 LINE",
+"563 0 LINE",
+"581 45 LINE",
+"583 45 LINE",
+"600 16 OFFCURVE",
+"631 0 OFFCURVE",
+"680 0 CURVE SMOOTH",
+"741 0 LINE",
+"741 76 LINE",
+"691 76 LINE SMOOTH",
+"647 76 OFFCURVE",
+"636 88 OFFCURVE",
+"636 135 CURVE SMOOTH",
+"636 426 LINE",
+"271 426 LINE SMOOTH",
+"230 426 OFFCURVE",
+"186 427 OFFCURVE",
+"137 430 CURVE SMOOTH",
+"89 433 OFFCURVE",
+"60 436 OFFCURVE",
+"49 438 CURVE",
+"49 367 LINE",
+"60 364 OFFCURVE",
+"90 360 OFFCURVE",
+"137 357 CURVE SMOOTH",
+"185 354 OFFCURVE",
+"231 353 OFFCURVE",
+"274 353 CURVE SMOOTH",
+"282 353 LINE",
+"132 -139 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"269 76 LINE",
+"354 353 LINE",
+"563 353 LINE",
+"563 128 LINE SMOOTH",
+"563 108 OFFCURVE",
+"565 91 OFFCURVE",
+"569 76 CURVE"
+);
+}
+);
+width = 741;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0722.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{151, -444}";
+}
+);
+hints = (
+{
+place = "{49, 71}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{126, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-392, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"70 126 LINE",
+"58 93 OFFCURVE",
+"49 35 OFFCURVE",
+"49 -1 CURVE SMOOTH",
+"49 -145 OFFCURVE",
+"107 -281 OFFCURVE",
+"222 -392 CURVE",
+"272 -351 LINE",
+"213 -278 OFFCURVE",
+"173 -214 OFFCURVE",
+"152 -159 CURVE SMOOTH",
+"131 -105 OFFCURVE",
+"120 -49 OFFCURVE",
+"120 8 CURVE SMOOTH",
+"120 21 LINE SMOOTH",
+"120 27 OFFCURVE",
+"121 34 OFFCURVE",
+"122 41 CURVE",
+"126 41 LINE",
+"157 17 OFFCURVE",
+"202 0 OFFCURVE",
+"266 0 CURVE",
+"266 76 LINE",
+"202 76 OFFCURVE",
+"165 93 OFFCURVE",
+"130 126 CURVE"
+);
+}
+);
+width = 266;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0726.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{645, -81}";
+}
+);
+hints = (
+{
+place = "{225, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{199, 71}";
+},
+{
+horizontal = 1;
+place = "{589, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"591 0 LINE",
+"610 47 LINE",
+"612 47 LINE",
+"628 20 OFFCURVE",
+"654 0 OFFCURVE",
+"705 0 CURVE SMOOTH",
+"723 0 LINE",
+"723 76 LINE",
+"705 76 LINE SMOOTH",
+"674 76 OFFCURVE",
+"670 110 OFFCURVE",
+"663 137 CURVE SMOOTH",
+"541 589 LINE",
+"469 565 LINE",
+"310 538 OFFCURVE",
+"225 464 OFFCURVE",
+"225 359 CURVE SMOOTH",
+"225 260 OFFCURVE",
+"294 199 OFFCURVE",
+"407 199 CURVE SMOOTH",
+"566 199 LINE",
+"600 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 270 LINE",
+"341 270 OFFCURVE",
+"304 300 OFFCURVE",
+"304 367 CURVE SMOOTH",
+"304 434 OFFCURVE",
+"365 477 OFFCURVE",
+"488 494 CURVE",
+"547 270 LINE"
+);
+}
+);
+width = 723;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0729.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{483, -99}";
+}
+);
+hints = (
+{
+place = "{392, 73}";
+},
+{
+place = "{743, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"392 0 LINE",
+"409 46 LINE",
+"411 46 LINE",
+"430 17 OFFCURVE",
+"460 0 OFFCURVE",
+"508 0 CURVE SMOOTH",
+"743 0 LINE",
+"760 46 LINE",
+"762 46 LINE",
+"779 17 OFFCURVE",
+"811 0 OFFCURVE",
+"859 0 CURVE SMOOTH",
+"921 0 LINE",
+"921 76 LINE",
+"871 76 LINE SMOOTH",
+"826 76 OFFCURVE",
+"816 88 OFFCURVE",
+"816 135 CURVE SMOOTH",
+"816 438 LINE",
+"791 433 OFFCURVE",
+"723 426 OFFCURVE",
+"663 426 CURVE SMOOTH",
+"545 426 LINE SMOOTH",
+"485 426 OFFCURVE",
+"417 433 OFFCURVE",
+"392 438 CURVE",
+"392 128 LINE SMOOTH",
+"392 108 OFFCURVE",
+"394 91 OFFCURVE",
+"398 76 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"520 76 LINE",
+"473 76 OFFCURVE",
+"465 90 OFFCURVE",
+"465 135 CURVE SMOOTH",
+"465 357 LINE",
+"494 354 OFFCURVE",
+"526 353 OFFCURVE",
+"550 353 CURVE SMOOTH",
+"658 353 LINE SMOOTH",
+"682 353 OFFCURVE",
+"714 353 OFFCURVE",
+"743 357 CURVE",
+"743 128 LINE SMOOTH",
+"743 108 OFFCURVE",
+"745 91 OFFCURVE",
+"749 76 CURVE"
+);
+}
+);
+width = 921;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0727.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{420, -98}";
+}
+);
+hints = (
+{
+place = "{249, 74}";
+},
+{
+place = "{340, 82}";
+},
+{
+place = "{402, 59}";
+},
+{
+place = "{525, 81}";
+},
+{
+place = "{597, 70}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{189, 66}";
+},
+{
+horizontal = 1;
+place = "{423, 74}";
+},
+{
+horizontal = 1;
+place = "{585, 86}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"734 0 LINE",
+"734 76 LINE",
+"645 76 LINE SMOOTH",
+"440 76 OFFCURVE",
+"323 148 OFFCURVE",
+"323 285 CURVE SMOOTH",
+"323 326 OFFCURVE",
+"337 360 OFFCURVE",
+"366 385 CURVE SMOOTH",
+"395 410 OFFCURVE",
+"430 423 OFFCURVE",
+"473 423 CURVE SMOOTH",
+"545 423 OFFCURVE",
+"597 388 OFFCURVE",
+"597 333 CURVE SMOOTH",
+"597 285 OFFCURVE",
+"572 255 OFFCURVE",
+"525 255 CURVE SMOOTH",
+"488 255 OFFCURVE",
+"461 279 OFFCURVE",
+"461 319 CURVE",
+"402 319 LINE",
+"402 310 LINE SMOOTH",
+"402 234 OFFCURVE",
+"449 189 OFFCURVE",
+"525 189 CURVE SMOOTH",
+"617 189 OFFCURVE",
+"667 246 OFFCURVE",
+"667 339 CURVE SMOOTH",
+"667 384 OFFCURVE",
+"648 422 OFFCURVE",
+"611 452 CURVE SMOOTH",
+"574 482 OFFCURVE",
+"528 497 OFFCURVE",
+"473 497 CURVE SMOOTH",
+"408 497 OFFCURVE",
+"355 477 OFFCURVE",
+"312 436 CURVE SMOOTH",
+"270 396 OFFCURVE",
+"249 345 OFFCURVE",
+"249 282 CURVE SMOOTH",
+"249 191 OFFCURVE",
+"288 120 OFFCURVE",
+"356 77 CURVE",
+"355 74 LINE",
+"332 75 OFFCURVE",
+"308 76 OFFCURVE",
+"287 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 585 LINE",
+"422 585 LINE",
+"422 671 LINE",
+"340 671 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 585 LINE",
+"606 585 LINE",
+"606 671 LINE",
+"525 671 LINE"
+);
+}
+);
+width = 734;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072A.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{258, -98}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 249, 505}";
+},
+{
+name = uni0716.loclSYRN.Fina;
+}
+);
+layerId = UUID0;
+width = 518;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni0728.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{262, -443}";
+}
+);
+hints = (
+{
+place = "{83, 63}";
+},
+{
+horizontal = 1;
+place = "{-381, 68}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{0, 193}";
+},
+{
+horizontal = 1;
+place = "{194, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"69 -313 LINE",
+"69 -381 LINE",
+"445 -381 LINE",
+"459 -322 LINE",
+"256 -221 OFFCURVE",
+"146 -72 OFFCURVE",
+"146 92 CURVE",
+"143 111 LINE",
+"146 112 LINE",
+"167 44 OFFCURVE",
+"222 0 OFFCURVE",
+"290 0 CURVE SMOOTH",
+"363 0 OFFCURVE",
+"407 30 OFFCURVE",
+"434 103 CURVE",
+"446 79 LINE",
+"470 24 OFFCURVE",
+"503 0 OFFCURVE",
+"556 0 CURVE",
+"556 76 LINE",
+"531 76 OFFCURVE",
+"512 97 OFFCURVE",
+"496 136 CURVE SMOOTH",
+"473 193 LINE",
+"414 193 LINE",
+"393 110 OFFCURVE",
+"355 76 OFFCURVE",
+"295 76 CURVE SMOOTH",
+"262 76 OFFCURVE",
+"233 88 OFFCURVE",
+"209 113 CURVE SMOOTH",
+"185 138 OFFCURVE",
+"170 165 OFFCURVE",
+"165 194 CURVE",
+"101 192 LINE",
+"86 148 OFFCURVE",
+"83 107 OFFCURVE",
+"83 62 CURVE SMOOTH",
+"83 -20 OFFCURVE",
+"107 -97 OFFCURVE",
+"155 -168 CURVE SMOOTH",
+"203 -239 OFFCURVE",
+"264 -290 OFFCURVE",
+"338 -319 CURVE",
+"337 -323 LINE",
+"280 -316 OFFCURVE",
+"226 -313 OFFCURVE",
+"183 -313 CURVE SMOOTH"
+);
+}
+);
+width = 556;
+}
+);
+rightKerningGroup = uni0728;
+},
+{
+color = 7;
+glyphname = uni0723.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{591, -98}";
+}
+);
+hints = (
+{
+place = "{293, 75}";
+},
+{
+place = "{578, 69}";
+},
+{
+place = "{856, 75}";
+},
+{
+place = "{856, 138}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{317, 75}";
+},
+{
+horizontal = 1;
+place = "{405, 71}";
+},
+{
+horizontal = 1;
+place = "{-2, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"465 0 LINE",
+"506 28 LINE",
+"559 9 OFFCURVE",
+"617 -2 OFFCURVE",
+"677 -2 CURVE SMOOTH",
+"748 -2 OFFCURVE",
+"808 13 OFFCURVE",
+"852 46 CURVE",
+"856 46 LINE",
+"881 18 OFFCURVE",
+"930 0 OFFCURVE",
+"994 0 CURVE",
+"994 76 LINE",
+"950 76 OFFCURVE",
+"919 84 OFFCURVE",
+"900 101 CURVE",
+"920 134 OFFCURVE",
+"931 178 OFFCURVE",
+"931 231 CURVE SMOOTH",
+"931 278 OFFCURVE",
+"916 317 OFFCURVE",
+"885 347 CURVE SMOOTH",
+"854 377 OFFCURVE",
+"817 392 OFFCURVE",
+"773 392 CURVE SMOOTH",
+"717 392 OFFCURVE",
+"680 375 OFFCURVE",
+"651 340 CURVE",
+"647 341 LINE",
+"646 425 OFFCURVE",
+"578 476 OFFCURVE",
+"475 476 CURVE SMOOTH",
+"426 476 OFFCURVE",
+"383 457 OFFCURVE",
+"347 418 CURVE SMOOTH",
+"311 379 OFFCURVE",
+"293 334 OFFCURVE",
+"293 283 CURVE SMOOTH",
+"293 187 OFFCURVE",
+"333 121 OFFCURVE",
+"414 74 CURVE",
+"411 71 LINE",
+"388 73 LINE",
+"316 75 LINE",
+"296 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 109 OFFCURVE",
+"603 153 OFFCURVE",
+"642 218 CURVE SMOOTH",
+"681 284 OFFCURVE",
+"722 317 OFFCURVE",
+"765 317 CURVE SMOOTH",
+"821 317 OFFCURVE",
+"856 281 OFFCURVE",
+"856 225 CURVE SMOOTH",
+"856 128 OFFCURVE",
+"792 70 OFFCURVE",
+"687 70 CURVE SMOOTH",
+"636 70 OFFCURVE",
+"597 76 OFFCURVE",
+"560 88 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"408 146 OFFCURVE",
+"368 206 OFFCURVE",
+"368 286 CURVE SMOOTH",
+"368 355 OFFCURVE",
+"417 405 OFFCURVE",
+"482 405 CURVE SMOOTH",
+"542 405 OFFCURVE",
+"578 371 OFFCURVE",
+"578 314 CURVE SMOOTH",
+"578 273 OFFCURVE",
+"568 234 OFFCURVE",
+"549 197 CURVE SMOOTH",
+"530 161 OFFCURVE",
+"512 132 OFFCURVE",
+"495 111 CURVE"
+);
+}
+);
+width = 994;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0724.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{441, -98}";
+}
+);
+hints = (
+{
+place = "{70, 75}";
+},
+{
+place = "{355, 65}";
+},
+{
+place = "{630, 75}";
+},
+{
+place = "{630, 135}";
+},
+{
+horizontal = 1;
+place = "{-2, 72}";
+},
+{
+horizontal = 1;
+place = "{319, 75}";
+},
+{
+horizontal = 1;
+place = "{405, 71}";
+},
+{
+horizontal = 1;
+place = "{-136, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"630 46 LINE",
+"654 18 OFFCURVE",
+"704 0 OFFCURVE",
+"765 0 CURVE",
+"765 76 LINE",
+"724 76 OFFCURVE",
+"691 84 OFFCURVE",
+"674 101 CURVE",
+"694 134 OFFCURVE",
+"705 178 OFFCURVE",
+"705 231 CURVE SMOOTH",
+"705 278 OFFCURVE",
+"689 316 OFFCURVE",
+"657 347 CURVE SMOOTH",
+"626 378 OFFCURVE",
+"588 394 OFFCURVE",
+"544 394 CURVE SMOOTH",
+"504 394 OFFCURVE",
+"464 378 OFFCURVE",
+"424 334 CURVE",
+"420 336 LINE",
+"420 420 OFFCURVE",
+"356 476 OFFCURVE",
+"253 476 CURVE SMOOTH",
+"204 476 OFFCURVE",
+"161 457 OFFCURVE",
+"124 418 CURVE SMOOTH",
+"88 380 OFFCURVE",
+"70 335 OFFCURVE",
+"70 284 CURVE SMOOTH",
+"70 175 OFFCURVE",
+"135 87 OFFCURVE",
+"247 38 CURVE",
+"174 -107 LINE",
+"231 -136 LINE",
+"312 16 LINE",
+"356 4 OFFCURVE",
+"403 -2 OFFCURVE",
+"451 -2 CURVE SMOOTH",
+"522 -2 OFFCURVE",
+"582 13 OFFCURVE",
+"626 46 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 108 LINE",
+"192 144 OFFCURVE",
+"145 208 OFFCURVE",
+"145 287 CURVE SMOOTH",
+"145 355 OFFCURVE",
+"194 405 OFFCURVE",
+"261 405 CURVE SMOOTH",
+"318 405 OFFCURVE",
+"355 367 OFFCURVE",
+"355 310 CURVE SMOOTH",
+"355 271 OFFCURVE",
+"345 239 OFFCURVE",
+"325 198 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"388 171 LINE",
+"437 276 OFFCURVE",
+"477 319 OFFCURVE",
+"536 319 CURVE SMOOTH",
+"592 319 OFFCURVE",
+"630 281 OFFCURVE",
+"630 225 CURVE SMOOTH",
+"630 128 OFFCURVE",
+"566 70 OFFCURVE",
+"461 70 CURVE SMOOTH",
+"422 70 OFFCURVE",
+"386 75 OFFCURVE",
+"347 86 CURVE"
+);
+}
+);
+width = 765;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072B.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{470, -98}";
+}
+);
+hints = (
+{
+place = "{605, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{340, 74}";
+},
+{
+horizontal = 1;
+place = "{440, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"615 0 LINE",
+"633 46 LINE",
+"635 46 LINE",
+"658 13 OFFCURVE",
+"695 0 OFFCURVE",
+"743 0 CURVE SMOOTH",
+"924 0 LINE",
+"924 76 LINE",
+"749 76 LINE",
+"688 78 OFFCURVE",
+"683 94 OFFCURVE",
+"678 170 CURVE",
+"678 340 LINE",
+"714 341 OFFCURVE",
+"749 344 OFFCURVE",
+"784 349 CURVE SMOOTH",
+"819 354 OFFCURVE",
+"844 361 OFFCURVE",
+"858 369 CURVE",
+"844 440 LINE",
+"816 428 OFFCURVE",
+"747 414 OFFCURVE",
+"642 414 CURVE SMOOTH",
+"535 414 OFFCURVE",
+"467 428 OFFCURVE",
+"439 440 CURVE",
+"425 369 LINE",
+"439 361 OFFCURVE",
+"463 354 OFFCURVE",
+"498 349 CURVE SMOOTH",
+"533 344 OFFCURVE",
+"569 341 OFFCURVE",
+"605 340 CURVE",
+"605 164 LINE SMOOTH",
+"605 128 OFFCURVE",
+"609 99 OFFCURVE",
+"618 76 CURVE"
+);
+}
+);
+width = 924;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072C.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{547, -79}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 112}";
+},
+{
+horizontal = 1;
+place = "{36, 76}";
+},
+{
+horizontal = 1;
+place = "{543, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-2, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"288 543 LINE",
+"230 540 LINE",
+"199 475 OFFCURVE",
+"164 394 OFFCURVE",
+"125 297 CURVE SMOOTH",
+"87 200 OFFCURVE",
+"68 127 OFFCURVE",
+"68 80 CURVE SMOOTH",
+"68 28 OFFCURVE",
+"94 0 OFFCURVE",
+"137 0 CURVE SMOOTH",
+"152 0 OFFCURVE",
+"173 6 OFFCURVE",
+"199 18 CURVE SMOOTH",
+"226 30 OFFCURVE",
+"250 36 OFFCURVE",
+"271 36 CURVE SMOOTH",
+"314 36 OFFCURVE",
+"336 22 OFFCURVE",
+"349 -2 CURVE",
+"430 0 LINE",
+"413 75 OFFCURVE",
+"359 112 OFFCURVE",
+"268 112 CURVE SMOOTH",
+"233 112 OFFCURVE",
+"187 96 OFFCURVE",
+"147 69 CURVE",
+"146 72 OFFCURVE",
+"143 76 OFFCURVE",
+"143 81 CURVE SMOOTH",
+"142 92 LINE",
+"142 120 OFFCURVE",
+"154 167 OFFCURVE",
+"177 232 CURVE SMOOTH",
+"201 297 OFFCURVE",
+"230 368 OFFCURVE",
+"264 444 CURVE",
+"543 48 LINE SMOOTH",
+"564 19 OFFCURVE",
+"592 0 OFFCURVE",
+"625 0 CURVE",
+"625 76 LINE",
+"618 76 OFFCURVE",
+"613 81 OFFCURVE",
+"608 88 CURVE SMOOTH"
+);
+}
+);
+width = 625;
+}
+);
+rightKerningGroup = uni072C;
+},
+{
+color = 7;
+glyphname = uni071B.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{433, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-285, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"1056 -3 LINE",
+"1056 76 LINE",
+"746 76 LINE",
+"429 693 LINE",
+"358 659 LINE",
+"659 76 LINE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"698 0 LINE",
+"845 -285 LINE",
+"875 -285 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"785 0 LINE",
+"1002 0 LINE",
+"881 -188 LINE"
+);
+}
+);
+width = 1002;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071C.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{433, -98}";
+}
+);
+hints = (
+{
+place = "{842, 77}";
+},
+{
+horizontal = 1;
+place = "{-120, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-300, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"1071 -3 LINE",
+"1071 76 LINE",
+"746 76 LINE",
+"429 693 LINE",
+"358 659 LINE",
+"659 76 LINE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"698 0 LINE",
+"852 -300 LINE",
+"882 -300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"852 -207 OFFCURVE",
+"828 -174 OFFCURVE",
+"804 -129 CURVE SMOOTH",
+"780 -84 OFFCURVE",
+"768 -41 OFFCURVE",
+"768 0 CURVE",
+"1019 0 LINE",
+"1002 -43 OFFCURVE",
+"978 -89 OFFCURVE",
+"946 -136 CURVE SMOOTH",
+"915 -183 OFFCURVE",
+"891 -214 OFFCURVE",
+"875 -227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"842 -120 LINE",
+"919 -120 LINE",
+"919 -41 LINE",
+"842 -41 LINE"
+);
+}
+);
+width = 1017;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0718.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{289, -98}";
+}
+);
+hints = (
+{
+place = "{68, 74}";
+},
+{
+place = "{436, 73}";
+},
+{
+horizontal = 1;
+place = "{-5, 72}";
+},
+{
+horizontal = 1;
+place = "{378, 73}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"573 76 LINE",
+"540 76 OFFCURVE",
+"503 97 OFFCURVE",
+"499 132 CURVE",
+"506 155 OFFCURVE",
+"509 180 OFFCURVE",
+"509 208 CURVE SMOOTH",
+"509 280 OFFCURVE",
+"489 338 OFFCURVE",
+"450 383 CURVE SMOOTH",
+"411 428 OFFCURVE",
+"359 451 OFFCURVE",
+"292 451 CURVE SMOOTH",
+"225 451 OFFCURVE",
+"170 428 OFFCURVE",
+"129 382 CURVE SMOOTH",
+"88 337 OFFCURVE",
+"68 279 OFFCURVE",
+"68 208 CURVE SMOOTH",
+"68 73 OFFCURVE",
+"149 -5 OFFCURVE",
+"289 -5 CURVE SMOOTH",
+"364 -5 OFFCURVE",
+"417 16 OFFCURVE",
+"454 55 CURVE",
+"458 55 LINE",
+"477 18 OFFCURVE",
+"518 0 OFFCURVE",
+"573 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"436 118 OFFCURVE",
+"390 67 OFFCURVE",
+"289 67 CURVE SMOOTH",
+"185 67 OFFCURVE",
+"142 118 OFFCURVE",
+"142 209 CURVE SMOOTH",
+"142 312 OFFCURVE",
+"198 378 OFFCURVE",
+"289 378 CURVE SMOOTH",
+"380 378 OFFCURVE",
+"436 312 OFFCURVE",
+"436 209 CURVE SMOOTH"
+);
+}
+);
+width = 573;
+}
+);
+rightKerningGroup = uni0718;
+},
+{
+color = 7;
+glyphname = uni071D.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{492, -98}";
+}
+);
+hints = (
+{
+place = "{414, 57}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{228, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"470 0 LINE",
+"472 132 LINE",
+"474 132 LINE",
+"554 51 LINE SMOOTH",
+"585 19 OFFCURVE",
+"614 0 OFFCURVE",
+"654 0 CURVE",
+"654 76 LINE",
+"641 76 OFFCURVE",
+"621 83 OFFCURVE",
+"593 108 CURVE",
+"468 228 LINE",
+"417 228 LINE",
+"411 76 LINE",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH"
+);
+}
+);
+width = 654;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0719.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{167, -173}";
+}
+);
+hints = (
+{
+place = "{83, 129}";
+},
+{
+place = "{156, 56}";
+},
+{
+place = "{156, 161}";
+},
+{
+place = "{83, 142}";
+},
+{
+horizontal = 1;
+place = "{-78, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{375, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"154 -63 LINE",
+"209 -78 LINE",
+"216 10 LINE",
+"245 2 OFFCURVE",
+"279 0 OFFCURVE",
+"295 0 CURVE SMOOTH",
+"317 0 LINE",
+"317 76 LINE",
+"295 76 LINE SMOOTH",
+"270 76 OFFCURVE",
+"244 79 OFFCURVE",
+"221 84 CURVE",
+"224 131 OFFCURVE",
+"225 178 OFFCURVE",
+"225 238 CURVE SMOOTH",
+"225 337 OFFCURVE",
+"205 375 OFFCURVE",
+"157 375 CURVE SMOOTH",
+"110 375 OFFCURVE",
+"83 331 OFFCURVE",
+"83 230 CURVE SMOOTH",
+"83 135 OFFCURVE",
+"104 67 OFFCURVE",
+"159 26 CURVE"
+);
+}
+);
+width = 317;
+}
+);
+rightKerningGroup = uni0719;
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ.Fina1;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{109, -195}";
+},
+{
+name = top;
+position = "{137, 735}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"137 682 LINE",
+"146 682 LINE",
+"137 735 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 674 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"144 -67 OFFCURVE",
+"157 -25 OFFCURVE",
+"165 30 CURVE",
+"167 30 LINE",
+"186 9 OFFCURVE",
+"218 0 OFFCURVE",
+"269 0 CURVE",
+"269 76 LINE",
+"237 76 OFFCURVE",
+"172 76 OFFCURVE",
+"170 111 CURVE",
+"170 122 OFFCURVE",
+"171 131 OFFCURVE",
+"171 142 CURVE SMOOTH",
+"171 674 LINE"
+);
+}
+);
+width = 269;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.Fina1;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{172, -141}";
+}
+);
+hints = (
+{
+place = "{193, 72}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-67, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{601, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"171 497 LINE",
+"184 481 OFFCURVE",
+"193 446 OFFCURVE",
+"193 403 CURVE SMOOTH",
+"193 298 OFFCURVE",
+"159 199 OFFCURVE",
+"83 76 CURVE",
+"59 76 LINE",
+"59 6 LINE",
+"72 0 LINE",
+"130 -67 LINE",
+"141 -67 LINE",
+"142 0 LINE",
+"356 0 LINE",
+"356 76 LINE",
+"238 76 LINE SMOOTH",
+"212 76 OFFCURVE",
+"186 75 OFFCURVE",
+"161 74 CURVE",
+"161 78 LINE",
+"165 86 OFFCURVE",
+"171 96 OFFCURVE",
+"178 107 CURVE SMOOTH",
+"187 123 LINE SMOOTH",
+"238 215 OFFCURVE",
+"265 309 OFFCURVE",
+"265 408 CURVE SMOOTH",
+"265 543 OFFCURVE",
+"221 593 OFFCURVE",
+"133 601 CURVE",
+"98 530 LINE"
+);
+}
+);
+width = 356;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.Fina1N;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{157, -153}";
+}
+);
+hints = (
+{
+place = "{191, 72}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-67, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{601, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"168 497 LINE",
+"181 481 OFFCURVE",
+"191 446 OFFCURVE",
+"191 403 CURVE SMOOTH",
+"191 298 OFFCURVE",
+"156 199 OFFCURVE",
+"81 76 CURVE",
+"56 76 LINE",
+"56 6 LINE",
+"70 0 LINE",
+"128 -67 LINE",
+"138 -67 LINE",
+"140 0 LINE",
+"356 0 LINE",
+"356 76 LINE",
+"160 76 LINE",
+"228 191 OFFCURVE",
+"263 304 OFFCURVE",
+"263 408 CURVE SMOOTH",
+"263 543 OFFCURVE",
+"219 593 OFFCURVE",
+"130 601 CURVE",
+"96 530 LINE"
+);
+}
+);
+width = 356;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ.Fina2;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{109, -195}";
+},
+{
+name = top;
+position = "{137, 735}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 674 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"158 -50 OFFCURVE",
+"171 31 OFFCURVE",
+"171 142 CURVE SMOOTH",
+"171 674 LINE"
+);
+}
+);
+width = 269;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.Fina2;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{184, -141}";
+}
+);
+hints = (
+{
+place = "{193, 72}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-67, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{601, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"171 497 LINE",
+"184 481 OFFCURVE",
+"193 446 OFFCURVE",
+"193 403 CURVE SMOOTH",
+"193 298 OFFCURVE",
+"159 199 OFFCURVE",
+"83 76 CURVE",
+"59 76 LINE",
+"59 6 LINE",
+"72 0 LINE",
+"130 -67 LINE",
+"141 -67 LINE",
+"142 0 LINE",
+"312 0 LINE",
+"312 76 LINE",
+"238 76 LINE SMOOTH",
+"212 76 OFFCURVE",
+"186 75 OFFCURVE",
+"161 74 CURVE",
+"161 78 LINE",
+"165 86 OFFCURVE",
+"171 96 OFFCURVE",
+"178 107 CURVE SMOOTH",
+"187 123 LINE SMOOTH",
+"238 215 OFFCURVE",
+"265 309 OFFCURVE",
+"265 408 CURVE SMOOTH",
+"265 543 OFFCURVE",
+"221 593 OFFCURVE",
+"133 601 CURVE",
+"98 530 LINE"
+);
+}
+);
+width = 370;
+}
+);
+leftKerningGroup = uni0710;
+rightKerningGroup = uni0710;
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ.Fina3;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{109, -195}";
+},
+{
+name = top;
+position = "{137, 735}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 674 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"158 -50 OFFCURVE",
+"171 31 OFFCURVE",
+"171 142 CURVE SMOOTH",
+"171 674 LINE"
+);
+}
+);
+width = 269;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.Fina3;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{183, -98}";
+}
+);
+components = (
+{
+name = uni0710.loclSYRN;
+}
+);
+layerId = UUID0;
+width = 371;
+}
+);
+leftKerningGroup = uni0710;
+rightKerningGroup = uni0710;
+},
+{
+color = 5;
+glyphname = uni0728.loclSYRJ.FinaAlt;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{134, -443}";
+},
+{
+name = top;
+position = "{147, 365}";
+}
+);
+components = (
+{
+name = uni0728.loclSYRJ.Fina;
+transform = "{1, 0, 0, 1, 20, 0}";
+}
+);
+layerId = UUID0;
+width = 280;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.FinaG;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{128, -412}";
+},
+{
+name = top;
+position = "{130, 268}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"157 0 LINE",
+"157 76 LINE",
+"154 76 LINE SMOOTH",
+"92 76 OFFCURVE",
+"68 39 OFFCURVE",
+"68 -20 CURVE SMOOTH",
+"68 -123 OFFCURVE",
+"149 -281 OFFCURVE",
+"273 -399 CURVE",
+"331 -353 LINE",
+"184 -195 OFFCURVE",
+"144 -75 OFFCURVE",
+"144 -9 CURVE SMOOTH",
+"144 -8 OFFCURVE",
+"144 -2 OFFCURVE",
+"145 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"157 0 LINE",
+"157 76 LINE",
+"154 76 LINE SMOOTH",
+"92 76 OFFCURVE",
+"68 39 OFFCURVE",
+"68 -20 CURVE SMOOTH",
+"68 -123 OFFCURVE",
+"149 -281 OFFCURVE",
+"273 -399 CURVE",
+"331 -353 LINE",
+"184 -195 OFFCURVE",
+"144 -75 OFFCURVE",
+"144 -9 CURVE SMOOTH",
+"144 -8 OFFCURVE",
+"144 -2 OFFCURVE",
+"145 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 -367 LINE",
+"305 -249 OFFCURVE",
+"168 -63 OFFCURVE",
+"107 25 CURVE",
+"114 29 LINE",
+"145 4 OFFCURVE",
+"193 0 OFFCURVE",
+"242 0 CURVE",
+"242 76 LINE",
+"193 76 OFFCURVE",
+"186 77 OFFCURVE",
+"170 83 CURVE SMOOTH",
+"163 86 OFFCURVE",
+"148 92 OFFCURVE",
+"120 119 CURVE SMOOTH",
+"100 139 OFFCURVE",
+"88 143 OFFCURVE",
+"69 143 CURVE SMOOTH",
+"35 143 OFFCURVE",
+"20 108 OFFCURVE",
+"20 70 CURVE SMOOTH",
+"20 45 OFFCURVE",
+"32 7 OFFCURVE",
+"52 -23 CURVE SMOOTH",
+"121 -125 OFFCURVE",
+"258 -301 OFFCURVE",
+"351 -405 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"406 -367 LINE",
+"305 -249 OFFCURVE",
+"168 -63 OFFCURVE",
+"107 25 CURVE",
+"114 29 LINE",
+"140 6 OFFCURVE",
+"163 0 OFFCURVE",
+"188 0 CURVE",
+"188 76 LINE",
+"171 76 OFFCURVE",
+"151 82 OFFCURVE",
+"117 116 CURVE SMOOTH",
+"97 136 OFFCURVE",
+"85 141 OFFCURVE",
+"66 141 CURVE SMOOTH",
+"35 141 OFFCURVE",
+"19 110 OFFCURVE",
+"19 72 CURVE SMOOTH",
+"19 47 OFFCURVE",
+"32 7 OFFCURVE",
+"52 -23 CURVE SMOOTH",
+"121 -125 OFFCURVE",
+"258 -301 OFFCURVE",
+"351 -405 CURVE"
+);
+}
+);
+width = 188;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ.FinaLiga;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{109, -195}";
+},
+{
+name = top;
+position = "{137, 735}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"98 674 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"145 -65 OFFCURVE",
+"158 -22 OFFCURVE",
+"166 35 CURVE",
+"168 35 LINE",
+"184 9 OFFCURVE",
+"210 -5 OFFCURVE",
+"255 -5 CURVE SMOOTH",
+"272 -5 OFFCURVE",
+"294 3 OFFCURVE",
+"294 32 CURVE SMOOTH",
+"294 46 OFFCURVE",
+"286 71 OFFCURVE",
+"247 71 CURVE SMOOTH",
+"194 71 OFFCURVE",
+"171 103 OFFCURVE",
+"171 143 CURVE SMOOTH",
+"171 674 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 674 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"145 -65 OFFCURVE",
+"158 -22 OFFCURVE",
+"166 35 CURVE",
+"168 35 LINE",
+"184 9 OFFCURVE",
+"210 -5 OFFCURVE",
+"255 -5 CURVE SMOOTH",
+"272 -5 OFFCURVE",
+"294 3 OFFCURVE",
+"294 32 CURVE SMOOTH",
+"294 46 OFFCURVE",
+"286 71 OFFCURVE",
+"247 71 CURVE SMOOTH",
+"194 71 OFFCURVE",
+"171 103 OFFCURVE",
+"171 143 CURVE SMOOTH",
+"171 674 LINE"
+);
+}
+);
+width = 247;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.FinaLiga;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{192, -141}";
+}
+);
+hints = (
+{
+place = "{213, 75}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{601, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-63, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"403 76 LINE",
+"198 76 LINE",
+"251 180 OFFCURVE",
+"288 289 OFFCURVE",
+"288 408 CURVE SMOOTH",
+"288 536 OFFCURVE",
+"242 593 OFFCURVE",
+"150 601 CURVE",
+"118 530 LINE",
+"193 497 LINE",
+"208 481 OFFCURVE",
+"213 446 OFFCURVE",
+"213 403 CURVE SMOOTH",
+"213 335 OFFCURVE",
+"201 268 OFFCURVE",
+"176 202 CURVE SMOOTH",
+"152 137 OFFCURVE",
+"112 60 OFFCURVE",
+"56 -28 CURVE",
+"115 -63 LINE",
+"135 -31 LINE",
+"155 0 LINE",
+"403 0 LINE"
+);
+}
+);
+width = 403;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.FinaLiga2;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{190, -141}";
+}
+);
+hints = (
+{
+place = "{213, 75}";
+},
+{
+horizontal = 1;
+place = "{-63, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{601, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"193 497 LINE",
+"208 481 OFFCURVE",
+"213 446 OFFCURVE",
+"213 403 CURVE SMOOTH",
+"213 335 OFFCURVE",
+"201 268 OFFCURVE",
+"176 202 CURVE SMOOTH",
+"152 137 OFFCURVE",
+"112 60 OFFCURVE",
+"56 -28 CURVE",
+"115 -63 LINE",
+"234 113 OFFCURVE",
+"288 263 OFFCURVE",
+"288 408 CURVE SMOOTH",
+"288 536 OFFCURVE",
+"242 593 OFFCURVE",
+"150 601 CURVE",
+"118 530 LINE"
+);
+}
+);
+width = 368;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ.FinaLigaLong;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{146, -195}";
+},
+{
+name = top;
+position = "{112, 735}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"329 -5 LINE SMOOTH",
+"346 -5 OFFCURVE",
+"368 3 OFFCURVE",
+"368 32 CURVE SMOOTH",
+"368 46 OFFCURVE",
+"359 71 OFFCURVE",
+"320 71 CURVE SMOOTH",
+"273 71 LINE SMOOTH",
+"221 71 OFFCURVE",
+"183 101 OFFCURVE",
+"183 155 CURVE SMOOTH",
+"183 674 LINE",
+"110 674 LINE",
+"110 141 LINE SMOOTH",
+"110 40 OFFCURVE",
+"95 -29 OFFCURVE",
+"75 -64 CURVE",
+"135 -94 LINE",
+"157 -65 OFFCURVE",
+"170 -22 OFFCURVE",
+"178 35 CURVE",
+"181 35 LINE",
+"196 9 OFFCURVE",
+"235 -5 OFFCURVE",
+"280 -5 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"329 -5 LINE SMOOTH",
+"346 -5 OFFCURVE",
+"368 3 OFFCURVE",
+"368 32 CURVE SMOOTH",
+"368 46 OFFCURVE",
+"359 71 OFFCURVE",
+"320 71 CURVE SMOOTH",
+"273 71 LINE SMOOTH",
+"221 71 OFFCURVE",
+"183 101 OFFCURVE",
+"183 155 CURVE SMOOTH",
+"183 674 LINE",
+"110 674 LINE",
+"110 141 LINE SMOOTH",
+"110 40 OFFCURVE",
+"95 -29 OFFCURVE",
+"75 -64 CURVE",
+"135 -94 LINE",
+"157 -65 OFFCURVE",
+"170 -22 OFFCURVE",
+"178 35 CURVE",
+"181 35 LINE",
+"196 9 OFFCURVE",
+"235 -5 OFFCURVE",
+"280 -5 CURVE SMOOTH"
+);
+}
+);
+width = 320;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0715.loclSYRJ.FinaQR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{272, 231}";
+},
+{
+name = RU;
+position = "{271, -112}";
+},
+{
+name = bottom;
+position = "{130, -430}";
+},
+{
+name = top;
+position = "{169, 414}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"102 -303 OFFCURVE",
+"122 -319 OFFCURVE",
+"151 -319 CURVE SMOOTH",
+"184 -319 OFFCURVE",
+"203 -300 OFFCURVE",
+"203 -263 CURVE SMOOTH",
+"203 -226 OFFCURVE",
+"184 -206 OFFCURVE",
+"151 -206 CURVE SMOOTH",
+"120 -206 OFFCURVE",
+"102 -226 OFFCURVE",
+"102 -263 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"81 162 OFFCURVE",
+"81 114 CURVE SMOOTH",
+"81 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"271 0 OFFCURVE",
+"280 0 CURVE",
+"280 76 LINE",
+"271 76 OFFCURVE",
+"251 77 OFFCURVE",
+"237 83 CURVE",
+"238 92 OFFCURVE",
+"238 96 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 148, -327}";
+},
+{
+name = uni0716.loclSYRJ.FinaQR;
+}
+);
+layerId = UUID0;
+width = 435;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0716.loclSYRJ.FinaQR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{287, 230}";
+},
+{
+name = RU;
+position = "{287, -116}";
+},
+{
+name = bottom;
+position = "{151, -303}";
+},
+{
+name = top;
+position = "{169, 414}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1481 -201 LINE",
+"1534 -158 OFFCURVE",
+"1580 -102 OFFCURVE",
+"1603 -36 CURVE",
+"1633 -39 OFFCURVE",
+"1679 -39 OFFCURVE",
+"1706 -39 CURVE SMOOTH",
+"1790 -39 LINE",
+"1790 37 LINE",
+"1730 37 LINE SMOOTH",
+"1637 37 OFFCURVE",
+"1619 45 OFFCURVE",
+"1590 88 CURVE SMOOTH",
+"1567 121 OFFCURVE",
+"1541 140 OFFCURVE",
+"1502 140 CURVE SMOOTH",
+"1457 140 OFFCURVE",
+"1423 103 OFFCURVE",
+"1423 62 CURVE SMOOTH",
+"1423 32 OFFCURVE",
+"1432 12 OFFCURVE",
+"1455 -10 CURVE SMOOTH",
+"1473 -27 OFFCURVE",
+"1493 -43 OFFCURVE",
+"1497 -60 CURVE",
+"1497 -81 OFFCURVE",
+"1470 -122 OFFCURVE",
+"1438 -155 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1501 -184 LINE",
+"1546 -139 OFFCURVE",
+"1577 -82 OFFCURVE",
+"1592 -35 CURVE",
+"1621 -38 OFFCURVE",
+"1688 -39 OFFCURVE",
+"1715 -39 CURVE SMOOTH",
+"1790 -39 LINE",
+"1790 37 LINE",
+"1720 37 LINE SMOOTH",
+"1627 37 OFFCURVE",
+"1620 40 OFFCURVE",
+"1590 85 CURVE SMOOTH",
+"1565 123 OFFCURVE",
+"1545 139 OFFCURVE",
+"1507 139 CURVE SMOOTH",
+"1465 139 OFFCURVE",
+"1434 102 OFFCURVE",
+"1434 61 CURVE SMOOTH",
+"1434 6 OFFCURVE",
+"1475 -14 OFFCURVE",
+"1516 -29 CURVE",
+"1515 -51 OFFCURVE",
+"1488 -106 OFFCURVE",
+"1457 -148 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1116 -184 LINE",
+"1161 -139 OFFCURVE",
+"1189 -81 OFFCURVE",
+"1204 -34 CURVE",
+"1233 -37 OFFCURVE",
+"1303 -39 OFFCURVE",
+"1330 -39 CURVE SMOOTH",
+"1405 -39 LINE",
+"1405 37 LINE",
+"1335 37 LINE SMOOTH",
+"1242 37 OFFCURVE",
+"1235 40 OFFCURVE",
+"1205 85 CURVE SMOOTH",
+"1180 123 OFFCURVE",
+"1160 139 OFFCURVE",
+"1122 139 CURVE SMOOTH",
+"1080 139 OFFCURVE",
+"1049 102 OFFCURVE",
+"1049 61 CURVE SMOOTH",
+"1049 9 OFFCURVE",
+"1088 -12 OFFCURVE",
+"1129 -29 CURVE",
+"1128 -51 OFFCURVE",
+"1103 -106 OFFCURVE",
+"1072 -148 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 153 OFFCURVE",
+"549 114 OFFCURVE",
+"549 71 CURVE SMOOTH",
+"549 16 OFFCURVE",
+"587 -9 OFFCURVE",
+"628 -27 CURVE",
+"627 -50 OFFCURVE",
+"602 -106 OFFCURVE",
+"571 -148 CURVE",
+"615 -184 LINE",
+"660 -139 OFFCURVE",
+"688 -80 OFFCURVE",
+"703 -33 CURVE",
+"727 -37 OFFCURVE",
+"756 -39 OFFCURVE",
+"765 -39 CURVE",
+"765 37 LINE",
+"756 37 OFFCURVE",
+"733 39 OFFCURVE",
+"717 45 CURVE",
+"715 56 OFFCURVE",
+"712 67 OFFCURVE",
+"709 76 CURVE SMOOTH",
+"689 137 OFFCURVE",
+"655 153 OFFCURVE",
+"622 153 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 96 OFFCURVE",
+"664 74 OFFCURVE",
+"664 43 CURVE SMOOTH",
+"664 37 OFFCURVE",
+"664 27 OFFCURVE",
+"662 16 CURVE",
+"631 18 OFFCURVE",
+"599 26 OFFCURVE",
+"599 61 CURVE SMOOTH",
+"599 82 OFFCURVE",
+"612 96 OFFCURVE",
+"629 96 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 153 OFFCURVE",
+"549 114 OFFCURVE",
+"549 71 CURVE SMOOTH",
+"549 16 OFFCURVE",
+"587 -9 OFFCURVE",
+"628 -27 CURVE",
+"627 -50 OFFCURVE",
+"602 -106 OFFCURVE",
+"571 -148 CURVE",
+"615 -184 LINE",
+"660 -139 OFFCURVE",
+"688 -80 OFFCURVE",
+"703 -33 CURVE",
+"727 -37 OFFCURVE",
+"756 -39 OFFCURVE",
+"765 -39 CURVE",
+"765 37 LINE",
+"756 37 OFFCURVE",
+"733 39 OFFCURVE",
+"717 45 CURVE",
+"715 56 OFFCURVE",
+"712 67 OFFCURVE",
+"709 76 CURVE SMOOTH",
+"689 137 OFFCURVE",
+"655 153 OFFCURVE",
+"622 153 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 135 OFFCURVE",
+"195 113 OFFCURVE",
+"195 82 CURVE SMOOTH",
+"195 76 OFFCURVE",
+"195 66 OFFCURVE",
+"193 55 CURVE",
+"162 57 OFFCURVE",
+"130 65 OFFCURVE",
+"130 100 CURVE SMOOTH",
+"130 121 OFFCURVE",
+"143 135 OFFCURVE",
+"160 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 153 OFFCURVE",
+"549 114 OFFCURVE",
+"549 71 CURVE SMOOTH",
+"549 16 OFFCURVE",
+"587 -9 OFFCURVE",
+"628 -27 CURVE",
+"627 -50 OFFCURVE",
+"602 -106 OFFCURVE",
+"571 -148 CURVE",
+"615 -184 LINE",
+"660 -139 OFFCURVE",
+"688 -80 OFFCURVE",
+"703 -33 CURVE",
+"727 -36 OFFCURVE",
+"802 -39 OFFCURVE",
+"829 -39 CURVE SMOOTH",
+"904 -39 LINE",
+"904 37 LINE",
+"834 37 LINE SMOOTH",
+"806 37 OFFCURVE",
+"729 39 OFFCURVE",
+"717 46 CURVE",
+"715 56 OFFCURVE",
+"712 67 OFFCURVE",
+"709 76 CURVE SMOOTH",
+"688 137 OFFCURVE",
+"655 153 OFFCURVE",
+"622 153 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"83 162 OFFCURVE",
+"83 114 CURVE SMOOTH",
+"83 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"271 0 OFFCURVE",
+"280 0 CURVE",
+"280 76 LINE",
+"271 76 OFFCURVE",
+"251 77 OFFCURVE",
+"237 83 CURVE",
+"237 88 OFFCURVE",
+"238 94 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"83 162 OFFCURVE",
+"83 114 CURVE SMOOTH",
+"83 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"271 0 OFFCURVE",
+"280 0 CURVE",
+"280 76 LINE",
+"271 76 OFFCURVE",
+"251 77 OFFCURVE",
+"237 83 CURVE",
+"237 88 OFFCURVE",
+"238 94 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"81 162 OFFCURVE",
+"81 114 CURVE SMOOTH",
+"81 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"272 0 OFFCURVE",
+"280 0 CURVE SMOOTH",
+"435 0 LINE",
+"435 76 LINE",
+"279 76 LINE SMOOTH",
+"271 76 OFFCURVE",
+"250 77 OFFCURVE",
+"237 83 CURVE",
+"238 92 OFFCURVE",
+"238 97 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+}
+);
+width = 435;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072F.loclSYRJ.FinaQR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{295, 241}";
+},
+{
+name = RU;
+position = "{309, -115}";
+},
+{
+name = bottom;
+position = "{194, -392}";
+},
+{
+name = top;
+position = "{192, 447}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-50 -150 OFFCURVE",
+"-30 -166 OFFCURVE",
+"-1 -166 CURVE SMOOTH",
+"32 -166 OFFCURVE",
+"51 -147 OFFCURVE",
+"51 -110 CURVE SMOOTH",
+"51 -73 OFFCURVE",
+"32 -53 OFFCURVE",
+"-1 -53 CURVE SMOOTH",
+"-32 -53 OFFCURVE",
+"-50 -73 OFFCURVE",
+"-50 -110 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"28 -314 OFFCURVE",
+"48 -330 OFFCURVE",
+"77 -330 CURVE SMOOTH",
+"110 -330 OFFCURVE",
+"129 -311 OFFCURVE",
+"129 -274 CURVE SMOOTH",
+"129 -237 OFFCURVE",
+"110 -217 OFFCURVE",
+"77 -217 CURVE SMOOTH",
+"46 -217 OFFCURVE",
+"28 -237 OFFCURVE",
+"28 -274 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 203 OFFCURVE",
+"104 162 OFFCURVE",
+"104 114 CURVE SMOOTH",
+"104 68 OFFCURVE",
+"126 39 OFFCURVE",
+"170 14 CURVE",
+"165 -11 OFFCURVE",
+"137 -60 OFFCURVE",
+"107 -102 CURVE",
+"149 -138 LINE",
+"189 -98 OFFCURVE",
+"224 -41 OFFCURVE",
+"243 4 CURVE",
+"265 1 OFFCURVE",
+"294 0 OFFCURVE",
+"303 0 CURVE",
+"303 76 LINE",
+"294 76 OFFCURVE",
+"274 77 OFFCURVE",
+"260 83 CURVE",
+"261 92 OFFCURVE",
+"261 96 OFFCURVE",
+"261 100 CURVE SMOOTH",
+"261 158 OFFCURVE",
+"234 203 OFFCURVE",
+"183 203 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, -1, -169}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 77, -333}";
+},
+{
+name = uni0716.loclSYRJ.FinaQR;
+transform = "{1, 0, 0, 1, 23, 0}";
+}
+);
+layerId = UUID0;
+width = 458;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072A.loclSYRJ.FinaQR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{299, 374}";
+},
+{
+name = RU;
+position = "{285, -113}";
+},
+{
+name = bottom;
+position = "{150, -303}";
+},
+{
+name = top;
+position = "{144, 544}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 305 OFFCURVE",
+"135 289 OFFCURVE",
+"164 289 CURVE SMOOTH",
+"197 289 OFFCURVE",
+"216 308 OFFCURVE",
+"216 345 CURVE SMOOTH",
+"216 382 OFFCURVE",
+"197 402 OFFCURVE",
+"164 402 CURVE SMOOTH",
+"133 402 OFFCURVE",
+"115 382 OFFCURVE",
+"115 345 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"81 162 OFFCURVE",
+"81 114 CURVE SMOOTH",
+"81 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"271 0 OFFCURVE",
+"280 0 CURVE",
+"280 76 LINE",
+"271 76 OFFCURVE",
+"251 77 OFFCURVE",
+"237 83 CURVE",
+"238 92 OFFCURVE",
+"238 96 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 164, 286}";
+},
+{
+name = uni0716.loclSYRJ.FinaQR;
+}
+);
+layerId = UUID0;
+width = 435;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0712.loclSYRN.FinaQR;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{721, -92}";
+}
+);
+components = (
+{
+name = uni0712.loclSYRN.Fina;
+},
+{
+name = Stretch5.loclSYRN;
+transform = "{1, 0, 0, 1, 800, 0}";
+}
+);
+layerId = UUID0;
+width = 910;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0715.loclSYRN.FinaQR;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{437, -77}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 259, -195}";
+},
+{
+name = uni0716.loclSYRN.Fina;
+},
+{
+name = Stretch.loclSYRN;
+transform = "{1, 0, 0, 1, 518, 0}";
+}
+);
+layerId = UUID0;
+width = 594;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni0716.loclSYRN.FinaQR;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{437, -77}";
+}
+);
+components = (
+{
+name = uni0716.loclSYRN.Fina;
+},
+{
+name = Stretch.loclSYRN;
+transform = "{1, 0, 0, 1, 518, 0}";
+}
+);
+layerId = UUID0;
+width = 594;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni0726.loclSYRN.FinaQR;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{645, -81}";
+}
+);
+components = (
+{
+name = uni0726.loclSYRN.Fina;
+},
+{
+name = Stretch5.loclSYRN;
+transform = "{1, 0, 0, 1, 723, 0}";
+}
+);
+layerId = UUID0;
+width = 833;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.FinaW;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{138, -412}";
+},
+{
+name = top;
+position = "{140, 268}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"322 0 LINE",
+"322 76 LINE",
+"132 76 LINE SMOOTH",
+"93 76 OFFCURVE",
+"78 51 OFFCURVE",
+"78 -4 CURVE SMOOTH",
+"78 -123 OFFCURVE",
+"154 -274 OFFCURVE",
+"283 -399 CURVE",
+"341 -353 LINE",
+"194 -195 OFFCURVE",
+"154 -76 OFFCURVE",
+"154 -8 CURVE SMOOTH",
+"154 -6 OFFCURVE",
+"154 -2 OFFCURVE",
+"155 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"322 0 LINE",
+"322 76 LINE",
+"132 76 LINE SMOOTH",
+"93 76 OFFCURVE",
+"78 51 OFFCURVE",
+"78 -4 CURVE SMOOTH",
+"78 -123 OFFCURVE",
+"154 -274 OFFCURVE",
+"283 -399 CURVE",
+"341 -353 LINE",
+"194 -195 OFFCURVE",
+"154 -76 OFFCURVE",
+"154 -8 CURVE SMOOTH",
+"154 -6 OFFCURVE",
+"154 -2 OFFCURVE",
+"155 0 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"406 -367 LINE",
+"305 -249 OFFCURVE",
+"168 -63 OFFCURVE",
+"107 25 CURVE",
+"114 29 LINE",
+"145 4 OFFCURVE",
+"194 0 OFFCURVE",
+"243 0 CURVE SMOOTH",
+"322 0 LINE",
+"322 76 LINE",
+"242 76 LINE SMOOTH",
+"193 76 OFFCURVE",
+"186 77 OFFCURVE",
+"170 83 CURVE SMOOTH",
+"163 86 OFFCURVE",
+"148 92 OFFCURVE",
+"120 119 CURVE SMOOTH",
+"100 139 OFFCURVE",
+"88 143 OFFCURVE",
+"69 143 CURVE SMOOTH",
+"35 143 OFFCURVE",
+"20 108 OFFCURVE",
+"20 70 CURVE SMOOTH",
+"20 45 OFFCURVE",
+"32 7 OFFCURVE",
+"52 -23 CURVE SMOOTH",
+"121 -125 OFFCURVE",
+"258 -301 OFFCURVE",
+"351 -405 CURVE"
+);
+}
+);
+width = 322;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN.FinaW;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{625, -91}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRN.Fina;
+},
+{
+name = Stretch2.loclSYRN;
+transform = "{1, 0, 0, 1, 764, 0}";
+}
+);
+layerId = UUID0;
+width = 900;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0714.loclSYRN.FinaW;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{625, -91}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 456, 139}";
+},
+{
+name = uni0713.loclSYRN.Fina;
+},
+{
+name = Stretch2.loclSYRN;
+transform = "{1, 0, 0, 1, 764, 0}";
+}
+);
+layerId = UUID0;
+width = 900;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN.FinaW;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{433, -98}";
+}
+);
+components = (
+{
+name = Stretch2.loclSYRN;
+transform = "{1, 0, 0, 1, 764, 0}";
+},
+{
+name = uni072E.loclSYRN.Fina;
+}
+);
+layerId = UUID0;
+width = 900;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0719.loclSYRN.FinaW;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{167, -173}";
+}
+);
+components = (
+{
+name = uni0719.loclSYRN.Fina;
+},
+{
+name = Stretch.loclSYRN;
+transform = "{1, 0, 0, 1, 317, 0}";
+}
+);
+layerId = UUID0;
+width = 394;
+}
+);
+rightKerningGroup = uni0719;
+},
+{
+color = 5;
+glyphname = uni0713.loclSYRJ.FinaWide;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{507, 161}";
+},
+{
+name = RU;
+position = "{693, -477}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{391, 357}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRJ.Fina;
+},
+{
+name = Stretch.loclSYRJ;
+transform = "{1, 0, 0, 1, 647, 0}";
+}
+);
+layerId = UUID0;
+width = 745;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0714.loclSYRJ.FinaWide;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{508, 161}";
+},
+{
+name = RU;
+position = "{693, -478}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{391, 357}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 210, 39}";
+},
+{
+name = uni0713.loclSYRJ.Fina;
+},
+{
+name = Stretch.loclSYRJ;
+transform = "{1, 0, 0, 1, 647, 0}";
+}
+);
+layerId = UUID0;
+width = 745;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072E.loclSYRJ.FinaWide;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{548, 392}";
+},
+{
+name = RU;
+position = "{693, -476}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{227, 402}";
+}
+);
+components = (
+{
+name = uni072E.loclSYRJ.Fina;
+},
+{
+name = Stretch.loclSYRJ;
+transform = "{1, 0, 0, 1, 647, 0}";
+}
+);
+layerId = UUID0;
+width = 745;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0713.loclSYRJ.FinaWide2;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{507, 161}";
+},
+{
+name = RU;
+position = "{693, -477}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{391, 357}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRJ.Fina;
+},
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 647, 0}";
+}
+);
+layerId = UUID0;
+width = 818;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0714.loclSYRJ.FinaWide2;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{508, 161}";
+},
+{
+name = RU;
+position = "{693, -478}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{391, 357}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 210, 39}";
+},
+{
+name = uni0713.loclSYRJ.Fina;
+},
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 647, 0}";
+}
+);
+layerId = UUID0;
+width = 818;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072E.loclSYRJ.FinaWide2;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{548, 392}";
+},
+{
+name = RU;
+position = "{693, -476}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{227, 402}";
+}
+);
+components = (
+{
+name = uni072E.loclSYRJ.Fina;
+},
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 647, 0}";
+}
+);
+layerId = UUID0;
+width = 818;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0712.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{480, 438}";
+},
+{
+name = RU;
+position = "{464, -68}";
+},
+{
+name = bottom;
+position = "{207, -98}";
+},
+{
+name = top;
+position = "{225, 514}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"379 0 LINE SMOOTH",
+"500 0 OFFCURVE",
+"538 60 OFFCURVE",
+"538 131 CURVE SMOOTH",
+"538 232 OFFCURVE",
+"485 301 OFFCURVE",
+"401 356 CURVE SMOOTH",
+"343 394 OFFCURVE",
+"278 414 OFFCURVE",
+"196 414 CURVE SMOOTH",
+"159 414 OFFCURVE",
+"91 402 OFFCURVE",
+"58 387 CURVE",
+"75 326 LINE",
+"112 337 OFFCURVE",
+"163 339 OFFCURVE",
+"186 339 CURVE SMOOTH",
+"323 339 OFFCURVE",
+"464 250 OFFCURVE",
+"464 134 CURVE SMOOTH",
+"464 107 OFFCURVE",
+"449 76 OFFCURVE",
+"394 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 606;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072D.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{267, -98}";
+},
+{
+name = top;
+position = "{130, 661}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"379 0 LINE SMOOTH",
+"500 0 OFFCURVE",
+"538 60 OFFCURVE",
+"538 131 CURVE SMOOTH",
+"538 317 OFFCURVE",
+"358 411 OFFCURVE",
+"200 411 CURVE SMOOTH",
+"185 411 OFFCURVE",
+"169 410 OFFCURVE",
+"155 408 CURVE",
+"155 412 LINE",
+"178 434 OFFCURVE",
+"241 495 OFFCURVE",
+"264 520 CURVE SMOOTH",
+"314 574 LINE",
+"261 618 LINE",
+"58 387 LINE",
+"74 333 LINE",
+"115 338 OFFCURVE",
+"152 339 OFFCURVE",
+"176 339 CURVE SMOOTH",
+"333 339 OFFCURVE",
+"464 254 OFFCURVE",
+"464 134 CURVE SMOOTH",
+"464 107 OFFCURVE",
+"449 76 OFFCURVE",
+"394 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"379 0 LINE SMOOTH",
+"500 0 OFFCURVE",
+"538 60 OFFCURVE",
+"538 131 CURVE SMOOTH",
+"538 317 OFFCURVE",
+"358 411 OFFCURVE",
+"200 411 CURVE SMOOTH",
+"185 411 OFFCURVE",
+"169 410 OFFCURVE",
+"155 408 CURVE",
+"155 412 LINE",
+"178 434 OFFCURVE",
+"241 495 OFFCURVE",
+"264 520 CURVE SMOOTH",
+"314 574 LINE",
+"261 618 LINE",
+"58 387 LINE",
+"74 333 LINE",
+"115 338 OFFCURVE",
+"152 339 OFFCURVE",
+"176 339 CURVE SMOOTH",
+"333 339 OFFCURVE",
+"464 254 OFFCURVE",
+"464 134 CURVE SMOOTH",
+"464 107 OFFCURVE",
+"449 76 OFFCURVE",
+"394 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 606;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0725.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{219, -98}";
+},
+{
+name = top;
+position = "{222, 513}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"227 0 LINE SMOOTH",
+"299 0 OFFCURVE",
+"336 12 OFFCURVE",
+"354 37 CURVE",
+"384 12 OFFCURVE",
+"417 -6 OFFCURVE",
+"464 -10 CURVE",
+"483 56 LINE",
+"437 67 OFFCURVE",
+"403 85 OFFCURVE",
+"344 153 CURVE SMOOTH",
+"96 436 LINE",
+"39 384 LINE",
+"301 85 LINE",
+"282 75 OFFCURVE",
+"252 76 OFFCURVE",
+"237 76 CURVE SMOOTH"
+);
+}
+);
+width = 532;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074F.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{150, -98}";
+},
+{
+name = top;
+position = "{151, 584}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"321 -3 LINE",
+"386 40 LINE",
+"263 229 LINE",
+"265 231 LINE",
+"315 233 OFFCURVE",
+"355 269 OFFCURVE",
+"355 327 CURVE SMOOTH",
+"355 388 OFFCURVE",
+"313 421 OFFCURVE",
+"259 421 CURVE SMOOTH",
+"221 421 OFFCURVE",
+"192 405 OFFCURVE",
+"176 372 CURVE",
+"172 372 LINE",
+"90 500 LINE",
+"26 458 LINE",
+"255 100 LINE",
+"243 76 OFFCURVE",
+"195 76 OFFCURVE",
+"175 76 CURVE SMOOTH",
+"-50 76 LINE SMOOTH",
+"-71 76 OFFCURVE",
+"-89 61 OFFCURVE",
+"-89 38 CURVE SMOOTH",
+"-89 14 OFFCURVE",
+"-71 0 OFFCURVE",
+"-50 0 CURVE SMOOTH",
+"164 0 LINE SMOOTH",
+"237 0 OFFCURVE",
+"274 12 OFFCURVE",
+"292 38 CURVE",
+"295 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 293 OFFCURVE",
+"287 274 OFFCURVE",
+"259 274 CURVE SMOOTH",
+"231 274 OFFCURVE",
+"210 293 OFFCURVE",
+"210 326 CURVE SMOOTH",
+"210 358 OFFCURVE",
+"229 377 OFFCURVE",
+"259 377 CURVE SMOOTH",
+"286 377 OFFCURVE",
+"307 358 OFFCURVE",
+"307 326 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"321 -3 LINE",
+"386 40 LINE",
+"263 229 LINE",
+"265 231 LINE",
+"315 233 OFFCURVE",
+"355 269 OFFCURVE",
+"355 327 CURVE SMOOTH",
+"355 388 OFFCURVE",
+"313 421 OFFCURVE",
+"259 421 CURVE SMOOTH",
+"221 421 OFFCURVE",
+"192 405 OFFCURVE",
+"176 372 CURVE",
+"172 372 LINE",
+"90 500 LINE",
+"26 458 LINE",
+"255 100 LINE",
+"243 76 OFFCURVE",
+"195 76 OFFCURVE",
+"175 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"164 0 LINE SMOOTH",
+"237 0 OFFCURVE",
+"274 12 OFFCURVE",
+"292 38 CURVE",
+"295 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 293 OFFCURVE",
+"287 274 OFFCURVE",
+"259 274 CURVE SMOOTH",
+"231 274 OFFCURVE",
+"210 293 OFFCURVE",
+"210 326 CURVE SMOOTH",
+"210 358 OFFCURVE",
+"229 377 OFFCURVE",
+"259 377 CURVE SMOOTH",
+"286 377 OFFCURVE",
+"307 358 OFFCURVE",
+"307 326 CURVE SMOOTH"
+);
+}
+);
+width = 435;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0713.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{492, 161}";
+},
+{
+name = RU;
+position = "{677, -477}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{375, 357}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"348 158 LINE",
+"303 95 LINE",
+"728 -220 LINE SMOOTH",
+"743 -231 OFFCURVE",
+"751 -244 OFFCURVE",
+"751 -259 CURVE SMOOTH",
+"751 -292 OFFCURVE",
+"716 -315 OFFCURVE",
+"669 -315 CURVE SMOOTH",
+"626 -315 OFFCURVE",
+"595 -296 OFFCURVE",
+"564 -273 CURVE SMOOTH",
+"187 9 LINE",
+"144 40 OFFCURVE",
+"94 76 OFFCURVE",
+"26 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 62 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 15 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"17 0 LINE SMOOTH",
+"64 0 OFFCURVE",
+"102 -24 OFFCURVE",
+"138 -51 CURVE SMOOTH",
+"508 -328 LINE SMOOTH",
+"568 -373 OFFCURVE",
+"619 -391 OFFCURVE",
+"667 -391 CURVE SMOOTH",
+"779 -391 OFFCURVE",
+"828 -319 OFFCURVE",
+"828 -259 CURVE SMOOTH",
+"828 -220 OFFCURVE",
+"812 -189 OFFCURVE",
+"771 -159 CURVE SMOOTH"
+);
+}
+);
+width = 833;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0714.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{492, 161}";
+},
+{
+name = RU;
+position = "{677, -477}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{375, 357}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 194, 39}";
+},
+{
+name = uni0713.loclSYRJ.Init;
+}
+);
+layerId = UUID0;
+width = 833;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072E.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{502, 388}";
+},
+{
+name = RU;
+position = "{677, -514}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{213, 401}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"576 251 OFFCURVE",
+"530 285 OFFCURVE",
+"474 328 CURVE SMOOTH",
+"399 385 LINE",
+"355 326 LINE",
+"432 268 LINE SMOOTH",
+"476 234 OFFCURVE",
+"501 216 OFFCURVE",
+"501 186 CURVE SMOOTH",
+"501 139 OFFCURVE",
+"456 125 OFFCURVE",
+"421 125 CURVE SMOOTH",
+"406 125 OFFCURVE",
+"385 131 OFFCURVE",
+"370 143 CURVE SMOOTH",
+"334 168 LINE",
+"290 105 LINE",
+"728 -220 LINE SMOOTH",
+"743 -231 OFFCURVE",
+"751 -244 OFFCURVE",
+"751 -259 CURVE SMOOTH",
+"751 -292 OFFCURVE",
+"716 -315 OFFCURVE",
+"669 -315 CURVE SMOOTH",
+"626 -315 OFFCURVE",
+"595 -296 OFFCURVE",
+"564 -273 CURVE SMOOTH",
+"187 9 LINE",
+"144 40 OFFCURVE",
+"94 76 OFFCURVE",
+"26 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 62 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 15 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"17 0 LINE SMOOTH",
+"64 0 OFFCURVE",
+"102 -24 OFFCURVE",
+"138 -51 CURVE SMOOTH",
+"508 -328 LINE SMOOTH",
+"568 -373 OFFCURVE",
+"619 -391 OFFCURVE",
+"667 -391 CURVE SMOOTH",
+"779 -391 OFFCURVE",
+"828 -319 OFFCURVE",
+"828 -259 CURVE SMOOTH",
+"828 -220 OFFCURVE",
+"812 -189 OFFCURVE",
+"771 -159 CURVE SMOOTH",
+"515 33 LINE SMOOTH",
+"498 46 OFFCURVE",
+"478 58 OFFCURVE",
+"458 71 CURVE",
+"458 75 LINE",
+"529 79 OFFCURVE",
+"576 126 OFFCURVE",
+"576 194 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"576 249 OFFCURVE",
+"531 284 OFFCURVE",
+"474 328 CURVE SMOOTH",
+"399 385 LINE",
+"355 326 LINE",
+"432 268 LINE SMOOTH",
+"478 234 OFFCURVE",
+"501 215 OFFCURVE",
+"501 186 CURVE SMOOTH",
+"501 139 OFFCURVE",
+"456 125 OFFCURVE",
+"421 125 CURVE SMOOTH",
+"406 125 OFFCURVE",
+"385 131 OFFCURVE",
+"370 143 CURVE SMOOTH",
+"334 168 LINE",
+"290 105 LINE",
+"728 -220 LINE SMOOTH",
+"743 -231 OFFCURVE",
+"751 -244 OFFCURVE",
+"751 -259 CURVE SMOOTH",
+"751 -292 OFFCURVE",
+"716 -315 OFFCURVE",
+"669 -315 CURVE SMOOTH",
+"626 -315 OFFCURVE",
+"595 -296 OFFCURVE",
+"564 -273 CURVE SMOOTH",
+"187 9 LINE",
+"144 40 OFFCURVE",
+"94 76 OFFCURVE",
+"26 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 62 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 15 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"17 0 LINE SMOOTH",
+"64 0 OFFCURVE",
+"102 -24 OFFCURVE",
+"138 -51 CURVE SMOOTH",
+"508 -328 LINE SMOOTH",
+"568 -373 OFFCURVE",
+"619 -391 OFFCURVE",
+"667 -391 CURVE SMOOTH",
+"779 -391 OFFCURVE",
+"828 -319 OFFCURVE",
+"828 -259 CURVE SMOOTH",
+"828 -220 OFFCURVE",
+"812 -189 OFFCURVE",
+"771 -159 CURVE SMOOTH",
+"515 33 LINE SMOOTH",
+"498 46 OFFCURVE",
+"478 58 OFFCURVE",
+"458 71 CURVE",
+"458 75 LINE",
+"529 79 OFFCURVE",
+"576 126 OFFCURVE",
+"576 194 CURVE SMOOTH"
+);
+}
+);
+width = 833;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071A.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{275, -98}";
+},
+{
+name = top;
+position = "{298, 366}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"2696 12 OFFCURVE",
+"2733 0 OFFCURVE",
+"2765 0 CURVE SMOOTH",
+"2807 0 OFFCURVE",
+"2838 13 OFFCURVE",
+"2870 48 CURVE",
+"2897 16 OFFCURVE",
+"2915 5 OFFCURVE",
+"2937 5 CURVE SMOOTH",
+"2987 5 OFFCURVE",
+"2988 47 OFFCURVE",
+"2988 61 CURVE SMOOTH",
+"2988 81 OFFCURVE",
+"2971 150 OFFCURVE",
+"2949 198 CURVE SMOOTH",
+"2933 233 OFFCURVE",
+"2915 241 OFFCURVE",
+"2895 241 CURVE SMOOTH",
+"2861 241 OFFCURVE",
+"2855 222 OFFCURVE",
+"2825 150 CURVE SMOOTH",
+"2808 109 OFFCURVE",
+"2793 89 OFFCURVE",
+"2781 89 CURVE SMOOTH",
+"2779 89 LINE SMOOTH",
+"2766 89 OFFCURVE",
+"2757 113 OFFCURVE",
+"2746 147 CURVE SMOOTH",
+"2727 208 OFFCURVE",
+"2714 241 OFFCURVE",
+"2678 241 CURVE SMOOTH",
+"2653 241 OFFCURVE",
+"2641 228 OFFCURVE",
+"2631 208 CURVE SMOOTH",
+"2610 163 OFFCURVE",
+"2597 125 OFFCURVE",
+"2578 103 CURVE SMOOTH",
+"2560 82 OFFCURVE",
+"2534 76 OFFCURVE",
+"2503 76 CURVE SMOOTH",
+"2482 76 OFFCURVE",
+"2464 61 OFFCURVE",
+"2464 38 CURVE SMOOTH",
+"2464 14 OFFCURVE",
+"2482 0 OFFCURVE",
+"2503 0 CURVE SMOOTH",
+"2565 0 OFFCURVE",
+"2616 12 OFFCURVE",
+"2663 48 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2846 172 LINE",
+"2823 131 LINE SMOOTH",
+"2805 100 OFFCURVE",
+"2796 85 OFFCURVE",
+"2787 82 CURVE",
+"2778 82 LINE",
+"2769 87 OFFCURVE",
+"2760 99 OFFCURVE",
+"2730 149 CURVE SMOOTH",
+"2702 195 OFFCURVE",
+"2692 203 OFFCURVE",
+"2670 203 CURVE SMOOTH",
+"2649 203 OFFCURVE",
+"2640 195 OFFCURVE",
+"2628 177 CURVE SMOOTH",
+"2601 136 LINE SMOOTH",
+"2571 91 OFFCURVE",
+"2541 76 OFFCURVE",
+"2503 76 CURVE SMOOTH",
+"2482 76 OFFCURVE",
+"2464 61 OFFCURVE",
+"2464 38 CURVE SMOOTH",
+"2464 14 OFFCURVE",
+"2482 0 OFFCURVE",
+"2503 0 CURVE SMOOTH",
+"2571 0 OFFCURVE",
+"2624 20 OFFCURVE",
+"2668 70 CURVE",
+"2711 16 OFFCURVE",
+"2741 0 OFFCURVE",
+"2775 0 CURVE SMOOTH",
+"2826 0 OFFCURVE",
+"2829 0 OFFCURVE",
+"2865 6 CURVE SMOOTH",
+"2923 17 OFFCURVE",
+"2952 59 OFFCURVE",
+"2952 111 CURVE SMOOTH",
+"2952 156 OFFCURVE",
+"2938 220 OFFCURVE",
+"2894 220 CURVE SMOOTH",
+"2865 220 OFFCURVE",
+"2852 211 OFFCURVE",
+"2839 182 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2041 76 OFFCURVE",
+"2023 61 OFFCURVE",
+"2023 38 CURVE SMOOTH",
+"2023 14 OFFCURVE",
+"2041 0 OFFCURVE",
+"2062 0 CURVE SMOOTH",
+"2099 0 LINE SMOOTH",
+"2150 0 OFFCURVE",
+"2190 0 OFFCURVE",
+"2226 6 CURVE SMOOTH",
+"2284 17 OFFCURVE",
+"2313 59 OFFCURVE",
+"2313 111 CURVE SMOOTH",
+"2313 156 OFFCURVE",
+"2299 220 OFFCURVE",
+"2255 220 CURVE SMOOTH",
+"2226 220 OFFCURVE",
+"2213 211 OFFCURVE",
+"2200 182 CURVE SMOOTH",
+"2190 157 OFFCURVE",
+"2177 108 OFFCURVE",
+"2171 79 CURVE",
+"2153 77 OFFCURVE",
+"2131 76 OFFCURVE",
+"2062 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"2041 76 OFFCURVE",
+"2023 61 OFFCURVE",
+"2023 38 CURVE SMOOTH",
+"2023 14 OFFCURVE",
+"2041 0 OFFCURVE",
+"2062 0 CURVE SMOOTH",
+"2099 0 LINE SMOOTH",
+"2150 0 OFFCURVE",
+"2190 0 OFFCURVE",
+"2226 6 CURVE SMOOTH",
+"2284 17 OFFCURVE",
+"2313 59 OFFCURVE",
+"2313 111 CURVE SMOOTH",
+"2313 156 OFFCURVE",
+"2299 220 OFFCURVE",
+"2255 220 CURVE SMOOTH",
+"2226 220 OFFCURVE",
+"2213 211 OFFCURVE",
+"2200 182 CURVE SMOOTH",
+"2190 157 OFFCURVE",
+"2177 108 OFFCURVE",
+"2171 79 CURVE",
+"2153 77 OFFCURVE",
+"2131 76 OFFCURVE",
+"2062 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"2190 157 OFFCURVE",
+"2177 108 OFFCURVE",
+"2170 77 CURVE",
+"2146 77 LINE",
+"2137 82 OFFCURVE",
+"2125 99 OFFCURVE",
+"2095 149 CURVE SMOOTH",
+"2067 195 OFFCURVE",
+"2057 203 OFFCURVE",
+"2035 203 CURVE SMOOTH",
+"2014 203 OFFCURVE",
+"2005 195 OFFCURVE",
+"1993 177 CURVE SMOOTH",
+"1966 136 LINE SMOOTH",
+"1936 91 OFFCURVE",
+"1906 76 OFFCURVE",
+"1868 76 CURVE SMOOTH",
+"1847 76 OFFCURVE",
+"1829 61 OFFCURVE",
+"1829 38 CURVE SMOOTH",
+"1829 14 OFFCURVE",
+"1847 0 OFFCURVE",
+"1868 0 CURVE SMOOTH",
+"1936 0 OFFCURVE",
+"1989 20 OFFCURVE",
+"2033 70 CURVE",
+"2076 16 OFFCURVE",
+"2115 0 OFFCURVE",
+"2169 0 CURVE SMOOTH",
+"2182 0 OFFCURVE",
+"2190 0 OFFCURVE",
+"2226 6 CURVE SMOOTH",
+"2284 17 OFFCURVE",
+"2313 59 OFFCURVE",
+"2313 111 CURVE SMOOTH",
+"2313 156 OFFCURVE",
+"2299 220 OFFCURVE",
+"2255 220 CURVE SMOOTH",
+"2226 220 OFFCURVE",
+"2214 211 OFFCURVE",
+"2201 182 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"2217 150 OFFCURVE",
+"2188 93 OFFCURVE",
+"2175 77 CURVE",
+"2146 77 LINE",
+"2137 82 OFFCURVE",
+"2125 99 OFFCURVE",
+"2095 149 CURVE SMOOTH",
+"2067 195 OFFCURVE",
+"2057 204 OFFCURVE",
+"2035 204 CURVE SMOOTH",
+"2014 204 OFFCURVE",
+"2004 195 OFFCURVE",
+"1992 177 CURVE SMOOTH",
+"1965 136 LINE SMOOTH",
+"1935 91 OFFCURVE",
+"1896 76 OFFCURVE",
+"1858 76 CURVE SMOOTH",
+"1837 76 OFFCURVE",
+"1819 61 OFFCURVE",
+"1819 38 CURVE SMOOTH",
+"1819 14 OFFCURVE",
+"1837 0 OFFCURVE",
+"1858 0 CURVE SMOOTH",
+"1926 0 OFFCURVE",
+"1989 20 OFFCURVE",
+"2033 70 CURVE",
+"2076 16 OFFCURVE",
+"2105 0 OFFCURVE",
+"2162 0 CURVE SMOOTH",
+"2238 0 OFFCURVE",
+"2314 45 OFFCURVE",
+"2320 124 CURVE SMOOTH",
+"2323 167 OFFCURVE",
+"2313 210 OFFCURVE",
+"2278 210 CURVE SMOOTH",
+"2259 210 OFFCURVE",
+"2244 200 OFFCURVE",
+"2230 174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"2219 150 OFFCURVE",
+"2186 90 OFFCURVE",
+"2172 77 CURVE",
+"2146 77 LINE",
+"2137 82 OFFCURVE",
+"2125 99 OFFCURVE",
+"2095 149 CURVE SMOOTH",
+"2067 195 OFFCURVE",
+"2057 204 OFFCURVE",
+"2035 204 CURVE SMOOTH",
+"2014 204 OFFCURVE",
+"2004 195 OFFCURVE",
+"1992 177 CURVE SMOOTH",
+"1965 136 LINE SMOOTH",
+"1935 91 OFFCURVE",
+"1896 76 OFFCURVE",
+"1858 76 CURVE SMOOTH",
+"1837 76 OFFCURVE",
+"1819 61 OFFCURVE",
+"1819 38 CURVE SMOOTH",
+"1819 14 OFFCURVE",
+"1837 0 OFFCURVE",
+"1858 0 CURVE SMOOTH",
+"1926 0 OFFCURVE",
+"1989 20 OFFCURVE",
+"2033 70 CURVE",
+"2076 16 OFFCURVE",
+"2105 0 OFFCURVE",
+"2162 0 CURVE SMOOTH",
+"2238 0 OFFCURVE",
+"2314 45 OFFCURVE",
+"2320 124 CURVE SMOOTH",
+"2323 167 OFFCURVE",
+"2313 210 OFFCURVE",
+"2278 210 CURVE SMOOTH",
+"2259 210 OFFCURVE",
+"2246 200 OFFCURVE",
+"2232 174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1497 16 OFFCURVE",
+"1526 0 OFFCURVE",
+"1583 0 CURVE SMOOTH",
+"1636 0 OFFCURVE",
+"1686 23 OFFCURVE",
+"1715 60 CURVE SMOOTH",
+"1732 82 OFFCURVE",
+"1742 108 OFFCURVE",
+"1742 138 CURVE SMOOTH",
+"1742 176 OFFCURVE",
+"1730 210 OFFCURVE",
+"1699 210 CURVE SMOOTH",
+"1680 210 OFFCURVE",
+"1667 200 OFFCURVE",
+"1653 174 CURVE SMOOTH",
+"1640 150 OFFCURVE",
+"1607 90 OFFCURVE",
+"1593 77 CURVE",
+"1567 77 LINE",
+"1558 82 OFFCURVE",
+"1546 99 OFFCURVE",
+"1516 149 CURVE SMOOTH",
+"1488 195 OFFCURVE",
+"1478 204 OFFCURVE",
+"1456 204 CURVE SMOOTH",
+"1435 204 OFFCURVE",
+"1425 195 OFFCURVE",
+"1413 177 CURVE SMOOTH",
+"1386 136 LINE SMOOTH",
+"1356 91 OFFCURVE",
+"1327 69 OFFCURVE",
+"1288 69 CURVE SMOOTH",
+"1200 69 OFFCURVE",
+"1173 132 OFFCURVE",
+"1171 213 CURVE",
+"1107 209 LINE",
+"1105 203 OFFCURVE",
+"1105 187 OFFCURVE",
+"1105 183 CURVE SMOOTH",
+"1105 68 OFFCURVE",
+"1158 -7 OFFCURVE",
+"1289 -7 CURVE SMOOTH",
+"1357 -7 OFFCURVE",
+"1410 20 OFFCURVE",
+"1454 70 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1497 16 OFFCURVE",
+"1526 0 OFFCURVE",
+"1583 0 CURVE SMOOTH",
+"1636 0 OFFCURVE",
+"1686 23 OFFCURVE",
+"1715 60 CURVE SMOOTH",
+"1732 82 OFFCURVE",
+"1742 108 OFFCURVE",
+"1742 138 CURVE SMOOTH",
+"1742 176 OFFCURVE",
+"1730 210 OFFCURVE",
+"1699 210 CURVE SMOOTH",
+"1680 210 OFFCURVE",
+"1667 200 OFFCURVE",
+"1653 174 CURVE SMOOTH",
+"1640 150 OFFCURVE",
+"1607 90 OFFCURVE",
+"1593 77 CURVE",
+"1567 77 LINE",
+"1558 82 OFFCURVE",
+"1546 99 OFFCURVE",
+"1516 149 CURVE SMOOTH",
+"1488 195 OFFCURVE",
+"1478 204 OFFCURVE",
+"1456 204 CURVE SMOOTH",
+"1435 204 OFFCURVE",
+"1425 195 OFFCURVE",
+"1413 177 CURVE SMOOTH",
+"1386 136 LINE SMOOTH",
+"1356 91 OFFCURVE",
+"1327 69 OFFCURVE",
+"1288 69 CURVE SMOOTH",
+"1200 69 OFFCURVE",
+"1173 132 OFFCURVE",
+"1171 213 CURVE",
+"1107 209 LINE",
+"1105 203 OFFCURVE",
+"1105 187 OFFCURVE",
+"1105 183 CURVE SMOOTH",
+"1105 68 OFFCURVE",
+"1158 -7 OFFCURVE",
+"1289 -7 CURVE SMOOTH",
+"1357 -7 OFFCURVE",
+"1410 20 OFFCURVE",
+"1454 70 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"909 150 OFFCURVE",
+"876 90 OFFCURVE",
+"862 77 CURVE",
+"836 77 LINE",
+"827 82 OFFCURVE",
+"815 99 OFFCURVE",
+"785 149 CURVE SMOOTH",
+"757 195 OFFCURVE",
+"747 204 OFFCURVE",
+"725 204 CURVE SMOOTH",
+"704 204 OFFCURVE",
+"694 195 OFFCURVE",
+"682 177 CURVE SMOOTH",
+"655 136 LINE SMOOTH",
+"641 115 OFFCURVE",
+"625 100 OFFCURVE",
+"608 91 CURVE SMOOTH",
+"589 80 OFFCURVE",
+"568 76 OFFCURVE",
+"548 76 CURVE SMOOTH",
+"527 76 OFFCURVE",
+"509 61 OFFCURVE",
+"509 38 CURVE SMOOTH",
+"509 14 OFFCURVE",
+"527 0 OFFCURVE",
+"548 0 CURVE SMOOTH",
+"616 0 OFFCURVE",
+"679 20 OFFCURVE",
+"723 70 CURVE",
+"766 16 OFFCURVE",
+"795 0 OFFCURVE",
+"852 0 CURVE SMOOTH",
+"905 0 OFFCURVE",
+"955 23 OFFCURVE",
+"984 60 CURVE SMOOTH",
+"1001 82 OFFCURVE",
+"1011 108 OFFCURVE",
+"1011 138 CURVE SMOOTH",
+"1011 176 OFFCURVE",
+"999 210 OFFCURVE",
+"968 210 CURVE SMOOTH",
+"949 210 OFFCURVE",
+"936 200 OFFCURVE",
+"922 174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"315 0 OFFCURVE",
+"339 10 OFFCURVE",
+"367 41 CURVE SMOOTH",
+"375 49 OFFCURVE",
+"383 59 OFFCURVE",
+"391 70 CURVE",
+"431 17 OFFCURVE",
+"461 0 OFFCURVE",
+"546 0 CURVE SMOOTH",
+"551 0 LINE",
+"551 76 LINE",
+"541 76 OFFCURVE",
+"512 78 OFFCURVE",
+"502 82 CURVE",
+"493 89 OFFCURVE",
+"468 129 OFFCURVE",
+"457 149 CURVE SMOOTH",
+"430 196 OFFCURVE",
+"421 203 OFFCURVE",
+"397 203 CURVE SMOOTH",
+"376 203 OFFCURVE",
+"364 191 OFFCURVE",
+"353 172 CURVE SMOOTH",
+"330 131 LINE SMOOTH",
+"312 100 OFFCURVE",
+"303 85 OFFCURVE",
+"294 82 CURVE",
+"285 82 LINE",
+"276 87 OFFCURVE",
+"267 99 OFFCURVE",
+"237 149 CURVE SMOOTH",
+"209 195 OFFCURVE",
+"199 203 OFFCURVE",
+"177 203 CURVE SMOOTH",
+"156 203 OFFCURVE",
+"148 195 OFFCURVE",
+"135 177 CURVE SMOOTH",
+"106 137 LINE SMOOTH",
+"91 117 OFFCURVE",
+"77 100 OFFCURVE",
+"60 91 CURVE SMOOTH",
+"41 80 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"30 0 OFFCURVE",
+"59 4 OFFCURVE",
+"85 12 CURVE SMOOTH",
+"108 19 OFFCURVE",
+"128 30 OFFCURVE",
+"147 44 CURVE SMOOTH",
+"157 52 OFFCURVE",
+"166 60 OFFCURVE",
+"175 70 CURVE",
+"218 16 OFFCURVE",
+"248 0 OFFCURVE",
+"282 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"315 0 OFFCURVE",
+"339 10 OFFCURVE",
+"367 41 CURVE SMOOTH",
+"375 49 OFFCURVE",
+"383 59 OFFCURVE",
+"391 70 CURVE",
+"431 17 OFFCURVE",
+"461 0 OFFCURVE",
+"546 0 CURVE SMOOTH",
+"551 0 LINE",
+"551 76 LINE",
+"541 76 OFFCURVE",
+"512 78 OFFCURVE",
+"502 82 CURVE",
+"493 89 OFFCURVE",
+"468 129 OFFCURVE",
+"457 149 CURVE SMOOTH",
+"430 196 OFFCURVE",
+"421 203 OFFCURVE",
+"397 203 CURVE SMOOTH",
+"376 203 OFFCURVE",
+"364 191 OFFCURVE",
+"353 172 CURVE SMOOTH",
+"330 131 LINE SMOOTH",
+"312 100 OFFCURVE",
+"303 85 OFFCURVE",
+"294 82 CURVE",
+"285 82 LINE",
+"276 87 OFFCURVE",
+"267 99 OFFCURVE",
+"237 149 CURVE SMOOTH",
+"209 195 OFFCURVE",
+"199 203 OFFCURVE",
+"177 203 CURVE SMOOTH",
+"156 203 OFFCURVE",
+"148 195 OFFCURVE",
+"135 177 CURVE SMOOTH",
+"106 137 LINE SMOOTH",
+"91 117 OFFCURVE",
+"77 100 OFFCURVE",
+"60 91 CURVE SMOOTH",
+"41 80 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"30 0 OFFCURVE",
+"59 4 OFFCURVE",
+"85 12 CURVE SMOOTH",
+"108 19 OFFCURVE",
+"128 30 OFFCURVE",
+"147 44 CURVE SMOOTH",
+"157 52 OFFCURVE",
+"166 60 OFFCURVE",
+"175 70 CURVE",
+"218 16 OFFCURVE",
+"248 0 OFFCURVE",
+"282 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 203 OFFCURVE",
+"148 195 OFFCURVE",
+"135 177 CURVE SMOOTH",
+"106 137 LINE SMOOTH",
+"92 118 OFFCURVE",
+"77 100 OFFCURVE",
+"60 91 CURVE SMOOTH",
+"41 80 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"30 0 OFFCURVE",
+"58 3 OFFCURVE",
+"85 12 CURVE SMOOTH",
+"107 19 OFFCURVE",
+"128 30 OFFCURVE",
+"147 44 CURVE SMOOTH",
+"157 52 OFFCURVE",
+"166 60 OFFCURVE",
+"175 70 CURVE",
+"218 16 OFFCURVE",
+"247 0 OFFCURVE",
+"304 0 CURVE SMOOTH",
+"357 0 OFFCURVE",
+"407 23 OFFCURVE",
+"436 60 CURVE SMOOTH",
+"453 82 OFFCURVE",
+"463 108 OFFCURVE",
+"463 138 CURVE SMOOTH",
+"463 176 OFFCURVE",
+"451 210 OFFCURVE",
+"420 210 CURVE SMOOTH",
+"401 210 OFFCURVE",
+"388 200 OFFCURVE",
+"374 174 CURVE SMOOTH",
+"361 150 OFFCURVE",
+"328 90 OFFCURVE",
+"314 77 CURVE",
+"288 77 LINE",
+"279 82 OFFCURVE",
+"267 99 OFFCURVE",
+"237 149 CURVE SMOOTH",
+"209 195 OFFCURVE",
+"199 203 OFFCURVE",
+"177 203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 203 OFFCURVE",
+"148 195 OFFCURVE",
+"135 177 CURVE SMOOTH",
+"106 137 LINE SMOOTH",
+"92 118 OFFCURVE",
+"77 100 OFFCURVE",
+"60 91 CURVE SMOOTH",
+"41 80 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"30 0 OFFCURVE",
+"58 3 OFFCURVE",
+"85 12 CURVE SMOOTH",
+"107 19 OFFCURVE",
+"128 30 OFFCURVE",
+"147 44 CURVE SMOOTH",
+"157 52 OFFCURVE",
+"166 60 OFFCURVE",
+"175 70 CURVE",
+"218 16 OFFCURVE",
+"247 0 OFFCURVE",
+"304 0 CURVE SMOOTH",
+"357 0 OFFCURVE",
+"407 23 OFFCURVE",
+"436 60 CURVE SMOOTH",
+"453 82 OFFCURVE",
+"463 108 OFFCURVE",
+"463 138 CURVE SMOOTH",
+"463 176 OFFCURVE",
+"451 210 OFFCURVE",
+"420 210 CURVE SMOOTH",
+"401 210 OFFCURVE",
+"388 200 OFFCURVE",
+"374 174 CURVE SMOOTH",
+"361 150 OFFCURVE",
+"328 90 OFFCURVE",
+"314 77 CURVE",
+"288 77 LINE",
+"279 82 OFFCURVE",
+"267 99 OFFCURVE",
+"237 149 CURVE SMOOTH",
+"209 195 OFFCURVE",
+"199 203 OFFCURVE",
+"177 203 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"158 203 OFFCURVE",
+"148 195 OFFCURVE",
+"135 177 CURVE SMOOTH",
+"106 137 LINE SMOOTH",
+"92 118 OFFCURVE",
+"77 100 OFFCURVE",
+"60 91 CURVE SMOOTH",
+"41 80 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"30 0 OFFCURVE",
+"58 3 OFFCURVE",
+"85 12 CURVE SMOOTH",
+"107 19 OFFCURVE",
+"128 30 OFFCURVE",
+"147 44 CURVE SMOOTH",
+"157 52 OFFCURVE",
+"166 60 OFFCURVE",
+"175 70 CURVE",
+"218 16 OFFCURVE",
+"247 0 OFFCURVE",
+"304 0 CURVE SMOOTH",
+"347 0 OFFCURVE",
+"397 22 OFFCURVE",
+"424 60 CURVE SMOOTH",
+"443 87 OFFCURVE",
+"454 112 OFFCURVE",
+"454 143 CURVE SMOOTH",
+"454 177 OFFCURVE",
+"442 210 OFFCURVE",
+"411 210 CURVE SMOOTH",
+"392 210 OFFCURVE",
+"379 200 OFFCURVE",
+"365 174 CURVE SMOOTH",
+"325 102 OFFCURVE",
+"313 82 OFFCURVE",
+"300 82 CURVE SMOOTH",
+"296 82 LINE SMOOTH",
+"284 82 OFFCURVE",
+"277 92 OFFCURVE",
+"241 149 CURVE SMOOTH",
+"212 195 OFFCURVE",
+"201 203 OFFCURVE",
+"179 203 CURVE SMOOTH"
+);
+}
+);
+width = 530;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071F.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{503, 447}";
+},
+{
+name = RU;
+position = "{486, -75}";
+},
+{
+name = bottom;
+position = "{241, -98}";
+},
+{
+name = top;
+position = "{258, 537}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"318 0 LINE SMOOTH",
+"455 0 OFFCURVE",
+"499 67 OFFCURVE",
+"499 159 CURVE SMOOTH",
+"499 340 OFFCURVE",
+"388 436 OFFCURVE",
+"271 436 CURVE SMOOTH",
+"166 436 OFFCURVE",
+"78 358 OFFCURVE",
+"56 251 CURVE",
+"120 238 LINE",
+"146 319 OFFCURVE",
+"208 360 OFFCURVE",
+"272 360 CURVE SMOOTH",
+"360 360 OFFCURVE",
+"425 279 OFFCURVE",
+"425 168 CURVE SMOOTH",
+"425 108 OFFCURVE",
+"401 76 OFFCURVE",
+"327 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 567;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074E.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{299, -98}";
+},
+{
+name = top;
+position = "{140, 680}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"286 613 LINE",
+"356 584 LINE SMOOTH",
+"408 563 OFFCURVE",
+"425 538 OFFCURVE",
+"425 508 CURVE SMOOTH",
+"425 470 OFFCURVE",
+"397 454 OFFCURVE",
+"368 450 CURVE",
+"328 471 OFFCURVE",
+"278 486 OFFCURVE",
+"213 486 CURVE",
+"200 416 LINE",
+"228 414 LINE SMOOTH",
+"327 404 OFFCURVE",
+"453 339 OFFCURVE",
+"453 195 CURVE SMOOTH",
+"453 83 OFFCURVE",
+"368 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"272 0 LINE SMOOTH",
+"427 0 OFFCURVE",
+"524 42 OFFCURVE",
+"524 188 CURVE SMOOTH",
+"524 290 OFFCURVE",
+"484 359 OFFCURVE",
+"424 406 CURVE",
+"424 409 LINE",
+"474 427 OFFCURVE",
+"500 469 OFFCURVE",
+"500 521 CURVE SMOOTH",
+"500 581 OFFCURVE",
+"452 623 OFFCURVE",
+"386 649 CURVE SMOOTH",
+"316 678 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"286 613 LINE",
+"356 584 LINE SMOOTH",
+"408 563 OFFCURVE",
+"425 538 OFFCURVE",
+"425 508 CURVE SMOOTH",
+"425 470 OFFCURVE",
+"397 454 OFFCURVE",
+"368 450 CURVE",
+"328 471 OFFCURVE",
+"278 486 OFFCURVE",
+"213 486 CURVE",
+"200 416 LINE",
+"228 414 LINE SMOOTH",
+"327 404 OFFCURVE",
+"453 339 OFFCURVE",
+"453 195 CURVE SMOOTH",
+"453 83 OFFCURVE",
+"368 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"272 0 LINE SMOOTH",
+"427 0 OFFCURVE",
+"524 42 OFFCURVE",
+"524 188 CURVE SMOOTH",
+"524 290 OFFCURVE",
+"484 359 OFFCURVE",
+"424 406 CURVE",
+"424 409 LINE",
+"474 427 OFFCURVE",
+"500 469 OFFCURVE",
+"500 521 CURVE SMOOTH",
+"500 581 OFFCURVE",
+"452 623 OFFCURVE",
+"386 649 CURVE SMOOTH",
+"316 678 LINE"
+);
+}
+);
+width = 593;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{192, -98}";
+},
+{
+name = top;
+position = "{148, 707}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-57 693 LINE",
+"-114 642 LINE",
+"373 87 LINE",
+"353 75 OFFCURVE",
+"321 76 OFFCURVE",
+"306 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"295 0 LINE SMOOTH",
+"363 0 OFFCURVE",
+"400 10 OFFCURVE",
+"420 33 CURVE",
+"459 -12 LINE",
+"518 38 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-57 693 LINE",
+"-114 642 LINE",
+"373 87 LINE",
+"355 77 OFFCURVE",
+"331 76 OFFCURVE",
+"306 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"295 0 LINE SMOOTH",
+"363 0 OFFCURVE",
+"400 10 OFFCURVE",
+"420 33 CURVE",
+"459 -12 LINE",
+"518 38 LINE"
+);
+}
+);
+width = 566;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0721.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{375, -98}";
+},
+{
+name = top;
+position = "{385, 507}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"6 404 LINE",
+"278 109 LINE",
+"274 77 OFFCURVE",
+"218 76 OFFCURVE",
+"195 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"185 0 LINE SMOOTH",
+"274 0 OFFCURVE",
+"315 22 OFFCURVE",
+"333 61 CURVE",
+"336 61 LINE",
+"379 20 OFFCURVE",
+"437 0 OFFCURVE",
+"502 0 CURVE SMOOTH",
+"573 0 OFFCURVE",
+"634 34 OFFCURVE",
+"666 88 CURVE SMOOTH",
+"683 118 OFFCURVE",
+"691 153 OFFCURVE",
+"691 190 CURVE SMOOTH",
+"691 308 OFFCURVE",
+"602 405 OFFCURVE",
+"466 405 CURVE SMOOTH",
+"378 405 OFFCURVE",
+"276 359 OFFCURVE",
+"268 220 CURVE",
+"265 220 LINE",
+"255 235 OFFCURVE",
+"241 254 OFFCURVE",
+"219 279 CURVE SMOOTH",
+"64 455 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 74 OFFCURVE",
+"333 147 OFFCURVE",
+"333 206 CURVE SMOOTH",
+"333 292 OFFCURVE",
+"396 332 OFFCURVE",
+"466 332 CURVE SMOOTH",
+"558 332 OFFCURVE",
+"618 272 OFFCURVE",
+"618 192 CURVE SMOOTH",
+"618 107 OFFCURVE",
+"559 74 OFFCURVE",
+"493 74 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"6 404 LINE",
+"278 109 LINE",
+"274 77 OFFCURVE",
+"218 76 OFFCURVE",
+"195 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"185 0 LINE SMOOTH",
+"274 0 OFFCURVE",
+"315 22 OFFCURVE",
+"333 61 CURVE",
+"336 61 LINE",
+"379 20 OFFCURVE",
+"437 0 OFFCURVE",
+"502 0 CURVE SMOOTH",
+"624 0 OFFCURVE",
+"691 86 OFFCURVE",
+"691 190 CURVE SMOOTH",
+"691 308 OFFCURVE",
+"602 405 OFFCURVE",
+"466 405 CURVE SMOOTH",
+"385 405 OFFCURVE",
+"293 366 OFFCURVE",
+"272 253 CURVE SMOOTH",
+"270 243 OFFCURVE",
+"269 232 OFFCURVE",
+"268 220 CURVE",
+"265 220 LINE",
+"255 235 OFFCURVE",
+"241 254 OFFCURVE",
+"219 279 CURVE SMOOTH",
+"64 455 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 74 OFFCURVE",
+"333 147 OFFCURVE",
+"333 206 CURVE SMOOTH",
+"333 292 OFFCURVE",
+"396 332 OFFCURVE",
+"466 332 CURVE SMOOTH",
+"558 332 OFFCURVE",
+"618 272 OFFCURVE",
+"618 192 CURVE SMOOTH",
+"618 107 OFFCURVE",
+"559 74 OFFCURVE",
+"493 74 CURVE SMOOTH"
+);
+}
+);
+width = 741;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{147, -98}";
+},
+{
+name = top;
+position = "{160, 537}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"136 412 LINE",
+"145 362 OFFCURVE",
+"150 260 OFFCURVE",
+"150 239 CURVE SMOOTH",
+"150 211 OFFCURVE",
+"149 142 OFFCURVE",
+"143 120 CURVE SMOOTH",
+"134 91 OFFCURVE",
+"114 76 OFFCURVE",
+"77 76 CURVE SMOOTH",
+"-20 76 LINE SMOOTH",
+"-41 76 OFFCURVE",
+"-59 61 OFFCURVE",
+"-59 38 CURVE SMOOTH",
+"-59 14 OFFCURVE",
+"-41 0 OFFCURVE",
+"-20 0 CURVE SMOOTH",
+"63 0 LINE SMOOTH",
+"131 0 OFFCURVE",
+"180 20 OFFCURVE",
+"204 73 CURVE SMOOTH",
+"222 114 OFFCURVE",
+"224 169 OFFCURVE",
+"224 237 CURVE SMOOTH",
+"224 264 OFFCURVE",
+"218 381 OFFCURVE",
+"209 423 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"141 268 LINE",
+"144 222 OFFCURVE",
+"144 215 OFFCURVE",
+"144 193 CURVE SMOOTH",
+"144 172 OFFCURVE",
+"143 143 OFFCURVE",
+"137 121 CURVE SMOOTH",
+"129 92 OFFCURVE",
+"110 76 OFFCURVE",
+"69 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"48 0 LINE SMOOTH",
+"101 0 OFFCURVE",
+"141 11 OFFCURVE",
+"172 41 CURVE",
+"201 10 OFFCURVE",
+"237 0 OFFCURVE",
+"316 0 CURVE",
+"316 76 LINE",
+"259 76 OFFCURVE",
+"220 84 OFFCURVE",
+"207 99 CURVE",
+"214 129 OFFCURVE",
+"217 163 OFFCURVE",
+"217 191 CURVE SMOOTH",
+"217 227 OFFCURVE",
+"216 239 OFFCURVE",
+"211 274 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"217 213 OFFCURVE",
+"216 244 OFFCURVE",
+"211 274 CURVE",
+"141 268 LINE",
+"144 237 OFFCURVE",
+"144 211 OFFCURVE",
+"144 203 CURVE SMOOTH",
+"144 182 OFFCURVE",
+"143 153 OFFCURVE",
+"137 131 CURVE SMOOTH",
+"129 99 OFFCURVE",
+"110 76 OFFCURVE",
+"69 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"38 0 LINE SMOOTH",
+"173 0 OFFCURVE",
+"217 67 OFFCURVE",
+"217 201 CURVE"
+);
+}
+);
+width = 316;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0726.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{498, 547}";
+},
+{
+name = RU;
+position = "{485, -70}";
+},
+{
+name = bottom;
+position = "{236, -98}";
+},
+{
+name = top;
+position = "{255, 634}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"272 0 LINE",
+"427 0 OFFCURVE",
+"524 61 OFFCURVE",
+"524 208 CURVE SMOOTH",
+"524 401 OFFCURVE",
+"388 533 OFFCURVE",
+"258 533 CURVE SMOOTH",
+"153 533 OFFCURVE",
+"59 464 OFFCURVE",
+"59 349 CURVE SMOOTH",
+"59 229 OFFCURVE",
+"155 187 OFFCURVE",
+"255 187 CURVE SMOOTH",
+"323 187 OFFCURVE",
+"397 215 OFFCURVE",
+"446 264 CURVE",
+"449 264 LINE",
+"451 248 OFFCURVE",
+"453 231 OFFCURVE",
+"453 214 CURVE SMOOTH",
+"453 103 OFFCURVE",
+"368 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"178 260 OFFCURVE",
+"132 293 OFFCURVE",
+"132 356 CURVE SMOOTH",
+"132 416 OFFCURVE",
+"186 457 OFFCURVE",
+"258 457 CURVE SMOOTH",
+"328 457 OFFCURVE",
+"393 410 OFFCURVE",
+"428 333 CURVE",
+"386 285 OFFCURVE",
+"317 260 OFFCURVE",
+"257 260 CURVE SMOOTH"
+);
+}
+);
+width = 592;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0729.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{287, -98}";
+},
+{
+name = top;
+position = "{292, 515}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"163 417 OFFCURVE",
+"63 341 OFFCURVE",
+"63 214 CURVE SMOOTH",
+"63 158 OFFCURVE",
+"82 115 OFFCURVE",
+"123 78 CURVE",
+"123 74 LINE",
+"101 76 OFFCURVE",
+"77 76 OFFCURVE",
+"62 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"287 0 LINE SMOOTH",
+"417 0 OFFCURVE",
+"511 75 OFFCURVE",
+"511 206 CURVE SMOOTH",
+"511 326 OFFCURVE",
+"418 417 OFFCURVE",
+"276 417 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 344 OFFCURVE",
+"437 286 OFFCURVE",
+"437 207 CURVE SMOOTH",
+"437 119 OFFCURVE",
+"372 76 OFFCURVE",
+"296 76 CURVE SMOOTH",
+"198 76 OFFCURVE",
+"136 138 OFFCURVE",
+"136 218 CURVE SMOOTH",
+"136 296 OFFCURVE",
+"201 344 OFFCURVE",
+"276 344 CURVE SMOOTH"
+);
+}
+);
+width = 561;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0727.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{310, -98}";
+},
+{
+name = top;
+position = "{329, 621}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"596 76 LINE",
+"478 76 LINE SMOOTH",
+"327 76 OFFCURVE",
+"160 77 OFFCURVE",
+"160 259 CURVE SMOOTH",
+"160 369 OFFCURVE",
+"249 442 OFFCURVE",
+"339 442 CURVE SMOOTH",
+"431 442 OFFCURVE",
+"479 401 OFFCURVE",
+"479 340 CURVE SMOOTH",
+"479 290 OFFCURVE",
+"444 260 OFFCURVE",
+"391 260 CURVE SMOOTH",
+"358 260 OFFCURVE",
+"321 279 OFFCURVE",
+"315 324 CURVE",
+"256 317 LINE",
+"256 243 OFFCURVE",
+"316 194 OFFCURVE",
+"394 194 CURVE SMOOTH",
+"490 194 OFFCURVE",
+"549 262 OFFCURVE",
+"549 342 CURVE SMOOTH",
+"549 436 OFFCURVE",
+"471 518 OFFCURVE",
+"336 518 CURVE SMOOTH",
+"207 518 OFFCURVE",
+"85 401 OFFCURVE",
+"85 253 CURVE SMOOTH",
+"85 164 OFFCURVE",
+"116 110 OFFCURVE",
+"170 78 CURVE",
+"168 74 LINE",
+"146 76 OFFCURVE",
+"122 76 OFFCURVE",
+"101 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"596 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"596 76 LINE",
+"478 76 LINE SMOOTH",
+"327 76 OFFCURVE",
+"160 77 OFFCURVE",
+"160 259 CURVE SMOOTH",
+"160 369 OFFCURVE",
+"249 442 OFFCURVE",
+"339 442 CURVE SMOOTH",
+"431 442 OFFCURVE",
+"479 401 OFFCURVE",
+"479 340 CURVE SMOOTH",
+"479 290 OFFCURVE",
+"444 260 OFFCURVE",
+"391 260 CURVE SMOOTH",
+"358 260 OFFCURVE",
+"321 279 OFFCURVE",
+"315 324 CURVE",
+"256 317 LINE",
+"256 243 OFFCURVE",
+"316 194 OFFCURVE",
+"394 194 CURVE SMOOTH",
+"490 194 OFFCURVE",
+"549 262 OFFCURVE",
+"549 342 CURVE SMOOTH",
+"549 436 OFFCURVE",
+"471 518 OFFCURVE",
+"336 518 CURVE SMOOTH",
+"207 518 OFFCURVE",
+"85 401 OFFCURVE",
+"85 253 CURVE SMOOTH",
+"85 164 OFFCURVE",
+"116 110 OFFCURVE",
+"170 78 CURVE",
+"168 74 LINE",
+"146 76 OFFCURVE",
+"122 76 OFFCURVE",
+"101 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"596 0 LINE"
+);
+}
+);
+width = 655;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0723.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{414, -98}";
+},
+{
+name = top;
+position = "{417, 477}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"504 403 OFFCURVE",
+"448 376 OFFCURVE",
+"419 320 CURVE",
+"416 320 LINE",
+"385 370 OFFCURVE",
+"330 399 OFFCURVE",
+"259 399 CURVE SMOOTH",
+"161 399 OFFCURVE",
+"73 335 OFFCURVE",
+"73 212 CURVE SMOOTH",
+"73 156 OFFCURVE",
+"89 113 OFFCURVE",
+"123 78 CURVE",
+"123 74 LINE",
+"102 76 OFFCURVE",
+"80 76 OFFCURVE",
+"61 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"267 0 LINE",
+"419 0 LINE",
+"532 0 LINE SMOOTH",
+"666 0 OFFCURVE",
+"753 66 OFFCURVE",
+"753 203 CURVE SMOOTH",
+"753 322 OFFCURVE",
+"679 403 OFFCURVE",
+"564 403 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"187 76 OFFCURVE",
+"145 138 OFFCURVE",
+"145 216 CURVE SMOOTH",
+"145 292 OFFCURVE",
+"199 326 OFFCURVE",
+"259 326 CURVE SMOOTH",
+"347 326 OFFCURVE",
+"389 266 OFFCURVE",
+"389 168 CURVE SMOOTH",
+"389 81 OFFCURVE",
+"324 76 OFFCURVE",
+"271 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 76 OFFCURVE",
+"446 95 OFFCURVE",
+"446 202 CURVE SMOOTH",
+"446 295 OFFCURVE",
+"511 330 OFFCURVE",
+"564 330 CURVE SMOOTH",
+"640 330 OFFCURVE",
+"683 285 OFFCURVE",
+"683 209 CURVE SMOOTH",
+"683 110 OFFCURVE",
+"612 76 OFFCURVE",
+"549 76 CURVE SMOOTH"
+);
+}
+);
+width = 812;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0724.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{414, -98}";
+},
+{
+name = top;
+position = "{417, 477}";
+}
+);
+components = (
+{
+name = uni0723.loclSYRJ.Init;
+}
+);
+layerId = UUID0;
+width = 812;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072B.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{238, -98}";
+},
+{
+name = top;
+position = "{247, 452}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"2342 -17 OFFCURVE",
+"2375 39 OFFCURVE",
+"2385 82 CURVE",
+"2388 82 LINE",
+"2425 39 OFFCURVE",
+"2481 -4 OFFCURVE",
+"2546 -10 CURVE",
+"2565 56 LINE",
+"2519 67 OFFCURVE",
+"2485 85 OFFCURVE",
+"2426 153 CURVE SMOOTH",
+"2178 436 LINE",
+"2121 384 LINE",
+"2321 156 LINE SMOOTH",
+"2330 146 OFFCURVE",
+"2333 135 OFFCURVE",
+"2333 123 CURVE SMOOTH",
+"2333 90 OFFCURVE",
+"2304 59 OFFCURVE",
+"2258 59 CURVE SMOOTH",
+"2221 59 OFFCURVE",
+"2193 88 OFFCURVE",
+"2162 124 CURVE SMOOTH",
+"1921 397 LINE",
+"1864 346 LINE",
+"2096 82 LINE SMOOTH",
+"2160 9 OFFCURVE",
+"2203 -17 OFFCURVE",
+"2254 -17 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"2380 210 LINE",
+"2380 296 OFFCURVE",
+"2284 351 OFFCURVE",
+"2211 351 CURVE SMOOTH",
+"2054 351 OFFCURVE",
+"2058 200 OFFCURVE",
+"2084 79 CURVE",
+"2073 77 OFFCURVE",
+"2036 76 OFFCURVE",
+"1996 76 CURVE SMOOTH",
+"1975 76 OFFCURVE",
+"1957 61 OFFCURVE",
+"1957 38 CURVE SMOOTH",
+"1957 14 OFFCURVE",
+"1975 0 OFFCURVE",
+"1996 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1511 329 OFFCURVE",
+"1459 248 OFFCURVE",
+"1443 79 CURVE",
+"1432 77 OFFCURVE",
+"1404 76 OFFCURVE",
+"1384 76 CURVE SMOOTH",
+"1363 76 OFFCURVE",
+"1345 61 OFFCURVE",
+"1345 38 CURVE SMOOTH",
+"1345 14 OFFCURVE",
+"1363 0 OFFCURVE",
+"1384 0 CURVE SMOOTH",
+"1580 0 LINE SMOOTH",
+"1668 0 OFFCURVE",
+"1737 12 OFFCURVE",
+"1773 77 CURVE",
+"1776 77 LINE",
+"1813 34 OFFCURVE",
+"1871 -5 OFFCURVE",
+"1937 -5 CURVE",
+"1947 63 LINE",
+"1900 68 OFFCURVE",
+"1869 77 OFFCURVE",
+"1814 148 CURVE SMOOTH",
+"1778 194 LINE SMOOTH",
+"1724 262 OFFCURVE",
+"1672 329 OFFCURVE",
+"1591 329 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"869 290 OFFCURVE",
+"835 242 OFFCURVE",
+"798 79 CURVE",
+"787 77 OFFCURVE",
+"757 76 OFFCURVE",
+"737 76 CURVE SMOOTH",
+"716 76 OFFCURVE",
+"698 61 OFFCURVE",
+"698 38 CURVE SMOOTH",
+"698 14 OFFCURVE",
+"716 0 OFFCURVE",
+"737 0 CURVE SMOOTH",
+"923 0 LINE SMOOTH",
+"1011 0 OFFCURVE",
+"1083 3 OFFCURVE",
+"1119 36 CURVE",
+"1122 36 LINE",
+"1159 8 OFFCURVE",
+"1206 0 OFFCURVE",
+"1238 0 CURVE",
+"1238 76 LINE",
+"1207 76 OFFCURVE",
+"1182 82 OFFCURVE",
+"1144 127 CURVE SMOOTH",
+"1086 194 LINE SMOOTH",
+"1034 254 OFFCURVE",
+"998 290 OFFCURVE",
+"946 290 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"854 329 OFFCURVE",
+"802 248 OFFCURVE",
+"786 79 CURVE",
+"775 77 OFFCURVE",
+"747 76 OFFCURVE",
+"727 76 CURVE SMOOTH",
+"706 76 OFFCURVE",
+"688 61 OFFCURVE",
+"688 38 CURVE SMOOTH",
+"688 14 OFFCURVE",
+"706 0 OFFCURVE",
+"727 0 CURVE SMOOTH",
+"923 0 LINE SMOOTH",
+"1011 0 OFFCURVE",
+"1083 3 OFFCURVE",
+"1119 36 CURVE",
+"1122 36 LINE",
+"1159 8 OFFCURVE",
+"1209 -6 OFFCURVE",
+"1261 -6 CURVE",
+"1264 62 LINE",
+"1217 65 OFFCURVE",
+"1179 82 OFFCURVE",
+"1124 153 CURVE SMOOTH",
+"1112 168 LINE SMOOTH",
+"1058 236 OFFCURVE",
+"1015 329 OFFCURVE",
+"934 329 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"869 290 OFFCURVE",
+"835 242 OFFCURVE",
+"798 79 CURVE",
+"787 77 OFFCURVE",
+"707 76 OFFCURVE",
+"687 76 CURVE SMOOTH",
+"666 76 OFFCURVE",
+"648 61 OFFCURVE",
+"648 38 CURVE SMOOTH",
+"648 14 OFFCURVE",
+"666 0 OFFCURVE",
+"687 0 CURVE SMOOTH",
+"923 0 LINE SMOOTH",
+"1011 0 OFFCURVE",
+"1083 3 OFFCURVE",
+"1119 36 CURVE",
+"1122 36 LINE",
+"1159 8 OFFCURVE",
+"1196 0 OFFCURVE",
+"1218 0 CURVE",
+"1218 76 LINE",
+"1209 76 OFFCURVE",
+"1182 82 OFFCURVE",
+"1144 127 CURVE SMOOTH",
+"1086 194 LINE SMOOTH",
+"1034 254 OFFCURVE",
+"998 290 OFFCURVE",
+"946 290 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"152 290 OFFCURVE",
+"118 242 OFFCURVE",
+"81 79 CURVE",
+"70 77 OFFCURVE",
+"-10 76 OFFCURVE",
+"-30 76 CURVE SMOOTH",
+"-51 76 OFFCURVE",
+"-69 61 OFFCURVE",
+"-69 38 CURVE SMOOTH",
+"-69 14 OFFCURVE",
+"-51 0 OFFCURVE",
+"-30 0 CURVE SMOOTH",
+"206 0 LINE SMOOTH",
+"294 0 OFFCURVE",
+"366 3 OFFCURVE",
+"402 36 CURVE",
+"405 36 LINE",
+"442 8 OFFCURVE",
+"496 -3 OFFCURVE",
+"528 -3 CURVE",
+"528 73 LINE",
+"502 73 OFFCURVE",
+"465 82 OFFCURVE",
+"427 127 CURVE SMOOTH",
+"369 194 LINE SMOOTH",
+"317 254 OFFCURVE",
+"281 290 OFFCURVE",
+"229 290 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"152 290 OFFCURVE",
+"102 230 OFFCURVE",
+"96 79 CURVE",
+"85 77 OFFCURVE",
+"-10 76 OFFCURVE",
+"-30 76 CURVE SMOOTH",
+"-51 76 OFFCURVE",
+"-69 61 OFFCURVE",
+"-69 38 CURVE SMOOTH",
+"-69 14 OFFCURVE",
+"-51 0 OFFCURVE",
+"-30 0 CURVE SMOOTH",
+"206 0 LINE SMOOTH",
+"294 0 OFFCURVE",
+"366 3 OFFCURVE",
+"402 36 CURVE",
+"405 36 LINE",
+"442 8 OFFCURVE",
+"479 0 OFFCURVE",
+"501 0 CURVE",
+"501 76 LINE",
+"492 76 OFFCURVE",
+"465 82 OFFCURVE",
+"427 127 CURVE SMOOTH",
+"369 194 LINE SMOOTH",
+"317 254 OFFCURVE",
+"281 290 OFFCURVE",
+"229 290 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"152 290 OFFCURVE",
+"102 230 OFFCURVE",
+"96 79 CURVE",
+"85 77 OFFCURVE",
+"-10 76 OFFCURVE",
+"-30 76 CURVE SMOOTH",
+"-51 76 OFFCURVE",
+"-69 61 OFFCURVE",
+"-69 38 CURVE SMOOTH",
+"-69 14 OFFCURVE",
+"-51 0 OFFCURVE",
+"-30 0 CURVE SMOOTH",
+"206 0 LINE SMOOTH",
+"294 0 OFFCURVE",
+"366 3 OFFCURVE",
+"402 36 CURVE",
+"405 36 LINE",
+"442 8 OFFCURVE",
+"479 0 OFFCURVE",
+"501 0 CURVE",
+"501 76 LINE",
+"492 76 OFFCURVE",
+"465 82 OFFCURVE",
+"427 127 CURVE SMOOTH",
+"369 194 LINE SMOOTH",
+"317 254 OFFCURVE",
+"281 290 OFFCURVE",
+"229 290 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"143 295 OFFCURVE",
+"102 230 OFFCURVE",
+"96 79 CURVE",
+"85 77 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"206 0 LINE SMOOTH",
+"294 0 OFFCURVE",
+"366 3 OFFCURVE",
+"405 36 CURVE",
+"442 8 OFFCURVE",
+"496 -3 OFFCURVE",
+"528 -3 CURVE",
+"528 73 LINE",
+"502 73 OFFCURVE",
+"465 82 OFFCURVE",
+"427 127 CURVE SMOOTH",
+"369 194 LINE SMOOTH",
+"317 254 OFFCURVE",
+"272 295 OFFCURVE",
+"220 295 CURVE SMOOTH"
+);
+}
+);
+width = 588;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071B.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{196, -381}";
+},
+{
+name = top;
+position = "{210, 690}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"26 -244 OFFCURVE",
+"102 -316 OFFCURVE",
+"202 -316 CURVE SMOOTH",
+"305 -316 OFFCURVE",
+"385 -248 OFFCURVE",
+"385 -127 CURVE SMOOTH",
+"385 7 OFFCURVE",
+"283 71 OFFCURVE",
+"161 75 CURVE",
+"183 118 OFFCURVE",
+"221 170 OFFCURVE",
+"251 210 CURVE SMOOTH",
+"349 341 OFFCURVE",
+"376 422 OFFCURVE",
+"376 490 CURVE SMOOTH",
+"376 554 OFFCURVE",
+"366 602 OFFCURVE",
+"313 655 CURVE",
+"309 655 LINE",
+"261 594 LINE",
+"292 559 OFFCURVE",
+"303 527 OFFCURVE",
+"303 484 CURVE SMOOTH",
+"303 442 OFFCURVE",
+"278 375 OFFCURVE",
+"224 298 CURVE",
+"177 234 OFFCURVE",
+"115 146 OFFCURVE",
+"82 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"52 0 LINE",
+"38 -39 OFFCURVE",
+"26 -83 OFFCURVE",
+"26 -134 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"148 0 LINE SMOOTH",
+"240 0 OFFCURVE",
+"314 -35 OFFCURVE",
+"314 -125 CURVE SMOOTH",
+"314 -200 OFFCURVE",
+"269 -243 OFFCURVE",
+"204 -243 CURVE SMOOTH",
+"128 -243 OFFCURVE",
+"97 -185 OFFCURVE",
+"97 -124 CURVE SMOOTH",
+"97 -88 OFFCURVE",
+"106 -41 OFFCURVE",
+"125 0 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"26 -244 OFFCURVE",
+"102 -316 OFFCURVE",
+"202 -316 CURVE SMOOTH",
+"305 -316 OFFCURVE",
+"385 -248 OFFCURVE",
+"385 -127 CURVE SMOOTH",
+"385 2 OFFCURVE",
+"295 66 OFFCURVE",
+"176 74 CURVE SMOOTH",
+"161 75 LINE",
+"183 118 OFFCURVE",
+"221 170 OFFCURVE",
+"251 210 CURVE SMOOTH",
+"349 341 OFFCURVE",
+"376 422 OFFCURVE",
+"376 490 CURVE SMOOTH",
+"376 554 OFFCURVE",
+"366 602 OFFCURVE",
+"313 655 CURVE",
+"309 655 LINE",
+"261 594 LINE",
+"292 559 OFFCURVE",
+"303 527 OFFCURVE",
+"303 484 CURVE SMOOTH",
+"303 442 OFFCURVE",
+"278 374 OFFCURVE",
+"223 298 CURVE SMOOTH",
+"177 233 OFFCURVE",
+"115 145 OFFCURVE",
+"82 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"52 0 LINE",
+"38 -39 OFFCURVE",
+"26 -83 OFFCURVE",
+"26 -134 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"148 0 LINE",
+"240 0 OFFCURVE",
+"314 -35 OFFCURVE",
+"314 -125 CURVE SMOOTH",
+"314 -200 OFFCURVE",
+"269 -243 OFFCURVE",
+"204 -243 CURVE SMOOTH",
+"128 -243 OFFCURVE",
+"97 -185 OFFCURVE",
+"97 -124 CURVE SMOOTH",
+"97 -88 OFFCURVE",
+"106 -41 OFFCURVE",
+"125 0 CURVE"
+);
+}
+);
+width = 438;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071C.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{198, -381}";
+},
+{
+name = top;
+position = "{211, 688}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"165 -143 OFFCURVE",
+"181 -157 OFFCURVE",
+"203 -157 CURVE SMOOTH",
+"223 -157 OFFCURVE",
+"240 -143 OFFCURVE",
+"240 -116 CURVE SMOOTH",
+"240 -89 OFFCURVE",
+"223 -75 OFFCURVE",
+"203 -75 CURVE SMOOTH",
+"181 -75 OFFCURVE",
+"165 -89 OFFCURVE",
+"165 -116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"26 -244 OFFCURVE",
+"102 -316 OFFCURVE",
+"202 -316 CURVE SMOOTH",
+"305 -316 OFFCURVE",
+"385 -248 OFFCURVE",
+"385 -127 CURVE SMOOTH",
+"385 2 OFFCURVE",
+"295 66 OFFCURVE",
+"176 74 CURVE SMOOTH",
+"161 75 LINE",
+"183 118 OFFCURVE",
+"221 170 OFFCURVE",
+"251 210 CURVE SMOOTH",
+"349 341 OFFCURVE",
+"376 422 OFFCURVE",
+"376 490 CURVE SMOOTH",
+"376 554 OFFCURVE",
+"366 602 OFFCURVE",
+"313 655 CURVE",
+"309 655 LINE",
+"261 594 LINE",
+"292 559 OFFCURVE",
+"303 527 OFFCURVE",
+"303 484 CURVE SMOOTH",
+"303 442 OFFCURVE",
+"278 374 OFFCURVE",
+"223 298 CURVE SMOOTH",
+"177 233 OFFCURVE",
+"115 145 OFFCURVE",
+"82 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"52 0 LINE",
+"38 -39 OFFCURVE",
+"26 -83 OFFCURVE",
+"26 -134 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"148 0 LINE",
+"240 0 OFFCURVE",
+"314 -35 OFFCURVE",
+"314 -125 CURVE SMOOTH",
+"314 -200 OFFCURVE",
+"269 -243 OFFCURVE",
+"204 -243 CURVE SMOOTH",
+"128 -243 OFFCURVE",
+"97 -185 OFFCURVE",
+"97 -124 CURVE SMOOTH",
+"97 -88 OFFCURVE",
+"106 -41 OFFCURVE",
+"125 0 CURVE"
+);
+}
+);
+width = 438;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071D.loclSYRJ.Init;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{157, -98}";
+},
+{
+name = top;
+position = "{175, 341}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1320 90 OFFCURVE",
+"1303 132 OFFCURVE",
+"1294 152 CURVE SMOOTH",
+"1271 202 OFFCURVE",
+"1263 213 OFFCURVE",
+"1232 213 CURVE SMOOTH",
+"1203 213 OFFCURVE",
+"1194 200 OFFCURVE",
+"1182 182 CURVE SMOOTH",
+"1151 133 LINE SMOOTH",
+"1120 84 OFFCURVE",
+"1092 76 OFFCURVE",
+"1054 76 CURVE SMOOTH",
+"1033 76 OFFCURVE",
+"1015 61 OFFCURVE",
+"1015 38 CURVE SMOOTH",
+"1015 14 OFFCURVE",
+"1033 0 OFFCURVE",
+"1054 0 CURVE SMOOTH",
+"1122 0 OFFCURVE",
+"1181 22 OFFCURVE",
+"1220 69 CURVE",
+"1261 8 OFFCURVE",
+"1295 0 OFFCURVE",
+"1380 0 CURVE SMOOTH",
+"1409 0 LINE",
+"1409 76 LINE",
+"1368 76 OFFCURVE",
+"1339 80 OFFCURVE",
+"1329 83 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1033 76 OFFCURVE",
+"1015 61 OFFCURVE",
+"1015 38 CURVE SMOOTH",
+"1015 14 OFFCURVE",
+"1033 0 OFFCURVE",
+"1054 0 CURVE SMOOTH",
+"1095 0 LINE SMOOTH",
+"1146 0 OFFCURVE",
+"1186 0 OFFCURVE",
+"1222 6 CURVE SMOOTH",
+"1275 16 OFFCURVE",
+"1304 53 OFFCURVE",
+"1304 113 CURVE SMOOTH",
+"1304 167 OFFCURVE",
+"1286 231 OFFCURVE",
+"1238 231 CURVE SMOOTH",
+"1201 231 OFFCURVE",
+"1189 210 OFFCURVE",
+"1181 185 CURVE SMOOTH",
+"1173 160 OFFCURVE",
+"1167 108 OFFCURVE",
+"1163 79 CURVE",
+"1145 77 OFFCURVE",
+"1123 76 OFFCURVE",
+"1054 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1033 76 OFFCURVE",
+"1015 61 OFFCURVE",
+"1015 38 CURVE SMOOTH",
+"1015 14 OFFCURVE",
+"1033 0 OFFCURVE",
+"1054 0 CURVE SMOOTH",
+"1095 0 LINE SMOOTH",
+"1146 0 OFFCURVE",
+"1237 1 OFFCURVE",
+"1254 8 CURVE SMOOTH",
+"1304 29 OFFCURVE",
+"1312 78 OFFCURVE",
+"1299 147 CURVE SMOOTH",
+"1291 187 OFFCURVE",
+"1276 213 OFFCURVE",
+"1242 213 CURVE SMOOTH",
+"1209 213 OFFCURVE",
+"1193 188 OFFCURVE",
+"1180 165 CURVE SMOOTH",
+"1131 80 LINE",
+"1113 78 OFFCURVE",
+"1083 76 OFFCURVE",
+"1054 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 145 OFFCURVE",
+"661 91 OFFCURVE",
+"654 77 CURVE",
+"620 77 LINE",
+"611 82 OFFCURVE",
+"599 99 OFFCURVE",
+"569 149 CURVE SMOOTH",
+"541 195 OFFCURVE",
+"531 204 OFFCURVE",
+"509 204 CURVE SMOOTH",
+"488 204 OFFCURVE",
+"478 195 OFFCURVE",
+"466 177 CURVE SMOOTH",
+"439 136 LINE SMOOTH",
+"409 91 OFFCURVE",
+"370 76 OFFCURVE",
+"332 76 CURVE SMOOTH",
+"311 76 OFFCURVE",
+"293 61 OFFCURVE",
+"293 38 CURVE SMOOTH",
+"293 14 OFFCURVE",
+"311 0 OFFCURVE",
+"332 0 CURVE SMOOTH",
+"400 0 OFFCURVE",
+"463 20 OFFCURVE",
+"507 70 CURVE",
+"550 16 OFFCURVE",
+"588 0 OFFCURVE",
+"645 0 CURVE SMOOTH",
+"721 0 OFFCURVE",
+"790 39 OFFCURVE",
+"790 118 CURVE SMOOTH",
+"790 161 OFFCURVE",
+"774 206 OFFCURVE",
+"739 206 CURVE SMOOTH",
+"720 206 OFFCURVE",
+"705 198 OFFCURVE",
+"693 170 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 76 OFFCURVE",
+"506 61 OFFCURVE",
+"506 38 CURVE SMOOTH",
+"506 14 OFFCURVE",
+"524 0 OFFCURVE",
+"545 0 CURVE SMOOTH",
+"582 0 LINE SMOOTH",
+"633 0 OFFCURVE",
+"673 0 OFFCURVE",
+"709 6 CURVE SMOOTH",
+"767 17 OFFCURVE",
+"796 59 OFFCURVE",
+"796 111 CURVE SMOOTH",
+"796 156 OFFCURVE",
+"782 220 OFFCURVE",
+"738 220 CURVE SMOOTH",
+"709 220 OFFCURVE",
+"696 211 OFFCURVE",
+"683 182 CURVE SMOOTH",
+"673 157 OFFCURVE",
+"660 108 OFFCURVE",
+"654 79 CURVE",
+"636 77 OFFCURVE",
+"614 76 OFFCURVE",
+"545 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"90 0 LINE SMOOTH",
+"166 0 OFFCURVE",
+"235 42 OFFCURVE",
+"235 121 CURVE SMOOTH",
+"235 164 OFFCURVE",
+"219 210 OFFCURVE",
+"184 210 CURVE SMOOTH",
+"165 210 OFFCURVE",
+"149 203 OFFCURVE",
+"137 175 CURVE SMOOTH",
+"126 150 OFFCURVE",
+"105 93 OFFCURVE",
+"98 79 CURVE",
+"80 77 OFFCURVE",
+"69 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"90 0 LINE SMOOTH",
+"130 0 OFFCURVE",
+"168 12 OFFCURVE",
+"195 34 CURVE SMOOTH",
+"220 54 OFFCURVE",
+"235 83 OFFCURVE",
+"235 121 CURVE SMOOTH",
+"235 164 OFFCURVE",
+"219 210 OFFCURVE",
+"184 210 CURVE SMOOTH",
+"165 210 OFFCURVE",
+"149 203 OFFCURVE",
+"137 175 CURVE SMOOTH",
+"126 150 OFFCURVE",
+"105 93 OFFCURVE",
+"98 79 CURVE",
+"80 77 OFFCURVE",
+"69 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 309;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0712.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{475, -81}";
+}
+);
+hints = (
+{
+place = "{396, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"431 0 LINE",
+"470 54 LINE",
+"470 426 LINE",
+"246 426 LINE SMOOTH",
+"208 426 OFFCURVE",
+"172 427 OFFCURVE",
+"137 430 CURVE SMOOTH",
+"103 433 OFFCURVE",
+"80 435 OFFCURVE",
+"68 438 CURVE",
+"68 367 LINE",
+"97 359 OFFCURVE",
+"174 353 OFFCURVE",
+"251 353 CURVE SMOOTH",
+"396 353 LINE",
+"396 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 538;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072D.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{255, -98}";
+}
+);
+hints = (
+{
+place = "{396, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{633, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"86 353 LINE",
+"396 353 LINE",
+"396 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"431 0 LINE",
+"470 54 LINE",
+"470 426 LINE",
+"279 426 LINE",
+"231 425 LINE SMOOTH",
+"210 425 OFFCURVE",
+"190 423 OFFCURVE",
+"183 423 CURVE",
+"183 427 LINE",
+"221 464 LINE",
+"240 484 LINE",
+"259 503 LINE",
+"337 587 LINE",
+"278 633 LINE",
+"86 414 LINE"
+);
+}
+);
+width = 538;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0725.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{198, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-5, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{515, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"318 0 LINE",
+"337 46 LINE",
+"339 46 LINE",
+"368 13 OFFCURVE",
+"399 -5 OFFCURVE",
+"447 -5 CURVE SMOOTH",
+"499 -5 OFFCURVE",
+"548 25 OFFCURVE",
+"569 82 CURVE",
+"532 131 LINE",
+"529 131 LINE",
+"513 95 OFFCURVE",
+"486 71 OFFCURVE",
+"450 71 CURVE SMOOTH",
+"435 71 OFFCURVE",
+"421 75 OFFCURVE",
+"408 84 CURVE SMOOTH",
+"396 93 OFFCURVE",
+"377 119 OFFCURVE",
+"349 159 CURVE SMOOTH",
+"100 515 LINE",
+"35 471 LINE",
+"276 125 LINE SMOOTH",
+"288 108 OFFCURVE",
+"304 88 OFFCURVE",
+"315 76 CURVE"
+);
+}
+);
+width = 618;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074F.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{201, -98}";
+}
+);
+hints = (
+{
+place = "{357, 48}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{377, 44}";
+},
+{
+horizontal = 1;
+place = "{-3, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{500, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"374 -3 LINE",
+"436 40 LINE",
+"313 229 LINE",
+"315 231 LINE",
+"367 234 OFFCURVE",
+"405 271 OFFCURVE",
+"405 327 CURVE SMOOTH",
+"405 384 OFFCURVE",
+"366 421 OFFCURVE",
+"309 421 CURVE SMOOTH",
+"270 421 OFFCURVE",
+"242 404 OFFCURVE",
+"226 372 CURVE",
+"222 372 LINE",
+"140 500 LINE",
+"78 458 LINE",
+"308 100 LINE",
+"300 83 OFFCURVE",
+"275 76 OFFCURVE",
+"228 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"217 0 LINE SMOOTH",
+"292 0 OFFCURVE",
+"328 14 OFFCURVE",
+"345 38 CURVE",
+"348 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 358 OFFCURVE",
+"280 377 OFFCURVE",
+"309 377 CURVE SMOOTH",
+"337 377 OFFCURVE",
+"357 358 OFFCURVE",
+"357 326 CURVE SMOOTH",
+"357 293 OFFCURVE",
+"337 274 OFFCURVE",
+"309 274 CURVE SMOOTH",
+"281 274 OFFCURVE",
+"260 293 OFFCURVE",
+"260 326 CURVE SMOOTH"
+);
+}
+);
+width = 485;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{273, -91}";
+}
+);
+hints = (
+{
+place = "{428, 96}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"428 -240 LINE",
+"524 -240 LINE",
+"524 -141 LINE",
+"478 -141 LINE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"350 0 LINE",
+"428 -152 LINE"
+);
+}
+);
+width = 451;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+color = 7;
+glyphname = uni0714.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{273, -91}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRN.Init;
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 55, 139}";
+}
+);
+layerId = UUID0;
+width = 451;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{169, -98}";
+}
+);
+hints = (
+{
+place = "{428, 96}";
+},
+{
+place = "{248, 71}";
+},
+{
+horizontal = 1;
+place = "{432, 59}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"428 -240 LINE",
+"524 -240 LINE",
+"524 -141 LINE",
+"478 -141 LINE",
+"179 436 LINE",
+"183 437 LINE",
+"192 433 OFFCURVE",
+"206 432 OFFCURVE",
+"215 432 CURVE SMOOTH",
+"282 432 OFFCURVE",
+"319 476 OFFCURVE",
+"319 540 CURVE SMOOTH",
+"319 569 OFFCURVE",
+"308 600 OFFCURVE",
+"292 632 CURVE SMOOTH",
+"260 693 LINE",
+"197 660 LINE",
+"230 598 LINE SMOOTH",
+"242 575 OFFCURVE",
+"248 554 OFFCURVE",
+"248 537 CURVE SMOOTH",
+"248 508 OFFCURVE",
+"226 491 OFFCURVE",
+"195 491 CURVE SMOOTH",
+"160 491 OFFCURVE",
+"143 508 OFFCURVE",
+"128 535 CURVE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"350 0 LINE",
+"428 -152 LINE"
+);
+}
+);
+width = 451;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+color = 7;
+glyphname = uni071A.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{258, -98}";
+}
+);
+hints = (
+{
+place = "{-39, 181}";
+},
+{
+place = "{83, 59}";
+},
+{
+place = "{299, 58}";
+},
+{
+horizontal = 1;
+place = "{0, 75}";
+},
+{
+horizontal = 1;
+place = "{-9, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{237, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"145 147 LINE",
+"147 147 LINE",
+"175 116 LINE SMOOTH",
+"224 61 OFFCURVE",
+"257 27 OFFCURVE",
+"272 15 CURVE",
+"288 4 OFFCURVE",
+"305 -2 OFFCURVE",
+"324 -2 CURVE SMOOTH",
+"336 -2 OFFCURVE",
+"347 -1 OFFCURVE",
+"355 0 CURVE",
+"360 146 LINE",
+"362 146 LINE",
+"499 -9 LINE",
+"555 38 LINE",
+"362 237 LINE",
+"302 237 LINE",
+"296 83 LINE",
+"292 86 OFFCURVE",
+"286 91 OFFCURVE",
+"279 98 CURVE SMOOTH",
+"257 119 LINE",
+"214 164 LINE",
+"147 237 LINE",
+"86 237 LINE",
+"80 75 LINE",
+"0 75 LINE SMOOTH",
+"-21 75 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"140 0 LINE"
+);
+}
+);
+width = 619;
+}
+);
+leftKerningGroup = uni071A;
+},
+{
+color = 7;
+glyphname = uni071F.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{522, -90}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{362, 75}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"532 0 LINE",
+"567 63 LINE",
+"563 75 OFFCURVE",
+"554 94 OFFCURVE",
+"543 117 CURVE SMOOTH",
+"494 220 LINE",
+"455 299 OFFCURVE",
+"415 355 OFFCURVE",
+"375 388 CURVE SMOOTH",
+"336 421 OFFCURVE",
+"288 437 OFFCURVE",
+"233 437 CURVE SMOOTH",
+"136 437 OFFCURVE",
+"66 389 OFFCURVE",
+"58 305 CURVE",
+"127 305 LINE",
+"136 342 OFFCURVE",
+"171 362 OFFCURVE",
+"228 362 CURVE SMOOTH",
+"267 362 OFFCURVE",
+"302 348 OFFCURVE",
+"333 320 CURVE SMOOTH",
+"365 292 OFFCURVE",
+"400 239 OFFCURVE",
+"438 162 CURVE SMOOTH",
+"480 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 636;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074E.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{255, -98}";
+}
+);
+hints = (
+{
+place = "{251, 76}";
+},
+{
+place = "{396, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{654, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"431 0 LINE",
+"470 54 LINE",
+"470 426 LINE",
+"361 426 LINE SMOOTH",
+"340 426 OFFCURVE",
+"317 425 OFFCURVE",
+"293 424 CURVE",
+"292 427 LINE",
+"315 442 OFFCURVE",
+"327 472 OFFCURVE",
+"327 505 CURVE SMOOTH",
+"327 562 OFFCURVE",
+"293 601 OFFCURVE",
+"213 629 CURVE SMOOTH",
+"138 654 LINE",
+"116 586 LINE",
+"183 564 LINE SMOOTH",
+"231 548 OFFCURVE",
+"251 531 OFFCURVE",
+"251 491 CURVE SMOOTH",
+"251 450 OFFCURVE",
+"233 427 OFFCURVE",
+"173 427 CURVE SMOOTH",
+"164 427 OFFCURVE",
+"146 427 OFFCURVE",
+"126 430 CURVE",
+"96 432 LINE SMOOTH",
+"85 433 OFFCURVE",
+"76 435 OFFCURVE",
+"68 436 CURVE",
+"68 364 LINE",
+"91 359 OFFCURVE",
+"162 353 OFFCURVE",
+"251 353 CURVE SMOOTH",
+"396 353 LINE",
+"396 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 538;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0720.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{169, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"323 0 LINE",
+"369 69 LINE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 418;
+}
+);
+leftKerningGroup = uni0720;
+},
+{
+color = 7;
+glyphname = uni0721.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{355, -98}";
+}
+);
+hints = (
+{
+place = "{621, 71}";
+},
+{
+horizontal = 1;
+place = "{-5, 81}";
+},
+{
+horizontal = 1;
+place = "{342, 72}";
+},
+{
+horizontal = 1;
+place = "{480, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"316 0 LINE",
+"334 46 LINE",
+"336 46 LINE",
+"371 13 OFFCURVE",
+"420 -5 OFFCURVE",
+"488 -5 CURVE SMOOTH",
+"617 -5 OFFCURVE",
+"692 65 OFFCURVE",
+"692 185 CURVE SMOOTH",
+"692 252 OFFCURVE",
+"674 306 OFFCURVE",
+"637 349 CURVE SMOOTH",
+"601 392 OFFCURVE",
+"553 414 OFFCURVE",
+"492 414 CURVE SMOOTH",
+"408 414 OFFCURVE",
+"339 370 OFFCURVE",
+"306 291 CURVE",
+"212 362 LINE SMOOTH",
+"132 423 OFFCURVE",
+"99 456 OFFCURVE",
+"75 480 CURVE",
+"26 424 LINE",
+"55 395 OFFCURVE",
+"112 346 OFFCURVE",
+"195 282 CURVE",
+"286 214 LINE",
+"285 205 OFFCURVE",
+"285 195 OFFCURVE",
+"285 185 CURVE SMOOTH",
+"285 142 OFFCURVE",
+"294 105 OFFCURVE",
+"312 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"621 108 OFFCURVE",
+"580 66 OFFCURVE",
+"488 66 CURVE SMOOTH",
+"396 66 OFFCURVE",
+"354 108 OFFCURVE",
+"354 187 CURVE SMOOTH",
+"354 275 OFFCURVE",
+"408 342 OFFCURVE",
+"488 342 CURVE SMOOTH",
+"568 342 OFFCURVE",
+"621 279 OFFCURVE",
+"621 187 CURVE SMOOTH"
+);
+}
+);
+width = 761;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0722.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{173, -97}";
+}
+);
+hints = (
+{
+place = "{158, 70}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{428, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"271 0 LINE",
+"295 54 LINE",
+"276 95 OFFCURVE",
+"260 146 OFFCURVE",
+"247 206 CURVE SMOOTH",
+"234 267 OFFCURVE",
+"228 322 OFFCURVE",
+"228 371 CURVE SMOOTH",
+"228 426 LINE",
+"151 426 LINE SMOOTH",
+"126 426 OFFCURVE",
+"100 427 OFFCURVE",
+"76 428 CURVE",
+"76 355 LINE",
+"96 354 OFFCURVE",
+"126 353 OFFCURVE",
+"151 353 CURVE SMOOTH",
+"158 353 LINE",
+"162 275 OFFCURVE",
+"171 210 OFFCURVE",
+"185 158 CURVE",
+"200 107 OFFCURVE",
+"207 79 OFFCURVE",
+"208 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 364;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0726.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{474, -81}";
+}
+);
+hints = (
+{
+place = "{54, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{199, 71}";
+},
+{
+horizontal = 1;
+place = "{589, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"297 565 LINE",
+"140 538 OFFCURVE",
+"54 464 OFFCURVE",
+"54 359 CURVE SMOOTH",
+"54 260 OFFCURVE",
+"121 199 OFFCURVE",
+"236 199 CURVE SMOOTH",
+"395 199 LINE",
+"428 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"477 0 LINE",
+"510 66 LINE",
+"370 589 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 270 LINE",
+"169 270 OFFCURVE",
+"133 300 OFFCURVE",
+"133 367 CURVE SMOOTH",
+"133 434 OFFCURVE",
+"195 477 OFFCURVE",
+"316 494 CURVE",
+"376 270 LINE"
+);
+}
+);
+width = 568;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0729.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{316, -98}";
+}
+);
+hints = (
+{
+place = "{105, 73}";
+},
+{
+place = "{456, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"104 0 LINE",
+"123 46 LINE",
+"125 46 LINE",
+"142 17 OFFCURVE",
+"173 0 OFFCURVE",
+"221 0 CURVE SMOOTH",
+"490 0 LINE",
+"529 54 LINE",
+"529 438 LINE",
+"504 433 OFFCURVE",
+"436 426 OFFCURVE",
+"375 426 CURVE SMOOTH",
+"258 426 LINE SMOOTH",
+"197 426 OFFCURVE",
+"130 433 OFFCURVE",
+"105 438 CURVE",
+"105 128 LINE SMOOTH",
+"105 108 OFFCURVE",
+"107 91 OFFCURVE",
+"111 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"371 353 LINE",
+"395 353 OFFCURVE",
+"427 353 OFFCURVE",
+"456 357 CURVE",
+"456 76 LINE",
+"232 76 LINE SMOOTH",
+"187 76 OFFCURVE",
+"178 90 OFFCURVE",
+"178 135 CURVE SMOOTH",
+"178 357 LINE",
+"207 353 OFFCURVE",
+"239 353 OFFCURVE",
+"263 353 CURVE SMOOTH"
+);
+}
+);
+width = 597;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0727.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{280, -98}";
+}
+);
+hints = (
+{
+place = "{-39, 175}";
+},
+{
+place = "{62, 74}";
+},
+{
+place = "{152, 82}";
+},
+{
+place = "{215, 59}";
+},
+{
+place = "{337, 81}";
+},
+{
+place = "{410, 70}";
+},
+{
+horizontal = 1;
+place = "{0, 70}";
+},
+{
+horizontal = 1;
+place = "{189, 66}";
+},
+{
+horizontal = 1;
+place = "{423, 74}";
+},
+{
+horizontal = 1;
+place = "{585, 86}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"478 0 LINE",
+"500 70 LINE",
+"477 70 LINE SMOOTH",
+"262 70 OFFCURVE",
+"136 145 OFFCURVE",
+"136 285 CURVE SMOOTH",
+"136 326 OFFCURVE",
+"150 360 OFFCURVE",
+"179 385 CURVE SMOOTH",
+"208 410 OFFCURVE",
+"243 423 OFFCURVE",
+"286 423 CURVE SMOOTH",
+"358 423 OFFCURVE",
+"410 388 OFFCURVE",
+"410 333 CURVE SMOOTH",
+"410 285 OFFCURVE",
+"385 255 OFFCURVE",
+"338 255 CURVE SMOOTH",
+"301 255 OFFCURVE",
+"274 278 OFFCURVE",
+"274 319 CURVE",
+"215 319 LINE",
+"215 310 LINE SMOOTH",
+"215 234 OFFCURVE",
+"262 189 OFFCURVE",
+"338 189 CURVE SMOOTH",
+"430 189 OFFCURVE",
+"480 246 OFFCURVE",
+"480 339 CURVE SMOOTH",
+"480 384 OFFCURVE",
+"461 422 OFFCURVE",
+"424 452 CURVE SMOOTH",
+"387 482 OFFCURVE",
+"341 497 OFFCURVE",
+"286 497 CURVE SMOOTH",
+"221 497 OFFCURVE",
+"168 477 OFFCURVE",
+"125 436 CURVE SMOOTH",
+"83 396 OFFCURVE",
+"62 345 OFFCURVE",
+"62 282 CURVE SMOOTH",
+"62 191 OFFCURVE",
+"101 120 OFFCURVE",
+"169 77 CURVE",
+"168 74 LINE",
+"145 75 OFFCURVE",
+"121 76 OFFCURVE",
+"100 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"152 585 LINE",
+"234 585 LINE",
+"234 671 LINE",
+"152 671 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"337 585 LINE",
+"418 585 LINE",
+"418 671 LINE",
+"337 671 LINE"
+);
+}
+);
+width = 568;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0723.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{365, -98}";
+}
+);
+hints = (
+{
+place = "{67, 75}";
+},
+{
+place = "{352, 69}";
+},
+{
+place = "{630, 75}";
+},
+{
+horizontal = 1;
+place = "{-2, 72}";
+},
+{
+horizontal = 1;
+place = "{317, 75}";
+},
+{
+horizontal = 1;
+place = "{405, 71}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"280 28 LINE",
+"333 9 OFFCURVE",
+"391 -2 OFFCURVE",
+"451 -2 CURVE SMOOTH",
+"618 -2 OFFCURVE",
+"705 82 OFFCURVE",
+"705 231 CURVE SMOOTH",
+"705 278 OFFCURVE",
+"690 317 OFFCURVE",
+"659 347 CURVE SMOOTH",
+"628 377 OFFCURVE",
+"591 392 OFFCURVE",
+"547 392 CURVE SMOOTH",
+"491 392 OFFCURVE",
+"454 375 OFFCURVE",
+"425 340 CURVE",
+"421 341 LINE",
+"418 425 OFFCURVE",
+"352 476 OFFCURVE",
+"249 476 CURVE SMOOTH",
+"200 476 OFFCURVE",
+"157 457 OFFCURVE",
+"121 418 CURVE SMOOTH",
+"85 379 OFFCURVE",
+"67 334 OFFCURVE",
+"67 283 CURVE SMOOTH",
+"67 187 OFFCURVE",
+"105 121 OFFCURVE",
+"188 74 CURVE",
+"185 71 LINE",
+"162 73 LINE",
+"90 75 LINE",
+"70 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"239 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 109 OFFCURVE",
+"376 153 OFFCURVE",
+"415 218 CURVE SMOOTH",
+"455 284 OFFCURVE",
+"496 317 OFFCURVE",
+"539 317 CURVE SMOOTH",
+"595 317 OFFCURVE",
+"630 281 OFFCURVE",
+"630 225 CURVE SMOOTH",
+"630 128 OFFCURVE",
+"566 70 OFFCURVE",
+"461 70 CURVE SMOOTH",
+"410 70 OFFCURVE",
+"371 76 OFFCURVE",
+"334 88 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"182 146 OFFCURVE",
+"142 206 OFFCURVE",
+"142 286 CURVE SMOOTH",
+"142 355 OFFCURVE",
+"191 405 OFFCURVE",
+"256 405 CURVE SMOOTH",
+"316 405 OFFCURVE",
+"352 371 OFFCURVE",
+"352 314 CURVE SMOOTH",
+"352 273 OFFCURVE",
+"342 234 OFFCURVE",
+"323 197 CURVE SMOOTH",
+"304 161 OFFCURVE",
+"286 132 OFFCURVE",
+"269 111 CURVE"
+);
+}
+);
+width = 771;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0724.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{364, -98}";
+}
+);
+components = (
+{
+name = uni0723.loclSYRN.Init;
+}
+);
+layerId = UUID0;
+width = 771;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072B.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{280, -98}";
+}
+);
+hints = (
+{
+place = "{246, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{340, 74}";
+},
+{
+horizontal = 1;
+place = "{440, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"256 0 LINE",
+"273 46 LINE",
+"275 46 LINE",
+"299 13 OFFCURVE",
+"336 0 OFFCURVE",
+"383 0 CURVE SMOOTH",
+"552 0 LINE",
+"552 76 LINE",
+"390 76 LINE",
+"329 78 OFFCURVE",
+"324 94 OFFCURVE",
+"319 170 CURVE",
+"319 340 LINE",
+"355 341 OFFCURVE",
+"390 344 OFFCURVE",
+"425 349 CURVE SMOOTH",
+"460 354 OFFCURVE",
+"485 361 OFFCURVE",
+"499 369 CURVE",
+"484 440 LINE",
+"457 428 OFFCURVE",
+"387 414 OFFCURVE",
+"282 414 CURVE SMOOTH",
+"177 414 OFFCURVE",
+"108 428 OFFCURVE",
+"80 440 CURVE",
+"66 369 LINE",
+"80 361 OFFCURVE",
+"104 354 OFFCURVE",
+"139 349 CURVE SMOOTH",
+"174 344 OFFCURVE",
+"209 341 OFFCURVE",
+"246 340 CURVE",
+"246 164 LINE SMOOTH",
+"246 128 OFFCURVE",
+"250 99 OFFCURVE",
+"259 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 601;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071B.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{175, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-285, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"674 -3 LINE",
+"674 76 LINE",
+"364 76 LINE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"316 0 LINE",
+"463 -285 LINE",
+"493 -285 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"403 0 LINE",
+"620 0 LINE",
+"500 -188 LINE"
+);
+}
+);
+width = 743;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+color = 7;
+glyphname = uni071C.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{175, -98}";
+}
+);
+hints = (
+{
+place = "{460, 78}";
+},
+{
+horizontal = 1;
+place = "{-120, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-300, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"689 -3 LINE",
+"689 76 LINE",
+"364 76 LINE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"316 0 LINE",
+"470 -300 LINE",
+"500 -300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 -207 OFFCURVE",
+"446 -174 OFFCURVE",
+"422 -129 CURVE SMOOTH",
+"398 -84 OFFCURVE",
+"386 -41 OFFCURVE",
+"386 0 CURVE",
+"637 0 LINE",
+"620 -43 OFFCURVE",
+"596 -89 OFFCURVE",
+"565 -136 CURVE SMOOTH",
+"534 -183 OFFCURVE",
+"510 -214 OFFCURVE",
+"493 -227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 -120 LINE",
+"538 -120 LINE",
+"538 -41 LINE",
+"460 -41 LINE"
+);
+}
+);
+width = 757;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+color = 7;
+glyphname = uni071D.loclSYRN.Init;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{161, -97}";
+}
+);
+hints = (
+{
+place = "{-39, 179}";
+},
+{
+place = "{82, 58}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-9, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{228, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"80 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"139 0 LINE",
+"141 132 LINE",
+"143 132 LINE",
+"283 -9 LINE",
+"339 34 LINE",
+"137 228 LINE",
+"85 228 LINE"
+);
+}
+);
+width = 403;
+}
+);
+leftKerningGroup = uni071A;
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.InitLiga;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{114, -98}";
+},
+{
+name = top;
+position = "{113, 735}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"76 141 LINE SMOOTH",
+"76 96 OFFCURVE",
+"53 71 OFFCURVE",
+"0 71 CURVE SMOOTH",
+"-17 71 OFFCURVE",
+"-39 60 OFFCURVE",
+"-39 31 CURVE SMOOTH",
+"-39 17 OFFCURVE",
+"-31 -5 OFFCURVE",
+"9 -5 CURVE SMOOTH",
+"103 -5 OFFCURVE",
+"149 57 OFFCURVE",
+"149 129 CURVE SMOOTH",
+"149 674 LINE",
+"76 674 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"76 141 LINE SMOOTH",
+"76 96 OFFCURVE",
+"53 71 OFFCURVE",
+"0 71 CURVE SMOOTH",
+"-17 71 OFFCURVE",
+"-39 60 OFFCURVE",
+"-39 31 CURVE SMOOTH",
+"-39 17 OFFCURVE",
+"-31 -5 OFFCURVE",
+"9 -5 CURVE SMOOTH",
+"103 -5 OFFCURVE",
+"149 57 OFFCURVE",
+"149 129 CURVE SMOOTH",
+"149 674 LINE",
+"76 674 LINE"
+);
+}
+);
+width = 247;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.InitLiga;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{113, -98}";
+},
+{
+name = top;
+position = "{113, 586}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"76 141 LINE SMOOTH",
+"76 96 OFFCURVE",
+"53 71 OFFCURVE",
+"0 71 CURVE SMOOTH",
+"-17 71 OFFCURVE",
+"-39 60 OFFCURVE",
+"-39 31 CURVE SMOOTH",
+"-39 17 OFFCURVE",
+"-31 -5 OFFCURVE",
+"9 -5 CURVE SMOOTH",
+"103 -5 OFFCURVE",
+"149 57 OFFCURVE",
+"149 129 CURVE SMOOTH",
+"149 420 LINE",
+"76 420 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"76 141 LINE SMOOTH",
+"76 96 OFFCURVE",
+"53 71 OFFCURVE",
+"0 71 CURVE SMOOTH",
+"-17 71 OFFCURVE",
+"-39 60 OFFCURVE",
+"-39 31 CURVE SMOOTH",
+"-39 17 OFFCURVE",
+"-31 -5 OFFCURVE",
+"9 -5 CURVE SMOOTH",
+"103 -5 OFFCURVE",
+"149 57 OFFCURVE",
+"149 129 CURVE SMOOTH",
+"149 420 LINE",
+"76 420 LINE"
+);
+}
+);
+width = 242;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.InitLong;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{363, -98}";
+},
+{
+name = top;
+position = "{319, 705}";
+}
+);
+components = (
+{
+name = uni0720.loclSYRJ.Init;
+transform = "{1, 0, 0, 1, 171, 0}";
+},
+{
+name = Stretch2.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 737;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071B.loclSYRJ.InitLong;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{490, -381}";
+},
+{
+name = top;
+position = "{504, 686}";
+}
+);
+components = (
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 157, 0}";
+},
+{
+name = uni071B.loclSYRJ.Init;
+transform = "{1, 0, 0, 1, 294, 0}";
+},
+{
+name = Stretch2.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 732;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071C.loclSYRJ.InitLong;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{492, -381}";
+},
+{
+name = top;
+position = "{502, 690}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 246, 20}";
+},
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 159, 0}";
+},
+{
+name = uni071B.loclSYRJ.Init;
+transform = "{1, 0, 0, 1, 294, 0}";
+},
+{
+name = Stretch2.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 732;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072B.loclSYRN.InitM;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{237, -98}";
+}
+);
+components = (
+{
+name = uni072B.loclSYRN.InitN;
+transform = "{1, 0, 0, 1, 31, 0}";
+},
+{
+name = Stretch3.loclSYRN;
+}
+);
+layerId = UUID0;
+width = 559;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.InitN;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{95, -98}";
+},
+{
+name = top;
+position = "{50, 707}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-154 693 LINE",
+"-211 642 LINE",
+"275 87 LINE",
+"255 75 OFFCURVE",
+"224 76 OFFCURVE",
+"208 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"197 0 LINE SMOOTH",
+"266 0 OFFCURVE",
+"303 10 OFFCURVE",
+"322 33 CURVE",
+"361 -12 LINE",
+"420 38 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-154 693 LINE",
+"-211 642 LINE",
+"275 87 LINE",
+"255 75 OFFCURVE",
+"224 76 OFFCURVE",
+"208 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"197 0 LINE SMOOTH",
+"266 0 OFFCURVE",
+"303 10 OFFCURVE",
+"322 33 CURVE",
+"361 -12 LINE",
+"420 38 LINE"
+);
+}
+);
+width = 469;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.InitN;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{93, -98}";
+},
+{
+name = top;
+position = "{107, 537}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"83 412 LINE",
+"92 362 OFFCURVE",
+"97 260 OFFCURVE",
+"97 239 CURVE SMOOTH",
+"97 211 OFFCURVE",
+"96 142 OFFCURVE",
+"90 120 CURVE",
+"81 91 OFFCURVE",
+"61 76 OFFCURVE",
+"23 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"9 0 LINE SMOOTH",
+"78 0 OFFCURVE",
+"126 20 OFFCURVE",
+"150 73 CURVE SMOOTH",
+"168 114 OFFCURVE",
+"170 169 OFFCURVE",
+"170 237 CURVE SMOOTH",
+"170 264 OFFCURVE",
+"165 381 OFFCURVE",
+"155 423 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"83 412 LINE",
+"92 362 OFFCURVE",
+"97 260 OFFCURVE",
+"97 239 CURVE SMOOTH",
+"97 211 OFFCURVE",
+"96 142 OFFCURVE",
+"90 120 CURVE SMOOTH",
+"81 91 OFFCURVE",
+"61 76 OFFCURVE",
+"23 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"9 0 LINE SMOOTH",
+"78 0 OFFCURVE",
+"126 20 OFFCURVE",
+"150 73 CURVE SMOOTH",
+"168 114 OFFCURVE",
+"170 169 OFFCURVE",
+"170 237 CURVE SMOOTH",
+"170 264 OFFCURVE",
+"165 381 OFFCURVE",
+"155 423 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"170 213 OFFCURVE",
+"169 244 OFFCURVE",
+"164 274 CURVE",
+"94 268 LINE",
+"97 237 OFFCURVE",
+"97 211 OFFCURVE",
+"97 203 CURVE SMOOTH",
+"97 182 OFFCURVE",
+"96 153 OFFCURVE",
+"90 131 CURVE SMOOTH",
+"82 99 OFFCURVE",
+"63 76 OFFCURVE",
+"22 76 CURVE SMOOTH",
+"-47 76 LINE SMOOTH",
+"-68 76 OFFCURVE",
+"-86 61 OFFCURVE",
+"-86 38 CURVE SMOOTH",
+"-86 14 OFFCURVE",
+"-68 0 OFFCURVE",
+"-47 0 CURVE SMOOTH",
+"-9 0 LINE SMOOTH",
+"126 0 OFFCURVE",
+"170 67 OFFCURVE",
+"170 201 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"170 213 OFFCURVE",
+"169 244 OFFCURVE",
+"164 274 CURVE",
+"94 268 LINE",
+"97 237 OFFCURVE",
+"97 211 OFFCURVE",
+"97 203 CURVE SMOOTH",
+"97 182 OFFCURVE",
+"96 153 OFFCURVE",
+"90 131 CURVE SMOOTH",
+"82 99 OFFCURVE",
+"63 76 OFFCURVE",
+"22 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"6 0 LINE SMOOTH",
+"121 0 OFFCURVE",
+"170 67 OFFCURVE",
+"170 201 CURVE SMOOTH"
+);
+}
+);
+width = 269;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0712.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{426, -81}";
+}
+);
+hints = (
+{
+place = "{348, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"382 0 LINE",
+"421 54 LINE",
+"421 426 LINE",
+"197 426 LINE SMOOTH",
+"121 426 OFFCURVE",
+"44 433 OFFCURVE",
+"20 438 CURVE",
+"20 367 LINE",
+"49 359 OFFCURVE",
+"125 353 OFFCURVE",
+"202 353 CURVE SMOOTH",
+"348 353 LINE",
+"348 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 489;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0725.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{161, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-5, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{515, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"233 0 LINE",
+"252 46 LINE",
+"254 46 LINE",
+"282 13 OFFCURVE",
+"314 -5 OFFCURVE",
+"362 -5 CURVE SMOOTH",
+"414 -5 OFFCURVE",
+"463 25 OFFCURVE",
+"483 82 CURVE",
+"446 131 LINE",
+"444 131 LINE",
+"427 95 OFFCURVE",
+"401 71 OFFCURVE",
+"365 71 CURVE SMOOTH",
+"350 71 OFFCURVE",
+"336 75 OFFCURVE",
+"323 84 CURVE SMOOTH",
+"310 93 OFFCURVE",
+"290 118 OFFCURVE",
+"263 159 CURVE",
+"15 515 LINE",
+"-50 471 LINE",
+"191 125 LINE SMOOTH",
+"202 108 OFFCURVE",
+"218 88 OFFCURVE",
+"229 76 CURVE"
+);
+}
+);
+width = 532;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{176, -91}";
+}
+);
+hints = (
+{
+place = "{331, 96}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"331 -240 LINE",
+"427 -240 LINE",
+"427 -141 LINE",
+"380 -141 LINE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"252 0 LINE",
+"331 -152 LINE"
+);
+}
+);
+width = 354;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{71, -98}";
+}
+);
+hints = (
+{
+place = "{331, 96}";
+},
+{
+place = "{150, 71}";
+},
+{
+horizontal = 1;
+place = "{432, 59}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"331 -240 LINE",
+"427 -240 LINE",
+"427 -141 LINE",
+"380 -141 LINE",
+"82 436 LINE",
+"85 437 LINE",
+"96 433 OFFCURVE",
+"108 432 OFFCURVE",
+"117 432 CURVE SMOOTH",
+"184 432 OFFCURVE",
+"221 476 OFFCURVE",
+"221 540 CURVE SMOOTH",
+"221 569 OFFCURVE",
+"211 600 OFFCURVE",
+"194 632 CURVE SMOOTH",
+"163 693 LINE",
+"100 660 LINE",
+"132 598 LINE",
+"145 575 OFFCURVE",
+"150 554 OFFCURVE",
+"150 537 CURVE SMOOTH",
+"150 508 OFFCURVE",
+"129 491 OFFCURVE",
+"97 491 CURVE SMOOTH",
+"64 491 OFFCURVE",
+"46 508 OFFCURVE",
+"31 535 CURVE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"252 0 LINE",
+"331 -152 LINE"
+);
+}
+);
+width = 354;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+color = 7;
+glyphname = uni0720.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{73, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"225 0 LINE",
+"271 69 LINE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 320;
+}
+);
+leftKerningGroup = uni0720;
+},
+{
+color = 7;
+glyphname = uni0721.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{403, -98}";
+}
+);
+hints = (
+{
+place = "{199, 69}";
+},
+{
+place = "{535, 72}";
+},
+{
+horizontal = 1;
+place = "{-5, 81}";
+},
+{
+horizontal = 1;
+place = "{342, 72}";
+},
+{
+horizontal = 1;
+place = "{480, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"230 0 LINE",
+"249 46 LINE",
+"250 46 LINE",
+"285 13 OFFCURVE",
+"335 -5 OFFCURVE",
+"402 -5 CURVE SMOOTH",
+"533 -5 OFFCURVE",
+"607 65 OFFCURVE",
+"607 185 CURVE SMOOTH",
+"607 252 OFFCURVE",
+"589 306 OFFCURVE",
+"552 349 CURVE SMOOTH",
+"516 392 OFFCURVE",
+"467 414 OFFCURVE",
+"406 414 CURVE SMOOTH",
+"322 414 OFFCURVE",
+"255 370 OFFCURVE",
+"220 291 CURVE",
+"127 362 LINE SMOOTH",
+"47 423 OFFCURVE",
+"14 456 OFFCURVE",
+"-10 480 CURVE",
+"-59 424 LINE",
+"-30 395 OFFCURVE",
+"27 346 OFFCURVE",
+"110 282 CURVE",
+"201 214 LINE",
+"200 205 OFFCURVE",
+"199 195 OFFCURVE",
+"199 185 CURVE SMOOTH",
+"199 142 OFFCURVE",
+"208 105 OFFCURVE",
+"227 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 108 OFFCURVE",
+"494 66 OFFCURVE",
+"402 66 CURVE SMOOTH",
+"311 66 OFFCURVE",
+"268 108 OFFCURVE",
+"268 187 CURVE SMOOTH",
+"268 275 OFFCURVE",
+"322 342 OFFCURVE",
+"402 342 CURVE SMOOTH",
+"483 342 OFFCURVE",
+"535 279 OFFCURVE",
+"535 187 CURVE SMOOTH"
+);
+}
+);
+width = 675;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072B.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{207, -98}";
+}
+);
+hints = (
+{
+place = "{172, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{340, 74}";
+},
+{
+horizontal = 1;
+place = "{440, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"183 0 LINE",
+"200 46 LINE",
+"202 46 LINE",
+"226 13 OFFCURVE",
+"262 0 OFFCURVE",
+"310 0 CURVE SMOOTH",
+"479 0 LINE",
+"479 76 LINE",
+"316 76 LINE",
+"257 78 OFFCURVE",
+"251 94 OFFCURVE",
+"246 170 CURVE",
+"246 340 LINE",
+"282 341 OFFCURVE",
+"317 344 OFFCURVE",
+"352 349 CURVE SMOOTH",
+"387 354 OFFCURVE",
+"411 361 OFFCURVE",
+"425 369 CURVE",
+"411 440 LINE",
+"384 428 OFFCURVE",
+"314 414 OFFCURVE",
+"209 414 CURVE SMOOTH",
+"104 414 OFFCURVE",
+"34 428 OFFCURVE",
+"7 440 CURVE",
+"-7 369 LINE",
+"7 361 OFFCURVE",
+"31 354 OFFCURVE",
+"66 349 CURVE SMOOTH",
+"101 344 OFFCURVE",
+"136 341 OFFCURVE",
+"172 340 CURVE",
+"172 164 LINE SMOOTH",
+"172 128 OFFCURVE",
+"177 99 OFFCURVE",
+"186 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 528;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071B.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{73, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-285, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"577 -3 LINE",
+"577 76 LINE",
+"266 76 LINE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"218 0 LINE",
+"365 -285 LINE",
+"395 -285 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 0 LINE",
+"522 0 LINE",
+"402 -188 LINE"
+);
+}
+);
+width = 645;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+color = 7;
+glyphname = uni071C.loclSYRN.InitN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{73, -98}";
+}
+);
+hints = (
+{
+place = "{362, 78}";
+},
+{
+horizontal = 1;
+place = "{-120, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-300, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"591 -3 LINE",
+"591 76 LINE",
+"266 76 LINE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"218 0 LINE",
+"373 -300 LINE",
+"402 -300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"372 -207 OFFCURVE",
+"348 -174 OFFCURVE",
+"324 -129 CURVE SMOOTH",
+"301 -84 OFFCURVE",
+"289 -41 OFFCURVE",
+"289 0 CURVE",
+"540 0 LINE",
+"523 -43 OFFCURVE",
+"499 -89 OFFCURVE",
+"467 -136 CURVE SMOOTH",
+"436 -183 OFFCURVE",
+"412 -214 OFFCURVE",
+"396 -227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 -120 LINE",
+"440 -120 LINE",
+"440 -41 LINE",
+"362 -41 LINE"
+);
+}
+);
+width = 660;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+color = 5;
+glyphname = uni0712.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{480, 439}";
+},
+{
+name = RU;
+position = "{464, -104}";
+},
+{
+name = bottom;
+position = "{207, -98}";
+},
+{
+name = top;
+position = "{226, 513}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"602 0 LINE",
+"602 76 LINE",
+"587 76 LINE SMOOTH",
+"568 76 OFFCURVE",
+"543 76 OFFCURVE",
+"520 74 CURVE",
+"518 78 LINE",
+"533 95 OFFCURVE",
+"539 123 OFFCURVE",
+"539 146 CURVE SMOOTH",
+"539 233 OFFCURVE",
+"482 305 OFFCURVE",
+"401 356 CURVE SMOOTH",
+"342 394 OFFCURVE",
+"278 414 OFFCURVE",
+"196 414 CURVE SMOOTH",
+"159 414 OFFCURVE",
+"91 402 OFFCURVE",
+"58 387 CURVE",
+"75 326 LINE",
+"112 337 OFFCURVE",
+"163 339 OFFCURVE",
+"186 339 CURVE SMOOTH",
+"323 339 OFFCURVE",
+"464 250 OFFCURVE",
+"464 134 CURVE SMOOTH",
+"464 107 OFFCURVE",
+"449 76 OFFCURVE",
+"394 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 602;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072D.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{267, -98}";
+},
+{
+name = top;
+position = "{132, 661}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"539 312 OFFCURVE",
+"358 411 OFFCURVE",
+"200 411 CURVE SMOOTH",
+"185 411 OFFCURVE",
+"169 410 OFFCURVE",
+"155 408 CURVE",
+"155 412 LINE",
+"178 434 OFFCURVE",
+"241 495 OFFCURVE",
+"264 520 CURVE SMOOTH",
+"314 574 LINE",
+"261 618 LINE",
+"58 387 LINE",
+"74 333 LINE",
+"115 338 OFFCURVE",
+"152 339 OFFCURVE",
+"176 339 CURVE SMOOTH",
+"333 339 OFFCURVE",
+"464 254 OFFCURVE",
+"464 134 CURVE SMOOTH",
+"464 107 OFFCURVE",
+"449 76 OFFCURVE",
+"394 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"602 0 LINE",
+"602 76 LINE",
+"587 76 LINE SMOOTH",
+"568 76 OFFCURVE",
+"543 76 OFFCURVE",
+"520 74 CURVE",
+"518 78 LINE",
+"533 95 OFFCURVE",
+"539 123 OFFCURVE",
+"539 146 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"539 312 OFFCURVE",
+"358 411 OFFCURVE",
+"200 411 CURVE SMOOTH",
+"185 411 OFFCURVE",
+"169 410 OFFCURVE",
+"155 408 CURVE",
+"155 412 LINE",
+"178 434 OFFCURVE",
+"241 495 OFFCURVE",
+"264 520 CURVE SMOOTH",
+"314 574 LINE",
+"261 618 LINE",
+"58 387 LINE",
+"74 333 LINE",
+"115 338 OFFCURVE",
+"152 339 OFFCURVE",
+"176 339 CURVE SMOOTH",
+"333 339 OFFCURVE",
+"464 254 OFFCURVE",
+"464 134 CURVE SMOOTH",
+"464 107 OFFCURVE",
+"449 76 OFFCURVE",
+"394 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"602 0 LINE",
+"602 76 LINE",
+"587 76 LINE SMOOTH",
+"568 76 OFFCURVE",
+"543 76 OFFCURVE",
+"520 74 CURVE",
+"518 78 LINE",
+"533 95 OFFCURVE",
+"539 123 OFFCURVE",
+"539 146 CURVE SMOOTH"
+);
+}
+);
+width = 602;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0725.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{220, -98}";
+},
+{
+name = top;
+position = "{220, 513}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"39 384 LINE",
+"300 87 LINE",
+"280 75 OFFCURVE",
+"249 76 OFFCURVE",
+"233 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"222 0 LINE SMOOTH",
+"293 0 OFFCURVE",
+"330 11 OFFCURVE",
+"349 35 CURVE",
+"374 14 OFFCURVE",
+"402 0 OFFCURVE",
+"441 0 CURVE",
+"441 76 LINE",
+"420 76 OFFCURVE",
+"401 87 OFFCURVE",
+"382 109 CURVE SMOOTH",
+"96 436 LINE"
+);
+}
+);
+width = 441;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074F.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{150, -98}";
+},
+{
+name = top;
+position = "{151, 584}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"398 76 LINE",
+"368 76 OFFCURVE",
+"347 98 OFFCURVE",
+"332 123 CURVE",
+"263 229 LINE",
+"265 231 LINE",
+"315 233 OFFCURVE",
+"355 269 OFFCURVE",
+"355 327 CURVE SMOOTH",
+"355 388 OFFCURVE",
+"313 421 OFFCURVE",
+"259 421 CURVE SMOOTH",
+"221 421 OFFCURVE",
+"192 405 OFFCURVE",
+"176 372 CURVE",
+"172 372 LINE",
+"90 500 LINE",
+"26 458 LINE",
+"255 100 LINE",
+"243 76 OFFCURVE",
+"195 76 OFFCURVE",
+"175 76 CURVE SMOOTH",
+"-50 76 LINE SMOOTH",
+"-71 76 OFFCURVE",
+"-89 61 OFFCURVE",
+"-89 38 CURVE SMOOTH",
+"-89 14 OFFCURVE",
+"-71 0 OFFCURVE",
+"-50 0 CURVE SMOOTH",
+"164 0 LINE SMOOTH",
+"243 0 OFFCURVE",
+"281 14 OFFCURVE",
+"297 43 CURVE",
+"323 16 OFFCURVE",
+"355 0 OFFCURVE",
+"398 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 293 OFFCURVE",
+"287 274 OFFCURVE",
+"259 274 CURVE SMOOTH",
+"231 274 OFFCURVE",
+"210 293 OFFCURVE",
+"210 326 CURVE SMOOTH",
+"210 358 OFFCURVE",
+"229 377 OFFCURVE",
+"259 377 CURVE SMOOTH",
+"286 377 OFFCURVE",
+"307 358 OFFCURVE",
+"307 326 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"398 76 LINE",
+"368 76 OFFCURVE",
+"347 98 OFFCURVE",
+"332 123 CURVE",
+"263 229 LINE",
+"265 231 LINE",
+"315 233 OFFCURVE",
+"355 269 OFFCURVE",
+"355 327 CURVE SMOOTH",
+"355 388 OFFCURVE",
+"313 421 OFFCURVE",
+"259 421 CURVE SMOOTH",
+"221 421 OFFCURVE",
+"192 405 OFFCURVE",
+"176 372 CURVE",
+"172 372 LINE",
+"90 500 LINE",
+"26 458 LINE",
+"255 100 LINE",
+"243 76 OFFCURVE",
+"195 76 OFFCURVE",
+"175 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"164 0 LINE SMOOTH",
+"243 0 OFFCURVE",
+"281 14 OFFCURVE",
+"297 43 CURVE",
+"323 16 OFFCURVE",
+"355 0 OFFCURVE",
+"398 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 293 OFFCURVE",
+"287 274 OFFCURVE",
+"259 274 CURVE SMOOTH",
+"231 274 OFFCURVE",
+"210 293 OFFCURVE",
+"210 326 CURVE SMOOTH",
+"210 358 OFFCURVE",
+"229 377 OFFCURVE",
+"259 377 CURVE SMOOTH",
+"286 377 OFFCURVE",
+"307 358 OFFCURVE",
+"307 326 CURVE SMOOTH"
+);
+}
+);
+width = 398;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0713.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{492, 161}";
+},
+{
+name = RU;
+position = "{677, -477}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{373, 357}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"374 139 LINE",
+"329 76 LINE",
+"728 -220 LINE SMOOTH",
+"743 -231 OFFCURVE",
+"751 -244 OFFCURVE",
+"751 -259 CURVE SMOOTH",
+"751 -292 OFFCURVE",
+"716 -315 OFFCURVE",
+"669 -315 CURVE SMOOTH",
+"626 -315 OFFCURVE",
+"595 -296 OFFCURVE",
+"564 -273 CURVE SMOOTH",
+"187 9 LINE",
+"144 40 OFFCURVE",
+"94 76 OFFCURVE",
+"26 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 62 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 15 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"17 0 LINE SMOOTH",
+"64 0 OFFCURVE",
+"102 -24 OFFCURVE",
+"138 -51 CURVE SMOOTH",
+"508 -328 LINE SMOOTH",
+"568 -373 OFFCURVE",
+"619 -391 OFFCURVE",
+"667 -391 CURVE SMOOTH",
+"779 -391 OFFCURVE",
+"828 -319 OFFCURVE",
+"828 -259 CURVE SMOOTH",
+"828 -220 OFFCURVE",
+"812 -189 OFFCURVE",
+"771 -159 CURVE SMOOTH",
+"629 -53 LINE SMOOTH",
+"614 -41 OFFCURVE",
+"551 1 OFFCURVE",
+"540 7 CURVE",
+"540 10 LINE",
+"570 5 OFFCURVE",
+"611 0 OFFCURVE",
+"626 0 CURVE SMOOTH",
+"631 0 LINE",
+"631 76 LINE",
+"456 76 LINE"
+);
+}
+);
+width = 631;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0714.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{492, 161}";
+},
+{
+name = RU;
+position = "{677, -476}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{375, 357}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 194, 39}";
+},
+{
+name = uni0713.loclSYRJ.Medi;
+}
+);
+layerId = UUID0;
+width = 631;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072E.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{527, 390}";
+},
+{
+name = RU;
+position = "{677, -477}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{213, 401}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"629 -53 LINE SMOOTH",
+"614 -41 OFFCURVE",
+"552 1 OFFCURVE",
+"540 7 CURVE",
+"540 11 LINE",
+"564 6 OFFCURVE",
+"610 0 OFFCURVE",
+"626 0 CURVE SMOOTH",
+"631 0 LINE",
+"631 76 LINE",
+"598 76 LINE SMOOTH",
+"572 76 OFFCURVE",
+"506 74 OFFCURVE",
+"480 72 CURVE",
+"480 79 LINE",
+"535 90 OFFCURVE",
+"577 132 OFFCURVE",
+"577 193 CURVE SMOOTH",
+"577 250 OFFCURVE",
+"531 284 OFFCURVE",
+"475 327 CURVE SMOOTH",
+"424 365 LINE",
+"380 306 LINE",
+"433 267 LINE SMOOTH",
+"477 233 OFFCURVE",
+"502 215 OFFCURVE",
+"502 185 CURVE SMOOTH",
+"502 138 OFFCURVE",
+"457 124 OFFCURVE",
+"422 124 CURVE SMOOTH",
+"401 124 OFFCURVE",
+"386 130 OFFCURVE",
+"371 142 CURVE SMOOTH",
+"351 156 LINE",
+"306 93 LINE",
+"728 -220 LINE SMOOTH",
+"743 -231 OFFCURVE",
+"751 -244 OFFCURVE",
+"751 -259 CURVE SMOOTH",
+"751 -292 OFFCURVE",
+"716 -315 OFFCURVE",
+"669 -315 CURVE SMOOTH",
+"626 -315 OFFCURVE",
+"595 -296 OFFCURVE",
+"564 -273 CURVE SMOOTH",
+"187 9 LINE",
+"144 40 OFFCURVE",
+"94 76 OFFCURVE",
+"26 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 62 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 15 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"17 0 LINE SMOOTH",
+"64 0 OFFCURVE",
+"102 -24 OFFCURVE",
+"138 -51 CURVE SMOOTH",
+"508 -328 LINE SMOOTH",
+"568 -373 OFFCURVE",
+"619 -391 OFFCURVE",
+"667 -391 CURVE SMOOTH",
+"779 -391 OFFCURVE",
+"828 -319 OFFCURVE",
+"828 -259 CURVE SMOOTH",
+"828 -220 OFFCURVE",
+"812 -189 OFFCURVE",
+"771 -159 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"629 -53 LINE SMOOTH",
+"614 -41 OFFCURVE",
+"552 1 OFFCURVE",
+"540 7 CURVE",
+"540 11 LINE",
+"564 6 OFFCURVE",
+"610 0 OFFCURVE",
+"626 0 CURVE SMOOTH",
+"631 0 LINE",
+"631 76 LINE",
+"598 76 LINE SMOOTH",
+"572 76 OFFCURVE",
+"506 74 OFFCURVE",
+"480 72 CURVE",
+"480 79 LINE",
+"535 90 OFFCURVE",
+"577 132 OFFCURVE",
+"577 193 CURVE SMOOTH",
+"577 250 OFFCURVE",
+"532 285 OFFCURVE",
+"475 327 CURVE SMOOTH",
+"424 365 LINE",
+"380 306 LINE",
+"433 267 LINE SMOOTH",
+"479 233 OFFCURVE",
+"502 214 OFFCURVE",
+"502 185 CURVE SMOOTH",
+"502 138 OFFCURVE",
+"457 124 OFFCURVE",
+"422 124 CURVE SMOOTH",
+"401 124 OFFCURVE",
+"386 130 OFFCURVE",
+"371 142 CURVE SMOOTH",
+"351 156 LINE",
+"306 93 LINE",
+"728 -220 LINE SMOOTH",
+"743 -231 OFFCURVE",
+"751 -244 OFFCURVE",
+"751 -259 CURVE SMOOTH",
+"751 -292 OFFCURVE",
+"716 -315 OFFCURVE",
+"669 -315 CURVE SMOOTH",
+"626 -315 OFFCURVE",
+"595 -296 OFFCURVE",
+"564 -273 CURVE SMOOTH",
+"187 9 LINE",
+"144 40 OFFCURVE",
+"94 76 OFFCURVE",
+"26 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 62 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 15 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"17 0 LINE SMOOTH",
+"64 0 OFFCURVE",
+"102 -24 OFFCURVE",
+"138 -51 CURVE SMOOTH",
+"508 -328 LINE SMOOTH",
+"568 -373 OFFCURVE",
+"619 -391 OFFCURVE",
+"667 -391 CURVE SMOOTH",
+"779 -391 OFFCURVE",
+"828 -319 OFFCURVE",
+"828 -259 CURVE SMOOTH",
+"828 -220 OFFCURVE",
+"812 -189 OFFCURVE",
+"771 -159 CURVE SMOOTH"
+);
+}
+);
+width = 631;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071A.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{279, -98}";
+},
+{
+name = top;
+position = "{298, 366}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"2159 10 OFFCURVE",
+"2202 0 OFFCURVE",
+"2234 0 CURVE SMOOTH",
+"2274 0 OFFCURVE",
+"2314 12 OFFCURVE",
+"2352 48 CURVE",
+"2385 15 OFFCURVE",
+"2425 0 OFFCURVE",
+"2525 0 CURVE",
+"2525 76 LINE",
+"2488 76 OFFCURVE",
+"2465 82 OFFCURVE",
+"2456 86 CURVE",
+"2449 96 OFFCURVE",
+"2438 125 OFFCURVE",
+"2427 153 CURVE SMOOTH",
+"2404 216 OFFCURVE",
+"2393 241 OFFCURVE",
+"2360 241 CURVE SMOOTH",
+"2325 241 OFFCURVE",
+"2316 222 OFFCURVE",
+"2286 150 CURVE SMOOTH",
+"2269 109 OFFCURVE",
+"2255 89 OFFCURVE",
+"2242 89 CURVE SMOOTH",
+"2240 89 LINE SMOOTH",
+"2227 89 OFFCURVE",
+"2218 113 OFFCURVE",
+"2207 147 CURVE SMOOTH",
+"2188 208 OFFCURVE",
+"2175 241 OFFCURVE",
+"2139 241 CURVE SMOOTH",
+"2114 241 OFFCURVE",
+"2102 228 OFFCURVE",
+"2092 208 CURVE SMOOTH",
+"2071 164 OFFCURVE",
+"2058 125 OFFCURVE",
+"2039 103 CURVE SMOOTH",
+"2019 79 OFFCURVE",
+"1991 76 OFFCURVE",
+"1964 76 CURVE SMOOTH",
+"1943 76 OFFCURVE",
+"1925 61 OFFCURVE",
+"1925 38 CURVE SMOOTH",
+"1925 14 OFFCURVE",
+"1943 0 OFFCURVE",
+"1964 0 CURVE SMOOTH",
+"2026 0 OFFCURVE",
+"2077 12 OFFCURVE",
+"2124 48 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"2240 82 LINE",
+"2231 89 OFFCURVE",
+"2208 129 OFFCURVE",
+"2197 149 CURVE SMOOTH",
+"2170 196 OFFCURVE",
+"2159 205 OFFCURVE",
+"2133 205 CURVE SMOOTH",
+"2110 205 OFFCURVE",
+"2098 195 OFFCURVE",
+"2087 177 CURVE SMOOTH",
+"2059 132 LINE SMOOTH",
+"2030 86 OFFCURVE",
+"2002 76 OFFCURVE",
+"1964 76 CURVE SMOOTH",
+"1943 76 OFFCURVE",
+"1925 61 OFFCURVE",
+"1925 38 CURVE SMOOTH",
+"1925 14 OFFCURVE",
+"1943 0 OFFCURVE",
+"1964 0 CURVE SMOOTH",
+"2032 0 OFFCURVE",
+"2085 20 OFFCURVE",
+"2129 70 CURVE",
+"2169 17 OFFCURVE",
+"2200 0 OFFCURVE",
+"2234 0 CURVE SMOOTH",
+"2269 0 OFFCURVE",
+"2301 20 OFFCURVE",
+"2345 70 CURVE",
+"2385 17 OFFCURVE",
+"2415 0 OFFCURVE",
+"2500 0 CURVE SMOOTH",
+"2535 0 LINE",
+"2535 76 LINE",
+"2494 76 OFFCURVE",
+"2466 80 OFFCURVE",
+"2456 82 CURVE",
+"2447 89 OFFCURVE",
+"2424 129 OFFCURVE",
+"2413 149 CURVE SMOOTH",
+"2386 196 OFFCURVE",
+"2375 205 OFFCURVE",
+"2349 205 CURVE SMOOTH",
+"2326 205 OFFCURVE",
+"2314 195 OFFCURVE",
+"2303 177 CURVE SMOOTH",
+"2275 132 LINE SMOOTH",
+"2246 86 OFFCURVE",
+"2256 86 OFFCURVE",
+"2243 82 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1616 82 LINE",
+"1607 87 OFFCURVE",
+"1598 99 OFFCURVE",
+"1568 149 CURVE SMOOTH",
+"1540 195 OFFCURVE",
+"1530 203 OFFCURVE",
+"1508 203 CURVE SMOOTH",
+"1487 203 OFFCURVE",
+"1477 195 OFFCURVE",
+"1465 177 CURVE SMOOTH",
+"1438 136 LINE SMOOTH",
+"1408 91 OFFCURVE",
+"1379 76 OFFCURVE",
+"1341 76 CURVE SMOOTH",
+"1320 76 OFFCURVE",
+"1302 61 OFFCURVE",
+"1302 38 CURVE SMOOTH",
+"1302 14 OFFCURVE",
+"1320 0 OFFCURVE",
+"1341 0 CURVE SMOOTH",
+"1409 0 OFFCURVE",
+"1462 20 OFFCURVE",
+"1506 70 CURVE",
+"1549 16 OFFCURVE",
+"1579 0 OFFCURVE",
+"1613 0 CURVE SMOOTH",
+"1655 0 OFFCURVE",
+"1683 16 OFFCURVE",
+"1722 70 CURVE",
+"1762 17 OFFCURVE",
+"1792 0 OFFCURVE",
+"1877 0 CURVE SMOOTH",
+"1912 0 LINE",
+"1912 76 LINE",
+"1871 76 OFFCURVE",
+"1843 80 OFFCURVE",
+"1833 82 CURVE",
+"1824 89 OFFCURVE",
+"1799 129 OFFCURVE",
+"1788 149 CURVE SMOOTH",
+"1761 196 OFFCURVE",
+"1752 203 OFFCURVE",
+"1728 203 CURVE SMOOTH",
+"1707 203 OFFCURVE",
+"1695 191 OFFCURVE",
+"1684 172 CURVE SMOOTH",
+"1661 131 LINE SMOOTH",
+"1643 100 OFFCURVE",
+"1634 85 OFFCURVE",
+"1625 82 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"953 82 LINE",
+"944 87 OFFCURVE",
+"935 99 OFFCURVE",
+"905 149 CURVE SMOOTH",
+"877 195 OFFCURVE",
+"867 203 OFFCURVE",
+"845 203 CURVE SMOOTH",
+"824 203 OFFCURVE",
+"814 195 OFFCURVE",
+"802 177 CURVE SMOOTH",
+"775 136 LINE SMOOTH",
+"745 91 OFFCURVE",
+"706 76 OFFCURVE",
+"668 76 CURVE SMOOTH",
+"647 76 OFFCURVE",
+"629 61 OFFCURVE",
+"629 38 CURVE SMOOTH",
+"629 14 OFFCURVE",
+"647 0 OFFCURVE",
+"668 0 CURVE SMOOTH",
+"736 0 OFFCURVE",
+"799 20 OFFCURVE",
+"843 70 CURVE",
+"886 16 OFFCURVE",
+"916 0 OFFCURVE",
+"950 0 CURVE SMOOTH",
+"992 0 OFFCURVE",
+"1020 16 OFFCURVE",
+"1059 70 CURVE",
+"1099 17 OFFCURVE",
+"1129 0 OFFCURVE",
+"1214 0 CURVE SMOOTH",
+"1259 0 LINE",
+"1259 76 LINE",
+"1218 76 OFFCURVE",
+"1180 80 OFFCURVE",
+"1170 82 CURVE",
+"1161 89 OFFCURVE",
+"1136 129 OFFCURVE",
+"1125 149 CURVE SMOOTH",
+"1098 196 OFFCURVE",
+"1089 203 OFFCURVE",
+"1065 203 CURVE SMOOTH",
+"1044 203 OFFCURVE",
+"1032 191 OFFCURVE",
+"1021 172 CURVE SMOOTH",
+"998 131 LINE SMOOTH",
+"980 100 OFFCURVE",
+"971 85 OFFCURVE",
+"962 82 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"824 204 OFFCURVE",
+"814 195 OFFCURVE",
+"802 177 CURVE SMOOTH",
+"775 136 LINE SMOOTH",
+"761 115 OFFCURVE",
+"745 100 OFFCURVE",
+"728 91 CURVE SMOOTH",
+"709 80 OFFCURVE",
+"688 76 OFFCURVE",
+"668 76 CURVE SMOOTH",
+"647 76 OFFCURVE",
+"629 61 OFFCURVE",
+"629 38 CURVE SMOOTH",
+"629 14 OFFCURVE",
+"647 0 OFFCURVE",
+"668 0 CURVE SMOOTH",
+"698 0 OFFCURVE",
+"726 3 OFFCURVE",
+"753 12 CURVE SMOOTH",
+"775 19 OFFCURVE",
+"796 30 OFFCURVE",
+"815 44 CURVE SMOOTH",
+"825 52 OFFCURVE",
+"834 60 OFFCURVE",
+"843 70 CURVE",
+"886 16 OFFCURVE",
+"915 0 OFFCURVE",
+"972 0 CURVE SMOOTH",
+"1025 0 OFFCURVE",
+"1075 23 OFFCURVE",
+"1104 60 CURVE SMOOTH",
+"1121 82 OFFCURVE",
+"1131 108 OFFCURVE",
+"1131 138 CURVE SMOOTH",
+"1131 176 OFFCURVE",
+"1119 210 OFFCURVE",
+"1088 210 CURVE SMOOTH",
+"1069 210 OFFCURVE",
+"1056 200 OFFCURVE",
+"1042 174 CURVE SMOOTH",
+"1029 150 OFFCURVE",
+"996 90 OFFCURVE",
+"982 77 CURVE",
+"956 77 LINE",
+"947 82 OFFCURVE",
+"935 99 OFFCURVE",
+"905 149 CURVE SMOOTH",
+"877 195 OFFCURVE",
+"867 204 OFFCURVE",
+"845 204 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-79 69 OFFCURVE",
+"-106 132 OFFCURVE",
+"-108 213 CURVE",
+"-172 209 LINE",
+"-174 203 OFFCURVE",
+"-174 187 OFFCURVE",
+"-174 183 CURVE SMOOTH",
+"-174 68 OFFCURVE",
+"-121 -7 OFFCURVE",
+"10 -7 CURVE SMOOTH",
+"78 -7 OFFCURVE",
+"131 20 OFFCURVE",
+"175 70 CURVE",
+"218 16 OFFCURVE",
+"248 0 OFFCURVE",
+"282 0 CURVE SMOOTH",
+"314 0 OFFCURVE",
+"338 9 OFFCURVE",
+"365 38 CURVE SMOOTH",
+"373 47 OFFCURVE",
+"382 58 OFFCURVE",
+"391 70 CURVE",
+"431 17 OFFCURVE",
+"461 0 OFFCURVE",
+"546 0 CURVE SMOOTH",
+"551 0 LINE",
+"551 76 LINE",
+"541 76 OFFCURVE",
+"512 78 OFFCURVE",
+"502 82 CURVE",
+"493 89 OFFCURVE",
+"468 129 OFFCURVE",
+"457 149 CURVE SMOOTH",
+"430 196 OFFCURVE",
+"421 204 OFFCURVE",
+"397 204 CURVE SMOOTH",
+"376 204 OFFCURVE",
+"364 191 OFFCURVE",
+"353 172 CURVE SMOOTH",
+"330 131 LINE SMOOTH",
+"312 100 OFFCURVE",
+"303 85 OFFCURVE",
+"294 82 CURVE",
+"285 82 LINE",
+"276 87 OFFCURVE",
+"267 99 OFFCURVE",
+"237 149 CURVE SMOOTH",
+"209 195 OFFCURVE",
+"199 204 OFFCURVE",
+"177 204 CURVE SMOOTH",
+"156 204 OFFCURVE",
+"146 195 OFFCURVE",
+"134 177 CURVE SMOOTH",
+"107 136 LINE SMOOTH",
+"77 91 OFFCURVE",
+"48 69 OFFCURVE",
+"9 69 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-79 69 OFFCURVE",
+"-106 132 OFFCURVE",
+"-108 213 CURVE",
+"-172 209 LINE",
+"-174 203 OFFCURVE",
+"-174 187 OFFCURVE",
+"-174 183 CURVE SMOOTH",
+"-174 68 OFFCURVE",
+"-121 -7 OFFCURVE",
+"10 -7 CURVE SMOOTH",
+"78 -7 OFFCURVE",
+"131 20 OFFCURVE",
+"175 70 CURVE",
+"218 16 OFFCURVE",
+"248 0 OFFCURVE",
+"282 0 CURVE SMOOTH",
+"314 0 OFFCURVE",
+"338 9 OFFCURVE",
+"365 38 CURVE SMOOTH",
+"373 47 OFFCURVE",
+"382 58 OFFCURVE",
+"391 70 CURVE",
+"431 17 OFFCURVE",
+"461 0 OFFCURVE",
+"546 0 CURVE SMOOTH",
+"551 0 LINE",
+"551 76 LINE",
+"541 76 OFFCURVE",
+"512 78 OFFCURVE",
+"502 82 CURVE",
+"493 89 OFFCURVE",
+"468 129 OFFCURVE",
+"457 149 CURVE SMOOTH",
+"430 196 OFFCURVE",
+"421 204 OFFCURVE",
+"397 204 CURVE SMOOTH",
+"376 204 OFFCURVE",
+"364 191 OFFCURVE",
+"353 172 CURVE SMOOTH",
+"330 131 LINE SMOOTH",
+"312 100 OFFCURVE",
+"303 85 OFFCURVE",
+"294 82 CURVE",
+"285 82 LINE",
+"276 87 OFFCURVE",
+"267 99 OFFCURVE",
+"237 149 CURVE SMOOTH",
+"209 195 OFFCURVE",
+"199 204 OFFCURVE",
+"177 204 CURVE SMOOTH",
+"156 204 OFFCURVE",
+"146 195 OFFCURVE",
+"134 177 CURVE SMOOTH",
+"107 136 LINE SMOOTH",
+"77 91 OFFCURVE",
+"48 69 OFFCURVE",
+"9 69 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"315 0 OFFCURVE",
+"339 10 OFFCURVE",
+"367 41 CURVE SMOOTH",
+"375 49 OFFCURVE",
+"383 59 OFFCURVE",
+"391 70 CURVE",
+"431 17 OFFCURVE",
+"461 0 OFFCURVE",
+"546 0 CURVE SMOOTH",
+"551 0 LINE",
+"551 76 LINE",
+"541 76 OFFCURVE",
+"512 78 OFFCURVE",
+"502 82 CURVE",
+"493 89 OFFCURVE",
+"468 129 OFFCURVE",
+"457 149 CURVE SMOOTH",
+"430 196 OFFCURVE",
+"421 203 OFFCURVE",
+"397 203 CURVE SMOOTH",
+"376 203 OFFCURVE",
+"364 191 OFFCURVE",
+"353 172 CURVE SMOOTH",
+"330 131 LINE SMOOTH",
+"312 100 OFFCURVE",
+"301 82 OFFCURVE",
+"292 82 CURVE SMOOTH",
+"286 82 LINE SMOOTH",
+"275 82 OFFCURVE",
+"268 92 OFFCURVE",
+"235 147 CURVE SMOOTH",
+"207 193 OFFCURVE",
+"199 203 OFFCURVE",
+"177 203 CURVE SMOOTH",
+"156 203 OFFCURVE",
+"148 195 OFFCURVE",
+"135 177 CURVE SMOOTH",
+"106 137 LINE SMOOTH",
+"91 117 OFFCURVE",
+"77 100 OFFCURVE",
+"60 91 CURVE SMOOTH",
+"41 80 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"30 0 OFFCURVE",
+"59 4 OFFCURVE",
+"85 12 CURVE SMOOTH",
+"108 19 OFFCURVE",
+"128 30 OFFCURVE",
+"147 44 CURVE SMOOTH",
+"157 52 OFFCURVE",
+"166 60 OFFCURVE",
+"175 70 CURVE",
+"217 10 OFFCURVE",
+"248 0 OFFCURVE",
+"282 0 CURVE SMOOTH"
+);
+}
+);
+width = 551;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071F.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{504, 447}";
+},
+{
+name = RU;
+position = "{486, -76}";
+},
+{
+name = bottom;
+position = "{241, -98}";
+},
+{
+name = top;
+position = "{257, 537}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"562 0 LINE",
+"562 76 LINE",
+"543 76 LINE SMOOTH",
+"523 76 OFFCURVE",
+"499 76 OFFCURVE",
+"475 74 CURVE",
+"474 78 LINE",
+"493 99 OFFCURVE",
+"499 134 OFFCURVE",
+"499 169 CURVE SMOOTH",
+"499 340 OFFCURVE",
+"388 436 OFFCURVE",
+"271 436 CURVE SMOOTH",
+"166 436 OFFCURVE",
+"78 358 OFFCURVE",
+"56 251 CURVE",
+"120 238 LINE",
+"146 319 OFFCURVE",
+"208 360 OFFCURVE",
+"272 360 CURVE SMOOTH",
+"360 360 OFFCURVE",
+"425 279 OFFCURVE",
+"425 168 CURVE SMOOTH",
+"425 108 OFFCURVE",
+"401 76 OFFCURVE",
+"327 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 562;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074E.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{299, -98}";
+},
+{
+name = top;
+position = "{140, 680}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"286 613 LINE",
+"356 584 LINE SMOOTH",
+"408 563 OFFCURVE",
+"425 538 OFFCURVE",
+"425 508 CURVE SMOOTH",
+"425 470 OFFCURVE",
+"397 454 OFFCURVE",
+"368 450 CURVE",
+"328 471 OFFCURVE",
+"278 486 OFFCURVE",
+"213 486 CURVE",
+"200 416 LINE",
+"228 414 LINE SMOOTH",
+"327 404 OFFCURVE",
+"453 339 OFFCURVE",
+"453 195 CURVE SMOOTH",
+"453 83 OFFCURVE",
+"368 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"606 0 LINE",
+"606 76 LINE",
+"544 76 LINE SMOOTH",
+"530 76 OFFCURVE",
+"512 76 OFFCURVE",
+"494 75 CURVE",
+"494 78 LINE",
+"513 105 OFFCURVE",
+"524 141 OFFCURVE",
+"524 188 CURVE SMOOTH",
+"524 290 OFFCURVE",
+"484 359 OFFCURVE",
+"424 406 CURVE",
+"424 409 LINE",
+"474 427 OFFCURVE",
+"500 469 OFFCURVE",
+"500 521 CURVE SMOOTH",
+"500 581 OFFCURVE",
+"452 623 OFFCURVE",
+"386 649 CURVE SMOOTH",
+"316 678 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"286 613 LINE",
+"356 584 LINE SMOOTH",
+"408 563 OFFCURVE",
+"425 538 OFFCURVE",
+"425 508 CURVE SMOOTH",
+"425 470 OFFCURVE",
+"397 454 OFFCURVE",
+"368 450 CURVE",
+"328 471 OFFCURVE",
+"278 486 OFFCURVE",
+"213 486 CURVE",
+"200 416 LINE",
+"228 414 LINE SMOOTH",
+"327 404 OFFCURVE",
+"453 339 OFFCURVE",
+"453 195 CURVE SMOOTH",
+"453 83 OFFCURVE",
+"368 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"606 0 LINE",
+"606 76 LINE",
+"544 76 LINE SMOOTH",
+"530 76 OFFCURVE",
+"512 76 OFFCURVE",
+"494 75 CURVE",
+"494 78 LINE",
+"513 105 OFFCURVE",
+"524 141 OFFCURVE",
+"524 188 CURVE SMOOTH",
+"524 290 OFFCURVE",
+"484 359 OFFCURVE",
+"424 406 CURVE",
+"424 409 LINE",
+"474 427 OFFCURVE",
+"500 469 OFFCURVE",
+"500 521 CURVE SMOOTH",
+"500 581 OFFCURVE",
+"452 623 OFFCURVE",
+"386 649 CURVE SMOOTH",
+"316 678 LINE"
+);
+}
+);
+width = 606;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{192, -98}";
+},
+{
+name = top;
+position = "{147, 707}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-57 693 LINE",
+"-114 642 LINE",
+"373 87 LINE",
+"355 77 OFFCURVE",
+"331 76 OFFCURVE",
+"306 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"295 0 LINE SMOOTH",
+"363 0 OFFCURVE",
+"400 10 OFFCURVE",
+"420 33 CURVE",
+"459 -12 LINE",
+"518 38 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"295 0 LINE SMOOTH",
+"366 0 OFFCURVE",
+"403 11 OFFCURVE",
+"422 35 CURVE",
+"447 14 OFFCURVE",
+"475 0 OFFCURVE",
+"514 0 CURVE",
+"514 76 LINE",
+"493 76 OFFCURVE",
+"474 87 OFFCURVE",
+"455 109 CURVE SMOOTH",
+"-57 693 LINE",
+"-114 642 LINE",
+"373 87 LINE",
+"353 77 OFFCURVE",
+"330 76 OFFCURVE",
+"306 76 CURVE SMOOTH"
+);
+}
+);
+width = 514;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0721.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{377, -98}";
+},
+{
+name = top;
+position = "{385, 507}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"6 404 LINE",
+"278 109 LINE",
+"274 77 OFFCURVE",
+"218 76 OFFCURVE",
+"195 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"185 0 LINE SMOOTH",
+"274 0 OFFCURVE",
+"315 22 OFFCURVE",
+"333 61 CURVE",
+"336 61 LINE",
+"379 20 OFFCURVE",
+"437 0 OFFCURVE",
+"502 0 CURVE SMOOTH",
+"624 0 OFFCURVE",
+"691 86 OFFCURVE",
+"691 190 CURVE SMOOTH",
+"691 308 OFFCURVE",
+"602 405 OFFCURVE",
+"466 405 CURVE SMOOTH",
+"385 405 OFFCURVE",
+"293 366 OFFCURVE",
+"272 253 CURVE SMOOTH",
+"270 243 OFFCURVE",
+"269 232 OFFCURVE",
+"268 220 CURVE",
+"265 220 LINE",
+"255 235 OFFCURVE",
+"241 254 OFFCURVE",
+"219 279 CURVE SMOOTH",
+"64 455 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 74 OFFCURVE",
+"333 147 OFFCURVE",
+"333 206 CURVE SMOOTH",
+"333 292 OFFCURVE",
+"396 332 OFFCURVE",
+"466 332 CURVE SMOOTH",
+"558 332 OFFCURVE",
+"618 272 OFFCURVE",
+"618 192 CURVE SMOOTH",
+"618 107 OFFCURVE",
+"559 74 OFFCURVE",
+"493 74 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"6 404 LINE",
+"278 109 LINE",
+"274 77 OFFCURVE",
+"218 76 OFFCURVE",
+"195 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"185 0 LINE SMOOTH",
+"274 0 OFFCURVE",
+"315 22 OFFCURVE",
+"333 61 CURVE",
+"336 61 LINE",
+"379 20 OFFCURVE",
+"437 0 OFFCURVE",
+"502 0 CURVE SMOOTH",
+"624 0 OFFCURVE",
+"691 86 OFFCURVE",
+"691 190 CURVE SMOOTH",
+"691 308 OFFCURVE",
+"602 405 OFFCURVE",
+"466 405 CURVE SMOOTH",
+"385 405 OFFCURVE",
+"293 366 OFFCURVE",
+"272 253 CURVE SMOOTH",
+"270 243 OFFCURVE",
+"269 232 OFFCURVE",
+"268 220 CURVE",
+"265 220 LINE",
+"255 235 OFFCURVE",
+"241 254 OFFCURVE",
+"219 279 CURVE SMOOTH",
+"64 455 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 74 OFFCURVE",
+"333 147 OFFCURVE",
+"333 206 CURVE SMOOTH",
+"333 292 OFFCURVE",
+"396 332 OFFCURVE",
+"466 332 CURVE SMOOTH",
+"558 332 OFFCURVE",
+"618 272 OFFCURVE",
+"618 192 CURVE SMOOTH",
+"618 107 OFFCURVE",
+"559 74 OFFCURVE",
+"493 74 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"6 404 LINE",
+"278 109 LINE",
+"274 77 OFFCURVE",
+"218 76 OFFCURVE",
+"195 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"185 0 LINE SMOOTH",
+"274 0 OFFCURVE",
+"315 22 OFFCURVE",
+"333 61 CURVE",
+"336 61 LINE",
+"379 20 OFFCURVE",
+"437 0 OFFCURVE",
+"502 0 CURVE SMOOTH",
+"624 0 OFFCURVE",
+"691 86 OFFCURVE",
+"691 190 CURVE SMOOTH",
+"691 308 OFFCURVE",
+"602 405 OFFCURVE",
+"466 405 CURVE SMOOTH",
+"385 405 OFFCURVE",
+"293 366 OFFCURVE",
+"272 253 CURVE SMOOTH",
+"270 243 OFFCURVE",
+"269 232 OFFCURVE",
+"268 220 CURVE",
+"265 220 LINE",
+"255 235 OFFCURVE",
+"241 254 OFFCURVE",
+"219 279 CURVE SMOOTH",
+"64 455 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 74 OFFCURVE",
+"333 147 OFFCURVE",
+"333 206 CURVE SMOOTH",
+"333 292 OFFCURVE",
+"396 332 OFFCURVE",
+"466 332 CURVE SMOOTH",
+"558 332 OFFCURVE",
+"618 272 OFFCURVE",
+"618 192 CURVE SMOOTH",
+"618 107 OFFCURVE",
+"559 74 OFFCURVE",
+"493 74 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"6 404 LINE",
+"278 109 LINE",
+"274 77 OFFCURVE",
+"218 76 OFFCURVE",
+"195 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"185 0 LINE SMOOTH",
+"274 0 OFFCURVE",
+"314 22 OFFCURVE",
+"333 61 CURVE",
+"335 61 LINE",
+"380 18 OFFCURVE",
+"439 0 OFFCURVE",
+"517 0 CURVE SMOOTH",
+"753 0 LINE",
+"753 76 LINE",
+"733 76 LINE SMOOTH",
+"711 76 OFFCURVE",
+"670 75 OFFCURVE",
+"646 74 CURVE",
+"646 77 LINE",
+"671 104 OFFCURVE",
+"691 145 OFFCURVE",
+"691 195 CURVE SMOOTH",
+"691 310 OFFCURVE",
+"602 405 OFFCURVE",
+"466 405 CURVE SMOOTH",
+"385 405 OFFCURVE",
+"293 366 OFFCURVE",
+"272 253 CURVE SMOOTH",
+"270 243 OFFCURVE",
+"269 232 OFFCURVE",
+"268 220 CURVE",
+"265 220 LINE",
+"255 235 OFFCURVE",
+"241 254 OFFCURVE",
+"219 279 CURVE SMOOTH",
+"64 455 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 74 OFFCURVE",
+"333 147 OFFCURVE",
+"333 206 CURVE SMOOTH",
+"333 292 OFFCURVE",
+"396 332 OFFCURVE",
+"466 332 CURVE SMOOTH",
+"558 332 OFFCURVE",
+"618 272 OFFCURVE",
+"618 192 CURVE SMOOTH",
+"618 107 OFFCURVE",
+"559 74 OFFCURVE",
+"493 74 CURVE SMOOTH"
+);
+}
+);
+width = 753;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{163, -98}";
+},
+{
+name = top;
+position = "{160, 537}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"130 412 LINE",
+"139 362 OFFCURVE",
+"144 285 OFFCURVE",
+"144 239 CURVE SMOOTH",
+"144 211 OFFCURVE",
+"143 140 OFFCURVE",
+"137 118 CURVE SMOOTH",
+"128 89 OFFCURVE",
+"110 76 OFFCURVE",
+"69 76 CURVE SMOOTH",
+"-15 76 LINE SMOOTH",
+"-36 76 OFFCURVE",
+"-54 61 OFFCURVE",
+"-54 38 CURVE SMOOTH",
+"-54 14 OFFCURVE",
+"-36 0 OFFCURVE",
+"-15 0 CURVE SMOOTH",
+"48 0 LINE SMOOTH",
+"101 0 OFFCURVE",
+"141 11 OFFCURVE",
+"172 41 CURVE",
+"195 10 OFFCURVE",
+"237 0 OFFCURVE",
+"302 0 CURVE SMOOTH",
+"316 0 LINE",
+"316 76 LINE",
+"306 76 LINE SMOOTH",
+"281 76 OFFCURVE",
+"221 78 OFFCURVE",
+"208 99 CURVE",
+"217 141 OFFCURVE",
+"217 202 OFFCURVE",
+"217 242 CURVE SMOOTH",
+"217 293 OFFCURVE",
+"213 381 OFFCURVE",
+"202 423 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"144 262 LINE",
+"144 229 OFFCURVE",
+"144 214 OFFCURVE",
+"144 202 CURVE SMOOTH",
+"144 181 OFFCURVE",
+"143 143 OFFCURVE",
+"137 121 CURVE SMOOTH",
+"129 92 OFFCURVE",
+"110 76 OFFCURVE",
+"69 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"48 0 LINE SMOOTH",
+"101 0 OFFCURVE",
+"141 11 OFFCURVE",
+"172 41 CURVE",
+"201 10 OFFCURVE",
+"237 0 OFFCURVE",
+"316 0 CURVE",
+"316 76 LINE",
+"259 76 OFFCURVE",
+"220 84 OFFCURVE",
+"207 99 CURVE",
+"214 123 OFFCURVE",
+"217 171 OFFCURVE",
+"217 199 CURVE SMOOTH",
+"217 210 OFFCURVE",
+"217 238 OFFCURVE",
+"213 268 CURVE"
+);
+}
+);
+width = 316;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0726.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{498, 547}";
+},
+{
+name = RU;
+position = "{485, -103}";
+},
+{
+name = bottom;
+position = "{238, -98}";
+},
+{
+name = top;
+position = "{256, 633}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"153 533 OFFCURVE",
+"59 464 OFFCURVE",
+"59 349 CURVE SMOOTH",
+"59 229 OFFCURVE",
+"155 187 OFFCURVE",
+"255 187 CURVE SMOOTH",
+"323 187 OFFCURVE",
+"397 215 OFFCURVE",
+"446 264 CURVE",
+"449 264 LINE",
+"451 248 OFFCURVE",
+"453 231 OFFCURVE",
+"453 214 CURVE SMOOTH",
+"453 103 OFFCURVE",
+"368 76 OFFCURVE",
+"278 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"606 0 LINE",
+"606 76 LINE",
+"536 76 LINE SMOOTH",
+"516 76 OFFCURVE",
+"491 76 OFFCURVE",
+"468 74 CURVE",
+"466 78 LINE",
+"505 108 OFFCURVE",
+"524 157 OFFCURVE",
+"524 217 CURVE SMOOTH",
+"524 401 OFFCURVE",
+"388 533 OFFCURVE",
+"258 533 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"178 260 OFFCURVE",
+"132 293 OFFCURVE",
+"132 356 CURVE SMOOTH",
+"132 416 OFFCURVE",
+"186 457 OFFCURVE",
+"258 457 CURVE SMOOTH",
+"328 457 OFFCURVE",
+"393 410 OFFCURVE",
+"428 333 CURVE",
+"386 285 OFFCURVE",
+"317 260 OFFCURVE",
+"257 260 CURVE SMOOTH"
+);
+}
+);
+width = 606;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0729.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{286, -98}";
+},
+{
+name = top;
+position = "{292, 515}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"574 0 LINE",
+"574 76 LINE",
+"542 76 LINE SMOOTH",
+"519 76 OFFCURVE",
+"479 75 OFFCURVE",
+"457 74 CURVE",
+"457 77 LINE",
+"487 106 OFFCURVE",
+"511 158 OFFCURVE",
+"511 210 CURVE SMOOTH",
+"511 331 OFFCURVE",
+"418 417 OFFCURVE",
+"276 417 CURVE SMOOTH",
+"163 417 OFFCURVE",
+"63 341 OFFCURVE",
+"63 214 CURVE SMOOTH",
+"63 158 OFFCURVE",
+"82 115 OFFCURVE",
+"123 78 CURVE",
+"123 74 LINE",
+"101 76 OFFCURVE",
+"77 76 OFFCURVE",
+"62 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 76 OFFCURVE",
+"136 138 OFFCURVE",
+"136 218 CURVE SMOOTH",
+"136 296 OFFCURVE",
+"201 344 OFFCURVE",
+"276 344 CURVE SMOOTH",
+"374 344 OFFCURVE",
+"437 286 OFFCURVE",
+"437 207 CURVE SMOOTH",
+"437 119 OFFCURVE",
+"372 76 OFFCURVE",
+"296 76 CURVE SMOOTH"
+);
+}
+);
+width = 574;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0727.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{311, -98}";
+},
+{
+name = top;
+position = "{331, 621}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"615 76 LINE",
+"478 76 LINE SMOOTH",
+"327 76 OFFCURVE",
+"160 77 OFFCURVE",
+"160 259 CURVE SMOOTH",
+"160 369 OFFCURVE",
+"249 442 OFFCURVE",
+"339 442 CURVE SMOOTH",
+"431 442 OFFCURVE",
+"479 401 OFFCURVE",
+"479 340 CURVE SMOOTH",
+"479 290 OFFCURVE",
+"444 260 OFFCURVE",
+"391 260 CURVE SMOOTH",
+"358 260 OFFCURVE",
+"321 279 OFFCURVE",
+"315 324 CURVE",
+"256 317 LINE",
+"256 243 OFFCURVE",
+"316 194 OFFCURVE",
+"394 194 CURVE SMOOTH",
+"490 194 OFFCURVE",
+"549 262 OFFCURVE",
+"549 342 CURVE SMOOTH",
+"549 436 OFFCURVE",
+"471 518 OFFCURVE",
+"336 518 CURVE SMOOTH",
+"207 518 OFFCURVE",
+"85 401 OFFCURVE",
+"85 253 CURVE SMOOTH",
+"85 164 OFFCURVE",
+"116 110 OFFCURVE",
+"170 78 CURVE",
+"168 74 LINE",
+"146 76 OFFCURVE",
+"122 76 OFFCURVE",
+"101 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"615 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"615 76 LINE",
+"478 76 LINE SMOOTH",
+"327 76 OFFCURVE",
+"160 77 OFFCURVE",
+"160 259 CURVE SMOOTH",
+"160 369 OFFCURVE",
+"249 442 OFFCURVE",
+"339 442 CURVE SMOOTH",
+"431 442 OFFCURVE",
+"479 401 OFFCURVE",
+"479 340 CURVE SMOOTH",
+"479 290 OFFCURVE",
+"444 260 OFFCURVE",
+"391 260 CURVE SMOOTH",
+"358 260 OFFCURVE",
+"321 279 OFFCURVE",
+"315 324 CURVE",
+"256 317 LINE",
+"256 243 OFFCURVE",
+"316 194 OFFCURVE",
+"394 194 CURVE SMOOTH",
+"490 194 OFFCURVE",
+"549 262 OFFCURVE",
+"549 342 CURVE SMOOTH",
+"549 436 OFFCURVE",
+"471 518 OFFCURVE",
+"336 518 CURVE SMOOTH",
+"207 518 OFFCURVE",
+"85 401 OFFCURVE",
+"85 253 CURVE SMOOTH",
+"85 164 OFFCURVE",
+"116 110 OFFCURVE",
+"170 78 CURVE",
+"168 74 LINE",
+"146 76 OFFCURVE",
+"122 76 OFFCURVE",
+"101 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"615 0 LINE"
+);
+}
+);
+width = 615;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0723.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{412, -98}";
+},
+{
+name = top;
+position = "{418, 477}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"504 403 OFFCURVE",
+"448 375 OFFCURVE",
+"419 320 CURVE",
+"416 320 LINE",
+"385 370 OFFCURVE",
+"330 399 OFFCURVE",
+"259 399 CURVE SMOOTH",
+"161 399 OFFCURVE",
+"73 335 OFFCURVE",
+"73 212 CURVE SMOOTH",
+"73 156 OFFCURVE",
+"89 113 OFFCURVE",
+"123 78 CURVE",
+"123 74 LINE",
+"102 76 OFFCURVE",
+"80 76 OFFCURVE",
+"61 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"265 0 LINE",
+"418 0 LINE",
+"545 0 LINE",
+"827 0 LINE",
+"827 76 LINE",
+"762 76 LINE SMOOTH",
+"745 76 OFFCURVE",
+"722 76 OFFCURVE",
+"700 74 CURVE",
+"700 78 LINE",
+"732 105 OFFCURVE",
+"753 156 OFFCURVE",
+"753 208 CURVE SMOOTH",
+"753 327 OFFCURVE",
+"679 403 OFFCURVE",
+"564 403 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"187 76 OFFCURVE",
+"145 138 OFFCURVE",
+"145 216 CURVE SMOOTH",
+"145 292 OFFCURVE",
+"199 326 OFFCURVE",
+"259 326 CURVE SMOOTH",
+"347 326 OFFCURVE",
+"389 266 OFFCURVE",
+"389 168 CURVE SMOOTH",
+"389 81 OFFCURVE",
+"324 76 OFFCURVE",
+"271 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 76 OFFCURVE",
+"446 95 OFFCURVE",
+"446 202 CURVE SMOOTH",
+"446 295 OFFCURVE",
+"511 330 OFFCURVE",
+"564 330 CURVE SMOOTH",
+"640 330 OFFCURVE",
+"683 285 OFFCURVE",
+"683 209 CURVE SMOOTH",
+"683 110 OFFCURVE",
+"612 76 OFFCURVE",
+"549 76 CURVE SMOOTH"
+);
+}
+);
+width = 827;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0724.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{412, -98}";
+},
+{
+name = top;
+position = "{416, 477}";
+}
+);
+components = (
+{
+name = uni0723.loclSYRJ.Medi;
+}
+);
+layerId = UUID0;
+width = 827;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072B.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{239, -98}";
+},
+{
+name = top;
+position = "{248, 452}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1480 0 OFFCURVE",
+"1555 9 OFFCURVE",
+"1626 41 CURVE",
+"1691 11 OFFCURVE",
+"1772 0 OFFCURVE",
+"1831 0 CURVE SMOOTH",
+"1856 0 LINE",
+"1856 76 LINE",
+"1853 76 LINE SMOOTH",
+"1799 76 OFFCURVE",
+"1761 91 OFFCURVE",
+"1736 116 CURVE",
+"1758 140 OFFCURVE",
+"1773 165 OFFCURVE",
+"1773 210 CURVE SMOOTH",
+"1773 296 OFFCURVE",
+"1702 351 OFFCURVE",
+"1629 351 CURVE SMOOTH",
+"1531 351 OFFCURVE",
+"1472 292 OFFCURVE",
+"1472 200 CURVE SMOOTH",
+"1472 167 OFFCURVE",
+"1481 141 OFFCURVE",
+"1500 114 CURVE",
+"1490 85 OFFCURVE",
+"1429 76 OFFCURVE",
+"1389 76 CURVE SMOOTH",
+"1368 76 OFFCURVE",
+"1350 61 OFFCURVE",
+"1350 38 CURVE SMOOTH",
+"1350 14 OFFCURVE",
+"1368 0 OFFCURVE",
+"1389 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"2185 329 OFFCURVE",
+"2133 248 OFFCURVE",
+"2117 79 CURVE",
+"2106 77 OFFCURVE",
+"2078 76 OFFCURVE",
+"2058 76 CURVE SMOOTH",
+"2037 76 OFFCURVE",
+"2019 61 OFFCURVE",
+"2019 38 CURVE SMOOTH",
+"2019 14 OFFCURVE",
+"2037 0 OFFCURVE",
+"2058 0 CURVE SMOOTH",
+"2254 0 LINE SMOOTH",
+"2342 0 OFFCURVE",
+"2411 12 OFFCURVE",
+"2447 77 CURVE",
+"2450 77 LINE",
+"2487 34 OFFCURVE",
+"2545 -5 OFFCURVE",
+"2611 -5 CURVE",
+"2621 63 LINE",
+"2574 68 OFFCURVE",
+"2543 77 OFFCURVE",
+"2488 148 CURVE SMOOTH",
+"2452 194 LINE SMOOTH",
+"2398 262 OFFCURVE",
+"2346 329 OFFCURVE",
+"2265 329 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"2185 329 OFFCURVE",
+"2133 248 OFFCURVE",
+"2117 79 CURVE",
+"2106 77 OFFCURVE",
+"2078 76 OFFCURVE",
+"2058 76 CURVE SMOOTH",
+"2037 76 OFFCURVE",
+"2019 61 OFFCURVE",
+"2019 38 CURVE SMOOTH",
+"2019 14 OFFCURVE",
+"2037 0 OFFCURVE",
+"2058 0 CURVE SMOOTH",
+"2254 0 LINE SMOOTH",
+"2342 0 OFFCURVE",
+"2414 3 OFFCURVE",
+"2450 36 CURVE",
+"2453 36 LINE",
+"2490 8 OFFCURVE",
+"2540 -6 OFFCURVE",
+"2592 -6 CURVE",
+"2595 62 LINE",
+"2548 65 OFFCURVE",
+"2522 67 OFFCURVE",
+"2467 138 CURVE SMOOTH",
+"2455 153 LINE SMOOTH",
+"2401 221 OFFCURVE",
+"2346 329 OFFCURVE",
+"2265 329 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1534 296 OFFCURVE",
+"1493 238 OFFCURVE",
+"1460 79 CURVE",
+"1449 77 OFFCURVE",
+"1419 76 OFFCURVE",
+"1399 76 CURVE SMOOTH",
+"1378 76 OFFCURVE",
+"1360 61 OFFCURVE",
+"1360 38 CURVE SMOOTH",
+"1360 14 OFFCURVE",
+"1378 0 OFFCURVE",
+"1399 0 CURVE SMOOTH",
+"1585 0 LINE SMOOTH",
+"1673 0 OFFCURVE",
+"1745 3 OFFCURVE",
+"1781 36 CURVE",
+"1784 36 LINE",
+"1821 8 OFFCURVE",
+"1868 0 OFFCURVE",
+"1920 0 CURVE",
+"1920 76 LINE",
+"1875 76 OFFCURVE",
+"1843 83 OFFCURVE",
+"1790 147 CURVE SMOOTH",
+"1749 197 LINE SMOOTH",
+"1698 260 OFFCURVE",
+"1663 296 OFFCURVE",
+"1611 296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"954 290 OFFCURVE",
+"920 242 OFFCURVE",
+"883 79 CURVE",
+"872 77 OFFCURVE",
+"822 76 OFFCURVE",
+"802 76 CURVE SMOOTH",
+"781 76 OFFCURVE",
+"763 61 OFFCURVE",
+"763 38 CURVE SMOOTH",
+"763 14 OFFCURVE",
+"781 0 OFFCURVE",
+"802 0 CURVE SMOOTH",
+"1008 0 LINE SMOOTH",
+"1096 0 OFFCURVE",
+"1168 3 OFFCURVE",
+"1204 36 CURVE",
+"1207 36 LINE",
+"1244 8 OFFCURVE",
+"1291 0 OFFCURVE",
+"1323 0 CURVE",
+"1323 76 LINE",
+"1292 76 OFFCURVE",
+"1267 82 OFFCURVE",
+"1229 127 CURVE SMOOTH",
+"1171 194 LINE SMOOTH",
+"1119 254 OFFCURVE",
+"1083 290 OFFCURVE",
+"1031 290 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"954 290 OFFCURVE",
+"920 242 OFFCURVE",
+"883 79 CURVE",
+"872 77 OFFCURVE",
+"792 76 OFFCURVE",
+"772 76 CURVE SMOOTH",
+"751 76 OFFCURVE",
+"733 61 OFFCURVE",
+"733 38 CURVE SMOOTH",
+"733 14 OFFCURVE",
+"751 0 OFFCURVE",
+"772 0 CURVE SMOOTH",
+"1008 0 LINE SMOOTH",
+"1096 0 OFFCURVE",
+"1168 3 OFFCURVE",
+"1204 36 CURVE",
+"1207 36 LINE",
+"1244 8 OFFCURVE",
+"1281 0 OFFCURVE",
+"1303 0 CURVE",
+"1303 76 LINE",
+"1294 76 OFFCURVE",
+"1267 82 OFFCURVE",
+"1229 127 CURVE SMOOTH",
+"1171 194 LINE SMOOTH",
+"1119 254 OFFCURVE",
+"1083 290 OFFCURVE",
+"1031 290 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"143 295 OFFCURVE",
+"102 230 OFFCURVE",
+"96 79 CURVE",
+"85 77 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"206 0 LINE SMOOTH",
+"294 0 OFFCURVE",
+"366 3 OFFCURVE",
+"405 36 CURVE",
+"442 8 OFFCURVE",
+"496 -3 OFFCURVE",
+"528 -3 CURVE",
+"528 73 LINE",
+"502 73 OFFCURVE",
+"465 82 OFFCURVE",
+"427 127 CURVE SMOOTH",
+"369 194 LINE SMOOTH",
+"317 254 OFFCURVE",
+"272 295 OFFCURVE",
+"220 295 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"143 295 OFFCURVE",
+"102 230 OFFCURVE",
+"96 79 CURVE",
+"85 77 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"206 0 LINE SMOOTH",
+"294 0 OFFCURVE",
+"366 3 OFFCURVE",
+"405 36 CURVE",
+"442 8 OFFCURVE",
+"496 -3 OFFCURVE",
+"528 -3 CURVE",
+"528 73 LINE",
+"502 73 OFFCURVE",
+"465 82 OFFCURVE",
+"427 127 CURVE SMOOTH",
+"369 194 LINE SMOOTH",
+"317 254 OFFCURVE",
+"272 295 OFFCURVE",
+"220 295 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"481 76 LINE",
+"460 76 OFFCURVE",
+"442 61 OFFCURVE",
+"442 38 CURVE SMOOTH",
+"442 14 OFFCURVE",
+"460 0 OFFCURVE",
+"481 0 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"143 295 OFFCURVE",
+"102 230 OFFCURVE",
+"96 79 CURVE",
+"85 77 OFFCURVE",
+"20 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"206 0 LINE SMOOTH",
+"294 0 OFFCURVE",
+"356 3 OFFCURVE",
+"395 36 CURVE",
+"425 6 OFFCURVE",
+"456 0 OFFCURVE",
+"481 0 CURVE",
+"481 76 LINE",
+"472 76 OFFCURVE",
+"456 81 OFFCURVE",
+"424 121 CURVE SMOOTH",
+"366 193 LINE SMOOTH",
+"313 259 OFFCURVE",
+"272 295 OFFCURVE",
+"220 295 CURVE SMOOTH"
+);
+}
+);
+width = 481;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071B.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{196, -381}";
+},
+{
+name = top;
+position = "{153, 664}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"29 -244 OFFCURVE",
+"102 -316 OFFCURVE",
+"202 -316 CURVE SMOOTH",
+"305 -316 OFFCURVE",
+"385 -248 OFFCURVE",
+"385 -127 CURVE SMOOTH",
+"385 12 OFFCURVE",
+"276 74 OFFCURVE",
+"149 76 CURVE",
+"168 141 OFFCURVE",
+"194 269 OFFCURVE",
+"194 385 CURVE SMOOTH",
+"194 400 OFFCURVE",
+"193 416 OFFCURVE",
+"191 440 CURVE",
+"196 440 LINE",
+"218 400 OFFCURVE",
+"317 250 OFFCURVE",
+"366 179 CURVE",
+"455 55 OFFCURVE",
+"492 0 OFFCURVE",
+"606 0 CURVE",
+"606 76 LINE",
+"535 76 OFFCURVE",
+"514 100 OFFCURVE",
+"423 226 CURVE SMOOTH",
+"350 326 OFFCURVE",
+"242 493 OFFCURVE",
+"188 592 CURVE",
+"120 564 LINE",
+"125 514 OFFCURVE",
+"125 476 OFFCURVE",
+"125 417 CURVE SMOOTH",
+"125 298 OFFCURVE",
+"102 158 OFFCURVE",
+"77 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"53 0 LINE",
+"39 -42 OFFCURVE",
+"29 -96 OFFCURVE",
+"29 -134 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"148 0 LINE SMOOTH",
+"240 0 OFFCURVE",
+"314 -35 OFFCURVE",
+"314 -125 CURVE SMOOTH",
+"314 -200 OFFCURVE",
+"269 -243 OFFCURVE",
+"204 -243 CURVE SMOOTH",
+"133 -243 OFFCURVE",
+"100 -185 OFFCURVE",
+"100 -124 CURVE SMOOTH",
+"100 -88 OFFCURVE",
+"109 -43 OFFCURVE",
+"126 0 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"29 -244 OFFCURVE",
+"102 -316 OFFCURVE",
+"202 -316 CURVE SMOOTH",
+"305 -316 OFFCURVE",
+"385 -248 OFFCURVE",
+"385 -127 CURVE SMOOTH",
+"385 11 OFFCURVE",
+"278 76 OFFCURVE",
+"152 76 CURVE SMOOTH",
+"149 76 LINE",
+"156 103 OFFCURVE",
+"165 139 OFFCURVE",
+"172 178 CURVE SMOOTH",
+"184 241 OFFCURVE",
+"194 318 OFFCURVE",
+"194 385 CURVE SMOOTH",
+"194 400 OFFCURVE",
+"193 416 OFFCURVE",
+"191 440 CURVE",
+"196 440 LINE",
+"218 400 OFFCURVE",
+"316 250 OFFCURVE",
+"366 179 CURVE SMOOTH",
+"454 54 OFFCURVE",
+"492 0 OFFCURVE",
+"606 0 CURVE",
+"606 76 LINE",
+"535 76 OFFCURVE",
+"514 100 OFFCURVE",
+"423 226 CURVE SMOOTH",
+"350 326 OFFCURVE",
+"242 493 OFFCURVE",
+"188 592 CURVE",
+"120 564 LINE",
+"125 514 OFFCURVE",
+"125 476 OFFCURVE",
+"125 417 CURVE SMOOTH",
+"125 342 OFFCURVE",
+"116 254 OFFCURVE",
+"102 181 CURVE SMOOTH",
+"95 141 OFFCURVE",
+"86 105 OFFCURVE",
+"77 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"53 0 LINE",
+"39 -42 OFFCURVE",
+"29 -96 OFFCURVE",
+"29 -134 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"148 0 LINE",
+"240 0 OFFCURVE",
+"314 -35 OFFCURVE",
+"314 -125 CURVE SMOOTH",
+"314 -200 OFFCURVE",
+"269 -243 OFFCURVE",
+"204 -243 CURVE SMOOTH",
+"133 -243 OFFCURVE",
+"100 -185 OFFCURVE",
+"100 -124 CURVE SMOOTH",
+"100 -88 OFFCURVE",
+"109 -43 OFFCURVE",
+"126 0 CURVE"
+);
+}
+);
+width = 606;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071C.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{196, -381}";
+},
+{
+name = top;
+position = "{155, 664}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"166 -143 OFFCURVE",
+"182 -157 OFFCURVE",
+"204 -157 CURVE SMOOTH",
+"224 -157 OFFCURVE",
+"241 -143 OFFCURVE",
+"241 -116 CURVE SMOOTH",
+"241 -89 OFFCURVE",
+"224 -75 OFFCURVE",
+"204 -75 CURVE SMOOTH",
+"182 -75 OFFCURVE",
+"166 -89 OFFCURVE",
+"166 -116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"29 -244 OFFCURVE",
+"102 -316 OFFCURVE",
+"202 -316 CURVE SMOOTH",
+"305 -316 OFFCURVE",
+"385 -248 OFFCURVE",
+"385 -127 CURVE SMOOTH",
+"385 11 OFFCURVE",
+"278 76 OFFCURVE",
+"152 76 CURVE SMOOTH",
+"149 76 LINE",
+"156 103 OFFCURVE",
+"165 139 OFFCURVE",
+"172 178 CURVE SMOOTH",
+"184 241 OFFCURVE",
+"194 318 OFFCURVE",
+"194 385 CURVE SMOOTH",
+"194 400 OFFCURVE",
+"193 416 OFFCURVE",
+"191 440 CURVE",
+"196 440 LINE",
+"218 400 OFFCURVE",
+"316 250 OFFCURVE",
+"366 179 CURVE SMOOTH",
+"454 54 OFFCURVE",
+"492 0 OFFCURVE",
+"606 0 CURVE",
+"606 76 LINE",
+"535 76 OFFCURVE",
+"514 100 OFFCURVE",
+"423 226 CURVE SMOOTH",
+"350 326 OFFCURVE",
+"242 493 OFFCURVE",
+"188 592 CURVE",
+"120 564 LINE",
+"125 514 OFFCURVE",
+"125 476 OFFCURVE",
+"125 417 CURVE SMOOTH",
+"125 342 OFFCURVE",
+"116 254 OFFCURVE",
+"102 181 CURVE SMOOTH",
+"95 141 OFFCURVE",
+"86 105 OFFCURVE",
+"77 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"53 0 LINE",
+"39 -42 OFFCURVE",
+"29 -96 OFFCURVE",
+"29 -134 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"148 0 LINE",
+"240 0 OFFCURVE",
+"314 -35 OFFCURVE",
+"314 -125 CURVE SMOOTH",
+"314 -200 OFFCURVE",
+"269 -243 OFFCURVE",
+"204 -243 CURVE SMOOTH",
+"133 -243 OFFCURVE",
+"100 -185 OFFCURVE",
+"100 -124 CURVE SMOOTH",
+"100 -88 OFFCURVE",
+"109 -43 OFFCURVE",
+"126 0 CURVE"
+);
+}
+);
+width = 606;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071D.loclSYRJ.Medi;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{168, -98}";
+},
+{
+name = top;
+position = "{174, 338}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1117 76 LINE",
+"1076 76 OFFCURVE",
+"1047 80 OFFCURVE",
+"1037 83 CURVE",
+"1028 90 OFFCURVE",
+"1012 131 OFFCURVE",
+"1002 152 CURVE SMOOTH",
+"979 202 OFFCURVE",
+"971 213 OFFCURVE",
+"940 213 CURVE SMOOTH",
+"911 213 OFFCURVE",
+"902 200 OFFCURVE",
+"891 183 CURVE SMOOTH",
+"859 133 LINE SMOOTH",
+"828 84 OFFCURVE",
+"791 68 OFFCURVE",
+"757 68 CURVE SMOOTH",
+"663 68 OFFCURVE",
+"637 127 OFFCURVE",
+"635 208 CURVE",
+"571 204 LINE",
+"569 198 OFFCURVE",
+"569 182 OFFCURVE",
+"569 178 CURVE SMOOTH",
+"569 64 OFFCURVE",
+"623 -7 OFFCURVE",
+"753 -7 CURVE SMOOTH",
+"839 -7 OFFCURVE",
+"891 32 OFFCURVE",
+"930 79 CURVE",
+"969 18 OFFCURVE",
+"993 0 OFFCURVE",
+"1078 0 CURVE SMOOTH",
+"1117 0 LINE",
+"1076 76 OFFCURVE",
+"1047 80 OFFCURVE",
+"1037 83 CURVE",
+"1028 90 OFFCURVE",
+"1012 131 OFFCURVE",
+"1002 152 CURVE SMOOTH",
+"979 202 OFFCURVE",
+"971 213 OFFCURVE",
+"940 213 CURVE SMOOTH",
+"911 213 OFFCURVE",
+"902 200 OFFCURVE",
+"891 183 CURVE SMOOTH",
+"859 133 LINE SMOOTH",
+"828 84 OFFCURVE",
+"791 68 OFFCURVE",
+"757 68 CURVE SMOOTH",
+"663 68 OFFCURVE",
+"637 127 OFFCURVE",
+"635 208 CURVE",
+"571 204 LINE",
+"569 198 OFFCURVE",
+"569 182 OFFCURVE",
+"569 178 CURVE SMOOTH",
+"569 64 OFFCURVE",
+"623 -7 OFFCURVE",
+"753 -7 CURVE SMOOTH",
+"839 -7 OFFCURVE",
+"891 32 OFFCURVE",
+"930 79 CURVE",
+"969 18 OFFCURVE",
+"993 0 OFFCURVE",
+"1078 0 CURVE SMOOTH",
+"1117 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1028 90 OFFCURVE",
+"1011 132 OFFCURVE",
+"1002 152 CURVE SMOOTH",
+"979 202 OFFCURVE",
+"971 213 OFFCURVE",
+"940 213 CURVE SMOOTH",
+"911 213 OFFCURVE",
+"900 200 OFFCURVE",
+"890 182 CURVE",
+"871 143 OFFCURVE",
+"854 108 OFFCURVE",
+"837 95 CURVE SMOOTH",
+"815 78 OFFCURVE",
+"789 76 OFFCURVE",
+"762 76 CURVE SMOOTH",
+"741 76 OFFCURVE",
+"723 61 OFFCURVE",
+"723 38 CURVE SMOOTH",
+"723 14 OFFCURVE",
+"741 0 OFFCURVE",
+"762 0 CURVE SMOOTH",
+"830 0 OFFCURVE",
+"880 11 OFFCURVE",
+"930 42 CURVE",
+"974 4 OFFCURVE",
+"1030 0 OFFCURVE",
+"1117 0 CURVE",
+"1117 76 LINE",
+"1076 76 OFFCURVE",
+"1047 80 OFFCURVE",
+"1037 83 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 89 OFFCURVE",
+"244 129 OFFCURVE",
+"233 149 CURVE SMOOTH",
+"206 196 OFFCURVE",
+"195 205 OFFCURVE",
+"169 205 CURVE SMOOTH",
+"146 205 OFFCURVE",
+"134 195 OFFCURVE",
+"123 177 CURVE SMOOTH",
+"95 132 LINE SMOOTH",
+"66 86 OFFCURVE",
+"38 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"68 0 OFFCURVE",
+"121 20 OFFCURVE",
+"165 70 CURVE",
+"205 17 OFFCURVE",
+"235 0 OFFCURVE",
+"320 0 CURVE SMOOTH",
+"355 0 LINE",
+"355 76 LINE",
+"314 76 OFFCURVE",
+"286 80 OFFCURVE",
+"276 82 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"315 0 OFFCURVE",
+"339 10 OFFCURVE",
+"367 41 CURVE SMOOTH",
+"375 49 OFFCURVE",
+"383 59 OFFCURVE",
+"391 70 CURVE",
+"431 17 OFFCURVE",
+"461 0 OFFCURVE",
+"546 0 CURVE SMOOTH",
+"591 0 LINE",
+"591 76 LINE",
+"550 76 OFFCURVE",
+"512 80 OFFCURVE",
+"502 82 CURVE",
+"493 89 OFFCURVE",
+"468 129 OFFCURVE",
+"457 149 CURVE SMOOTH",
+"430 196 OFFCURVE",
+"421 203 OFFCURVE",
+"397 203 CURVE SMOOTH",
+"376 203 OFFCURVE",
+"364 191 OFFCURVE",
+"353 172 CURVE SMOOTH",
+"330 131 LINE SMOOTH",
+"312 100 OFFCURVE",
+"303 85 OFFCURVE",
+"294 82 CURVE",
+"285 82 LINE",
+"276 87 OFFCURVE",
+"267 99 OFFCURVE",
+"237 149 CURVE SMOOTH",
+"209 195 OFFCURVE",
+"199 203 OFFCURVE",
+"177 203 CURVE SMOOTH",
+"156 203 OFFCURVE",
+"146 195 OFFCURVE",
+"134 177 CURVE SMOOTH",
+"107 136 LINE SMOOTH",
+"77 91 OFFCURVE",
+"38 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"30 0 OFFCURVE",
+"59 4 OFFCURVE",
+"85 12 CURVE SMOOTH",
+"108 19 OFFCURVE",
+"128 30 OFFCURVE",
+"147 44 CURVE SMOOTH",
+"157 52 OFFCURVE",
+"166 60 OFFCURVE",
+"175 70 CURVE",
+"218 16 OFFCURVE",
+"248 0 OFFCURVE",
+"282 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"325 76 LINE",
+"308 76 OFFCURVE",
+"286 79 OFFCURVE",
+"276 82 CURVE",
+"267 89 OFFCURVE",
+"245 129 OFFCURVE",
+"233 149 CURVE SMOOTH",
+"206 196 OFFCURVE",
+"195 205 OFFCURVE",
+"169 205 CURVE SMOOTH",
+"146 205 OFFCURVE",
+"134 195 OFFCURVE",
+"123 177 CURVE SMOOTH",
+"95 132 LINE SMOOTH",
+"64 83 OFFCURVE",
+"28 68 OFFCURVE",
+"-6 68 CURVE SMOOTH",
+"-100 68 OFFCURVE",
+"-126 127 OFFCURVE",
+"-128 208 CURVE",
+"-192 204 LINE",
+"-194 198 OFFCURVE",
+"-194 182 OFFCURVE",
+"-194 178 CURVE SMOOTH",
+"-194 64 OFFCURVE",
+"-140 -7 OFFCURVE",
+"-10 -7 CURVE SMOOTH",
+"76 -7 OFFCURVE",
+"126 23 OFFCURVE",
+"165 70 CURVE",
+"205 17 OFFCURVE",
+"235 0 OFFCURVE",
+"320 0 CURVE SMOOTH",
+"325 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"147 203 OFFCURVE",
+"137 193 OFFCURVE",
+"125 175 CURVE SMOOTH",
+"94 129 LINE SMOOTH",
+"81 110 OFFCURVE",
+"71 100 OFFCURVE",
+"59 91 CURVE SMOOTH",
+"41 79 OFFCURVE",
+"22 76 OFFCURVE",
+"0 76 CURVE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"31 0 OFFCURVE",
+"60 5 OFFCURVE",
+"85 14 CURVE SMOOTH",
+"106 22 OFFCURVE",
+"125 33 OFFCURVE",
+"143 48 CURVE SMOOTH",
+"151 55 OFFCURVE",
+"158 62 OFFCURVE",
+"165 70 CURVE",
+"205 17 OFFCURVE",
+"235 0 OFFCURVE",
+"320 0 CURVE SMOOTH",
+"325 0 LINE",
+"325 76 LINE",
+"308 76 OFFCURVE",
+"286 79 OFFCURVE",
+"276 82 CURVE",
+"267 89 OFFCURVE",
+"244 129 OFFCURVE",
+"233 149 CURVE SMOOTH",
+"206 196 OFFCURVE",
+"196 203 OFFCURVE",
+"170 203 CURVE SMOOTH"
+);
+}
+);
+width = 325;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0712.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{475, -91}";
+}
+);
+hints = (
+{
+place = "{396, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"407 0 LINE",
+"424 46 LINE",
+"426 46 LINE",
+"449 13 OFFCURVE",
+"487 0 OFFCURVE",
+"534 0 CURVE SMOOTH",
+"575 0 LINE",
+"575 76 LINE",
+"541 76 LINE",
+"480 78 OFFCURVE",
+"475 94 OFFCURVE",
+"470 170 CURVE",
+"470 426 LINE",
+"246 426 LINE SMOOTH",
+"208 426 OFFCURVE",
+"172 427 OFFCURVE",
+"137 430 CURVE SMOOTH",
+"103 433 OFFCURVE",
+"80 435 OFFCURVE",
+"68 438 CURVE",
+"68 367 LINE",
+"97 359 OFFCURVE",
+"174 353 OFFCURVE",
+"251 353 CURVE SMOOTH",
+"396 353 LINE",
+"396 164 LINE SMOOTH",
+"396 128 OFFCURVE",
+"401 99 OFFCURVE",
+"410 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 575;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072D.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{255, -98}";
+}
+);
+hints = (
+{
+place = "{396, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{633, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"407 0 LINE",
+"424 46 LINE",
+"426 46 LINE",
+"450 13 OFFCURVE",
+"487 0 OFFCURVE",
+"534 0 CURVE SMOOTH",
+"575 0 LINE",
+"575 76 LINE",
+"541 76 LINE",
+"480 78 OFFCURVE",
+"475 94 OFFCURVE",
+"470 170 CURVE",
+"470 426 LINE",
+"279 426 LINE",
+"231 425 LINE SMOOTH",
+"210 425 OFFCURVE",
+"190 423 OFFCURVE",
+"183 423 CURVE",
+"183 427 LINE",
+"221 464 LINE",
+"240 484 LINE",
+"259 503 LINE",
+"337 587 LINE",
+"278 633 LINE",
+"86 414 LINE",
+"86 353 LINE",
+"396 353 LINE",
+"396 164 LINE SMOOTH",
+"396 128 OFFCURVE",
+"401 99 OFFCURVE",
+"410 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 575;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0725.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{198, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{515, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"318 0 LINE",
+"337 46 LINE",
+"339 46 LINE",
+"367 14 OFFCURVE",
+"394 0 OFFCURVE",
+"421 0 CURVE",
+"421 76 LINE",
+"408 76 OFFCURVE",
+"393 95 OFFCURVE",
+"348 159 CURVE SMOOTH",
+"100 515 LINE",
+"35 471 LINE",
+"276 125 LINE SMOOTH",
+"288 108 OFFCURVE",
+"303 88 OFFCURVE",
+"314 76 CURVE"
+);
+}
+);
+width = 421;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074F.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{199, -98}";
+}
+);
+hints = (
+{
+place = "{357, 48}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{377, 44}";
+},
+{
+horizontal = 1;
+place = "{500, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"217 0 LINE",
+"290 0 OFFCURVE",
+"330 12 OFFCURVE",
+"349 43 CURVE",
+"351 43 LINE",
+"375 15 OFFCURVE",
+"405 0 OFFCURVE",
+"448 0 CURVE",
+"448 76 LINE",
+"424 76 OFFCURVE",
+"402 90 OFFCURVE",
+"382 123 CURVE",
+"313 229 LINE",
+"315 231 LINE",
+"367 234 OFFCURVE",
+"405 271 OFFCURVE",
+"405 327 CURVE SMOOTH",
+"405 384 OFFCURVE",
+"366 421 OFFCURVE",
+"309 421 CURVE SMOOTH",
+"270 421 OFFCURVE",
+"242 404 OFFCURVE",
+"226 372 CURVE",
+"222 372 LINE",
+"140 500 LINE",
+"78 458 LINE",
+"308 100 LINE",
+"300 84 OFFCURVE",
+"276 76 OFFCURVE",
+"228 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 358 OFFCURVE",
+"280 377 OFFCURVE",
+"309 377 CURVE SMOOTH",
+"337 377 OFFCURVE",
+"357 358 OFFCURVE",
+"357 326 CURVE SMOOTH",
+"357 293 OFFCURVE",
+"337 274 OFFCURVE",
+"309 274 CURVE SMOOTH",
+"281 274 OFFCURVE",
+"260 293 OFFCURVE",
+"260 326 CURVE SMOOTH"
+);
+}
+);
+width = 448;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{242, -91}";
+}
+);
+hints = (
+{
+place = "{397, 96}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"382 0 LINE",
+"382 76 LINE",
+"366 76 OFFCURVE",
+"358 91 OFFCURVE",
+"334 134 CURVE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"275 0 LINE",
+"293 46 LINE",
+"295 46 LINE",
+"397 -152 LINE",
+"397 -240 LINE",
+"493 -240 LINE",
+"493 -141 LINE",
+"447 -141 LINE",
+"374 0 LINE"
+);
+}
+);
+width = 382;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0714.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{242, -91}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRN.Medi;
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 55, 139}";
+}
+);
+layerId = UUID0;
+width = 382;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{169, -98}";
+}
+);
+hints = (
+{
+place = "{248, 71}";
+},
+{
+place = "{397, 96}";
+},
+{
+horizontal = 1;
+place = "{432, 59}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"397 -240 LINE",
+"493 -240 LINE",
+"493 -141 LINE",
+"447 -141 LINE",
+"374 0 LINE",
+"382 0 LINE",
+"382 76 LINE",
+"366 76 OFFCURVE",
+"358 91 OFFCURVE",
+"334 134 CURVE",
+"179 436 LINE",
+"183 437 LINE",
+"192 433 OFFCURVE",
+"206 432 OFFCURVE",
+"215 432 CURVE SMOOTH",
+"282 432 OFFCURVE",
+"319 476 OFFCURVE",
+"319 540 CURVE SMOOTH",
+"319 569 OFFCURVE",
+"308 600 OFFCURVE",
+"292 632 CURVE SMOOTH",
+"260 693 LINE",
+"197 660 LINE",
+"230 598 LINE SMOOTH",
+"242 575 OFFCURVE",
+"248 554 OFFCURVE",
+"248 537 CURVE SMOOTH",
+"248 508 OFFCURVE",
+"226 491 OFFCURVE",
+"195 491 CURVE SMOOTH",
+"160 491 OFFCURVE",
+"143 508 OFFCURVE",
+"128 535 CURVE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"275 0 LINE",
+"293 46 LINE",
+"295 46 LINE",
+"397 -152 LINE"
+);
+}
+);
+width = 382;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071A.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{258, -98}";
+}
+);
+hints = (
+{
+place = "{-39, 181}";
+},
+{
+place = "{83, 59}";
+},
+{
+place = "{298, 59}";
+},
+{
+horizontal = 1;
+place = "{-2, 78}";
+},
+{
+horizontal = 1;
+place = "{237, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"140 0 LINE",
+"145 148 LINE",
+"147 148 LINE",
+"175 116 LINE SMOOTH",
+"222 63 OFFCURVE",
+"254 30 OFFCURVE",
+"270 17 CURVE SMOOTH",
+"287 4 OFFCURVE",
+"305 -2 OFFCURVE",
+"324 -2 CURVE SMOOTH",
+"336 -2 OFFCURVE",
+"347 -1 OFFCURVE",
+"355 0 CURVE",
+"360 147 LINE",
+"362 147 LINE",
+"437 58 LINE SMOOTH",
+"472 17 OFFCURVE",
+"500 0 OFFCURVE",
+"539 0 CURVE",
+"539 76 LINE",
+"524 76 OFFCURVE",
+"506 85 OFFCURVE",
+"479 114 CURVE SMOOTH",
+"362 237 LINE",
+"301 237 LINE",
+"296 83 LINE",
+"288 90 OFFCURVE",
+"273 103 OFFCURVE",
+"258 119 CURVE SMOOTH",
+"235 142 LINE",
+"214 164 LINE",
+"147 237 LINE",
+"86 237 LINE",
+"80 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 539;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071F.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{498, -81}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{362, 75}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"476 0 LINE",
+"494 46 LINE",
+"496 46 LINE",
+"517 14 OFFCURVE",
+"541 0 OFFCURVE",
+"577 0 CURVE SMOOTH",
+"587 0 LINE",
+"587 76 LINE",
+"577 76 LINE SMOOTH",
+"574 76 OFFCURVE",
+"570 78 OFFCURVE",
+"565 81 CURVE SMOOTH",
+"560 85 OFFCURVE",
+"544 115 OFFCURVE",
+"517 171 CURVE SMOOTH",
+"499 210 LINE SMOOTH",
+"423 367 OFFCURVE",
+"350 437 OFFCURVE",
+"233 437 CURVE SMOOTH",
+"136 437 OFFCURVE",
+"66 389 OFFCURVE",
+"58 305 CURVE",
+"127 305 LINE",
+"136 342 OFFCURVE",
+"171 362 OFFCURVE",
+"228 362 CURVE SMOOTH",
+"267 362 OFFCURVE",
+"302 348 OFFCURVE",
+"333 320 CURVE SMOOTH",
+"365 292 OFFCURVE",
+"400 239 OFFCURVE",
+"438 162 CURVE SMOOTH",
+"480 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 587;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074E.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{254, -98}";
+}
+);
+hints = (
+{
+place = "{251, 76}";
+},
+{
+place = "{396, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{654, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"407 0 LINE",
+"424 46 LINE",
+"426 46 LINE",
+"450 13 OFFCURVE",
+"487 0 OFFCURVE",
+"534 0 CURVE SMOOTH",
+"575 0 LINE",
+"575 76 LINE",
+"541 76 LINE",
+"480 78 OFFCURVE",
+"475 94 OFFCURVE",
+"470 170 CURVE",
+"470 426 LINE",
+"361 426 LINE SMOOTH",
+"340 426 OFFCURVE",
+"317 425 OFFCURVE",
+"293 424 CURVE",
+"292 427 LINE",
+"315 442 OFFCURVE",
+"327 472 OFFCURVE",
+"327 505 CURVE SMOOTH",
+"327 562 OFFCURVE",
+"293 601 OFFCURVE",
+"213 629 CURVE SMOOTH",
+"138 654 LINE",
+"116 586 LINE",
+"183 564 LINE SMOOTH",
+"231 548 OFFCURVE",
+"251 531 OFFCURVE",
+"251 491 CURVE SMOOTH",
+"251 450 OFFCURVE",
+"233 427 OFFCURVE",
+"173 427 CURVE SMOOTH",
+"164 427 OFFCURVE",
+"146 427 OFFCURVE",
+"126 430 CURVE",
+"96 432 LINE SMOOTH",
+"85 433 OFFCURVE",
+"76 435 OFFCURVE",
+"68 436 CURVE",
+"68 364 LINE",
+"91 359 OFFCURVE",
+"162 353 OFFCURVE",
+"251 353 CURVE SMOOTH",
+"396 353 LINE",
+"396 164 LINE SMOOTH",
+"396 128 OFFCURVE",
+"401 99 OFFCURVE",
+"410 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 575;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0720.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{169, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"383 0 LINE",
+"383 76 LINE",
+"372 76 OFFCURVE",
+"363 83 OFFCURVE",
+"354 98 CURVE SMOOTH",
+"335 134 LINE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"276 0 LINE",
+"294 45 LINE",
+"296 45 LINE",
+"316 17 OFFCURVE",
+"339 0 OFFCURVE",
+"375 0 CURVE SMOOTH"
+);
+}
+);
+width = 383;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0721.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{355, -98}";
+}
+);
+hints = (
+{
+place = "{621, 71}";
+},
+{
+horizontal = 1;
+place = "{-5, 81}";
+},
+{
+horizontal = 1;
+place = "{342, 72}";
+},
+{
+horizontal = 1;
+place = "{480, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"317 0 LINE",
+"334 46 LINE",
+"336 46 LINE",
+"371 12 OFFCURVE",
+"422 -5 OFFCURVE",
+"488 -5 CURVE SMOOTH",
+"555 -5 OFFCURVE",
+"605 13 OFFCURVE",
+"640 46 CURVE",
+"643 46 LINE",
+"664 15 OFFCURVE",
+"699 0 OFFCURVE",
+"746 0 CURVE SMOOTH",
+"761 0 LINE",
+"761 76 LINE",
+"746 76 LINE SMOOTH",
+"711 76 OFFCURVE",
+"689 87 OFFCURVE",
+"682 114 CURVE",
+"689 135 OFFCURVE",
+"692 159 OFFCURVE",
+"692 185 CURVE SMOOTH",
+"692 252 OFFCURVE",
+"674 306 OFFCURVE",
+"637 349 CURVE SMOOTH",
+"601 392 OFFCURVE",
+"553 414 OFFCURVE",
+"492 414 CURVE SMOOTH",
+"408 414 OFFCURVE",
+"339 370 OFFCURVE",
+"306 291 CURVE",
+"212 362 LINE SMOOTH",
+"132 423 OFFCURVE",
+"99 456 OFFCURVE",
+"75 480 CURVE",
+"26 424 LINE",
+"55 395 OFFCURVE",
+"112 346 OFFCURVE",
+"195 282 CURVE",
+"286 214 LINE",
+"285 205 OFFCURVE",
+"285 195 OFFCURVE",
+"285 185 CURVE SMOOTH",
+"285 142 OFFCURVE",
+"294 105 OFFCURVE",
+"312 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"621 108 OFFCURVE",
+"580 66 OFFCURVE",
+"488 66 CURVE SMOOTH",
+"396 66 OFFCURVE",
+"354 108 OFFCURVE",
+"354 187 CURVE SMOOTH",
+"354 275 OFFCURVE",
+"408 342 OFFCURVE",
+"488 342 CURVE SMOOTH",
+"568 342 OFFCURVE",
+"621 279 OFFCURVE",
+"621 187 CURVE SMOOTH"
+);
+}
+);
+width = 761;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0722.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{173, -98}";
+}
+);
+hints = (
+{
+place = "{76, 152}";
+},
+{
+place = "{158, 70}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{428, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"208 0 LINE",
+"225 46 LINE",
+"227 46 LINE",
+"254 13 OFFCURVE",
+"286 0 OFFCURVE",
+"331 0 CURVE SMOOTH",
+"335 0 LINE",
+"335 76 LINE",
+"331 76 LINE SMOOTH",
+"249 72 OFFCURVE",
+"234 220 OFFCURVE",
+"228 398 CURVE",
+"228 426 LINE",
+"151 426 LINE SMOOTH",
+"126 426 OFFCURVE",
+"100 427 OFFCURVE",
+"76 428 CURVE",
+"76 355 LINE",
+"96 354 OFFCURVE",
+"126 353 OFFCURVE",
+"151 353 CURVE SMOOTH",
+"158 353 LINE",
+"163 228 OFFCURVE",
+"181 131 OFFCURVE",
+"208 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 335;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0726.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{474, -89}";
+}
+);
+hints = (
+{
+place = "{54, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{199, 71}";
+},
+{
+horizontal = 1;
+place = "{589, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"419 0 LINE",
+"439 47 LINE",
+"441 47 LINE",
+"457 20 OFFCURVE",
+"483 0 OFFCURVE",
+"534 0 CURVE SMOOTH",
+"551 0 LINE",
+"551 76 LINE",
+"533 76 LINE SMOOTH",
+"504 76 OFFCURVE",
+"499 110 OFFCURVE",
+"491 137 CURVE",
+"370 589 LINE",
+"298 565 LINE",
+"145 541 OFFCURVE",
+"54 467 OFFCURVE",
+"54 359 CURVE SMOOTH",
+"54 260 OFFCURVE",
+"121 199 OFFCURVE",
+"236 199 CURVE SMOOTH",
+"395 199 LINE",
+"428 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 270 LINE",
+"169 270 OFFCURVE",
+"133 300 OFFCURVE",
+"133 367 CURVE SMOOTH",
+"133 434 OFFCURVE",
+"195 477 OFFCURVE",
+"316 494 CURVE",
+"376 270 LINE"
+);
+}
+);
+width = 551;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0729.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{316, -98}";
+}
+);
+hints = (
+{
+place = "{105, 73}";
+},
+{
+place = "{456, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"104 0 LINE",
+"123 46 LINE",
+"125 46 LINE",
+"142 17 OFFCURVE",
+"173 0 OFFCURVE",
+"221 0 CURVE SMOOTH",
+"456 0 LINE",
+"473 46 LINE",
+"475 46 LINE",
+"492 17 OFFCURVE",
+"524 0 OFFCURVE",
+"572 0 CURVE SMOOTH",
+"634 0 LINE",
+"634 76 LINE",
+"583 76 LINE SMOOTH",
+"539 76 OFFCURVE",
+"529 88 OFFCURVE",
+"529 135 CURVE SMOOTH",
+"529 438 LINE",
+"504 433 OFFCURVE",
+"436 426 OFFCURVE",
+"375 426 CURVE SMOOTH",
+"258 426 LINE SMOOTH",
+"197 426 OFFCURVE",
+"130 433 OFFCURVE",
+"105 438 CURVE",
+"105 128 LINE SMOOTH",
+"105 108 OFFCURVE",
+"107 91 OFFCURVE",
+"111 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"232 76 LINE",
+"187 76 OFFCURVE",
+"178 90 OFFCURVE",
+"178 135 CURVE SMOOTH",
+"178 357 LINE",
+"207 353 OFFCURVE",
+"239 353 OFFCURVE",
+"263 353 CURVE SMOOTH",
+"371 353 LINE SMOOTH",
+"395 353 OFFCURVE",
+"427 353 OFFCURVE",
+"456 357 CURVE",
+"456 128 LINE SMOOTH",
+"456 108 OFFCURVE",
+"458 91 OFFCURVE",
+"462 76 CURVE"
+);
+}
+);
+width = 634;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0727.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{279, -98}";
+}
+);
+hints = (
+{
+place = "{-39, 175}";
+},
+{
+place = "{62, 74}";
+},
+{
+place = "{152, 82}";
+},
+{
+place = "{215, 59}";
+},
+{
+place = "{337, 81}";
+},
+{
+place = "{410, 70}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{189, 66}";
+},
+{
+horizontal = 1;
+place = "{423, 74}";
+},
+{
+horizontal = 1;
+place = "{585, 86}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"168 74 LINE",
+"145 75 OFFCURVE",
+"121 76 OFFCURVE",
+"100 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"547 0 LINE",
+"547 76 LINE",
+"458 76 LINE SMOOTH",
+"253 76 OFFCURVE",
+"136 148 OFFCURVE",
+"136 285 CURVE SMOOTH",
+"136 326 OFFCURVE",
+"150 360 OFFCURVE",
+"179 385 CURVE SMOOTH",
+"208 410 OFFCURVE",
+"243 423 OFFCURVE",
+"286 423 CURVE SMOOTH",
+"358 423 OFFCURVE",
+"410 388 OFFCURVE",
+"410 333 CURVE SMOOTH",
+"410 285 OFFCURVE",
+"385 255 OFFCURVE",
+"338 255 CURVE SMOOTH",
+"301 255 OFFCURVE",
+"274 279 OFFCURVE",
+"274 319 CURVE",
+"215 319 LINE",
+"215 310 LINE SMOOTH",
+"215 234 OFFCURVE",
+"262 189 OFFCURVE",
+"338 189 CURVE SMOOTH",
+"430 189 OFFCURVE",
+"480 246 OFFCURVE",
+"480 339 CURVE SMOOTH",
+"480 384 OFFCURVE",
+"461 422 OFFCURVE",
+"424 452 CURVE SMOOTH",
+"387 482 OFFCURVE",
+"341 497 OFFCURVE",
+"286 497 CURVE SMOOTH",
+"221 497 OFFCURVE",
+"168 477 OFFCURVE",
+"125 436 CURVE SMOOTH",
+"83 396 OFFCURVE",
+"62 345 OFFCURVE",
+"62 282 CURVE SMOOTH",
+"62 191 OFFCURVE",
+"101 120 OFFCURVE",
+"169 77 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"152 585 LINE",
+"234 585 LINE",
+"234 671 LINE",
+"152 671 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"337 585 LINE",
+"418 585 LINE",
+"418 671 LINE",
+"337 671 LINE"
+);
+}
+);
+width = 547;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0723.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{365, -98}";
+}
+);
+hints = (
+{
+place = "{67, 75}";
+},
+{
+place = "{352, 69}";
+},
+{
+place = "{630, 75}";
+},
+{
+place = "{630, 138}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{317, 75}";
+},
+{
+horizontal = 1;
+place = "{405, 71}";
+},
+{
+horizontal = 1;
+place = "{-2, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"239 0 LINE",
+"280 28 LINE",
+"333 9 OFFCURVE",
+"391 -2 OFFCURVE",
+"451 -2 CURVE SMOOTH",
+"522 -2 OFFCURVE",
+"582 13 OFFCURVE",
+"626 46 CURVE",
+"630 46 LINE",
+"654 18 OFFCURVE",
+"704 0 OFFCURVE",
+"768 0 CURVE",
+"768 76 LINE",
+"724 76 OFFCURVE",
+"691 84 OFFCURVE",
+"674 101 CURVE",
+"694 134 OFFCURVE",
+"705 178 OFFCURVE",
+"705 231 CURVE SMOOTH",
+"705 278 OFFCURVE",
+"690 317 OFFCURVE",
+"659 347 CURVE SMOOTH",
+"628 377 OFFCURVE",
+"591 392 OFFCURVE",
+"547 392 CURVE SMOOTH",
+"491 392 OFFCURVE",
+"454 375 OFFCURVE",
+"425 340 CURVE",
+"421 341 LINE",
+"418 425 OFFCURVE",
+"352 476 OFFCURVE",
+"249 476 CURVE SMOOTH",
+"200 476 OFFCURVE",
+"157 457 OFFCURVE",
+"121 418 CURVE SMOOTH",
+"85 379 OFFCURVE",
+"67 334 OFFCURVE",
+"67 283 CURVE SMOOTH",
+"67 187 OFFCURVE",
+"105 121 OFFCURVE",
+"188 74 CURVE",
+"185 71 LINE",
+"162 73 LINE",
+"90 75 LINE",
+"70 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 109 OFFCURVE",
+"376 153 OFFCURVE",
+"415 218 CURVE SMOOTH",
+"455 284 OFFCURVE",
+"496 317 OFFCURVE",
+"539 317 CURVE SMOOTH",
+"595 317 OFFCURVE",
+"630 281 OFFCURVE",
+"630 225 CURVE SMOOTH",
+"630 128 OFFCURVE",
+"566 70 OFFCURVE",
+"461 70 CURVE SMOOTH",
+"410 70 OFFCURVE",
+"371 76 OFFCURVE",
+"334 88 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"182 146 OFFCURVE",
+"142 206 OFFCURVE",
+"142 286 CURVE SMOOTH",
+"142 355 OFFCURVE",
+"191 405 OFFCURVE",
+"256 405 CURVE SMOOTH",
+"316 405 OFFCURVE",
+"352 371 OFFCURVE",
+"352 314 CURVE SMOOTH",
+"352 273 OFFCURVE",
+"342 234 OFFCURVE",
+"323 197 CURVE SMOOTH",
+"304 161 OFFCURVE",
+"286 132 OFFCURVE",
+"269 111 CURVE"
+);
+}
+);
+width = 768;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0724.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{364, -98}";
+}
+);
+components = (
+{
+name = uni0723.loclSYRN.Medi;
+}
+);
+layerId = UUID0;
+width = 764;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072B.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{280, -98}";
+}
+);
+hints = (
+{
+place = "{246, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{340, 74}";
+},
+{
+horizontal = 1;
+place = "{440, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"256 0 LINE",
+"273 46 LINE",
+"275 46 LINE",
+"299 13 OFFCURVE",
+"336 0 OFFCURVE",
+"383 0 CURVE SMOOTH",
+"564 0 LINE",
+"564 76 LINE",
+"390 76 LINE",
+"329 78 OFFCURVE",
+"324 94 OFFCURVE",
+"319 170 CURVE",
+"319 340 LINE",
+"355 341 OFFCURVE",
+"390 344 OFFCURVE",
+"425 349 CURVE SMOOTH",
+"460 354 OFFCURVE",
+"485 361 OFFCURVE",
+"499 369 CURVE",
+"484 440 LINE",
+"457 428 OFFCURVE",
+"387 414 OFFCURVE",
+"282 414 CURVE SMOOTH",
+"177 414 OFFCURVE",
+"108 428 OFFCURVE",
+"80 440 CURVE",
+"66 369 LINE",
+"80 361 OFFCURVE",
+"104 354 OFFCURVE",
+"139 349 CURVE SMOOTH",
+"174 344 OFFCURVE",
+"209 341 OFFCURVE",
+"246 340 CURVE",
+"246 164 LINE SMOOTH",
+"246 128 OFFCURVE",
+"250 99 OFFCURVE",
+"259 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 564;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071B.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{175, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-285, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"674 -3 LINE",
+"674 76 LINE",
+"364 76 LINE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"316 0 LINE",
+"463 -285 LINE",
+"493 -285 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"403 0 LINE",
+"620 0 LINE",
+"500 -188 LINE"
+);
+}
+);
+width = 621;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071C.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{175, -98}";
+}
+);
+hints = (
+{
+place = "{460, 78}";
+},
+{
+horizontal = 1;
+place = "{-120, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-300, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"689 -3 LINE",
+"689 76 LINE",
+"364 76 LINE",
+"47 693 LINE",
+"-23 659 LINE",
+"277 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"316 0 LINE",
+"470 -300 LINE",
+"500 -300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 -207 OFFCURVE",
+"446 -174 OFFCURVE",
+"422 -129 CURVE SMOOTH",
+"398 -84 OFFCURVE",
+"386 -41 OFFCURVE",
+"386 0 CURVE",
+"637 0 LINE",
+"620 -43 OFFCURVE",
+"596 -89 OFFCURVE",
+"565 -136 CURVE SMOOTH",
+"534 -183 OFFCURVE",
+"510 -214 OFFCURVE",
+"493 -227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 -120 LINE",
+"538 -120 LINE",
+"538 -41 LINE",
+"460 -41 LINE"
+);
+}
+);
+width = 635;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071D.loclSYRN.Medi;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{162, -98}";
+}
+);
+hints = (
+{
+place = "{-39, 179}";
+},
+{
+place = "{82, 58}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{228, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"140 0 LINE",
+"141 132 LINE",
+"143 132 LINE",
+"223 51 LINE SMOOTH",
+"254 19 OFFCURVE",
+"283 0 OFFCURVE",
+"324 0 CURVE",
+"324 76 LINE",
+"309 76 OFFCURVE",
+"290 83 OFFCURVE",
+"263 108 CURVE SMOOTH",
+"137 228 LINE",
+"85 228 LINE",
+"80 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 324;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ.Medi2;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{109, -195}";
+},
+{
+name = top;
+position = "{137, 735}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 674 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"144 -67 OFFCURVE",
+"157 -25 OFFCURVE",
+"165 30 CURVE",
+"167 30 LINE",
+"186 9 OFFCURVE",
+"218 0 OFFCURVE",
+"269 0 CURVE",
+"269 76 LINE",
+"237 76 OFFCURVE",
+"172 76 OFFCURVE",
+"170 111 CURVE",
+"170 122 OFFCURVE",
+"171 131 OFFCURVE",
+"171 142 CURVE SMOOTH",
+"171 674 LINE"
+);
+}
+);
+width = 269;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.Medi2;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{172, -141}";
+}
+);
+components = (
+{
+name = uni0710.loclSYRN.Fina1;
+}
+);
+layerId = UUID0;
+width = 356;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.Medi2N;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{156, -152}";
+}
+);
+components = (
+{
+name = uni0710.loclSYRN.Fina1N;
+}
+);
+layerId = UUID0;
+width = 356;
+}
+);
+rightKerningGroup = uni0710;
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ.MediLiga;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{109, -195}";
+},
+{
+name = top;
+position = "{137, 735}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"98 674 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"145 -65 OFFCURVE",
+"158 -22 OFFCURVE",
+"166 35 CURVE",
+"168 35 LINE",
+"184 9 OFFCURVE",
+"210 -5 OFFCURVE",
+"255 -5 CURVE SMOOTH",
+"272 -5 OFFCURVE",
+"294 3 OFFCURVE",
+"294 32 CURVE SMOOTH",
+"294 46 OFFCURVE",
+"286 71 OFFCURVE",
+"247 71 CURVE SMOOTH",
+"194 71 OFFCURVE",
+"171 103 OFFCURVE",
+"171 143 CURVE SMOOTH",
+"171 674 LINE"
+);
+}
+);
+};
+components = (
+{
+name = uni0710.loclSYRJ.FinaLiga;
+}
+);
+layerId = UUID0;
+width = 247;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.MediLiga;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{113, -98}";
+},
+{
+name = top;
+position = "{113, 735}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"76 141 LINE SMOOTH",
+"76 96 OFFCURVE",
+"53 71 OFFCURVE",
+"0 71 CURVE SMOOTH",
+"-17 71 OFFCURVE",
+"-39 60 OFFCURVE",
+"-39 31 CURVE SMOOTH",
+"-39 17 OFFCURVE",
+"-31 -5 OFFCURVE",
+"9 -5 CURVE SMOOTH",
+"62 -5 OFFCURVE",
+"99 14 OFFCURVE",
+"122 43 CURVE",
+"141 14 OFFCURVE",
+"180 0 OFFCURVE",
+"247 0 CURVE SMOOTH",
+"251 0 LINE",
+"251 76 LINE",
+"247 76 LINE SMOOTH",
+"216 76 OFFCURVE",
+"149 76 OFFCURVE",
+"149 112 CURVE SMOOTH",
+"149 674 LINE",
+"76 674 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"76 141 LINE SMOOTH",
+"76 96 OFFCURVE",
+"53 71 OFFCURVE",
+"0 71 CURVE SMOOTH",
+"-17 71 OFFCURVE",
+"-39 60 OFFCURVE",
+"-39 31 CURVE SMOOTH",
+"-39 17 OFFCURVE",
+"-31 -5 OFFCURVE",
+"9 -5 CURVE SMOOTH",
+"62 -5 OFFCURVE",
+"99 14 OFFCURVE",
+"122 43 CURVE",
+"141 14 OFFCURVE",
+"180 0 OFFCURVE",
+"251 0 CURVE",
+"251 76 LINE",
+"216 76 OFFCURVE",
+"149 76 OFFCURVE",
+"149 112 CURVE SMOOTH",
+"149 674 LINE",
+"76 674 LINE"
+);
+}
+);
+width = 251;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.MediLiga;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{113, -98}";
+},
+{
+name = top;
+position = "{113, 586}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"76 141 LINE SMOOTH",
+"76 96 OFFCURVE",
+"53 71 OFFCURVE",
+"0 71 CURVE SMOOTH",
+"-17 71 OFFCURVE",
+"-39 60 OFFCURVE",
+"-39 31 CURVE SMOOTH",
+"-39 17 OFFCURVE",
+"-31 -5 OFFCURVE",
+"9 -5 CURVE SMOOTH",
+"62 -5 OFFCURVE",
+"99 14 OFFCURVE",
+"122 43 CURVE",
+"141 14 OFFCURVE",
+"180 0 OFFCURVE",
+"247 0 CURVE SMOOTH",
+"251 0 LINE",
+"251 76 LINE",
+"247 76 LINE SMOOTH",
+"216 76 OFFCURVE",
+"149 76 OFFCURVE",
+"149 112 CURVE SMOOTH",
+"149 420 LINE",
+"76 420 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"76 141 LINE SMOOTH",
+"76 96 OFFCURVE",
+"53 71 OFFCURVE",
+"0 71 CURVE SMOOTH",
+"-17 71 OFFCURVE",
+"-39 60 OFFCURVE",
+"-39 31 CURVE SMOOTH",
+"-39 17 OFFCURVE",
+"-31 -5 OFFCURVE",
+"9 -5 CURVE SMOOTH",
+"62 -5 OFFCURVE",
+"99 14 OFFCURVE",
+"122 43 CURVE",
+"141 14 OFFCURVE",
+"180 0 OFFCURVE",
+"247 0 CURVE SMOOTH",
+"251 0 LINE",
+"251 76 LINE",
+"247 76 LINE SMOOTH",
+"216 76 OFFCURVE",
+"149 76 OFFCURVE",
+"149 112 CURVE SMOOTH",
+"149 420 LINE",
+"76 420 LINE"
+);
+}
+);
+width = 251;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN.MediLiga;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{192, -141}";
+}
+);
+hints = (
+{
+place = "{213, 75}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{601, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-63, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"403 76 LINE",
+"198 76 LINE",
+"251 180 OFFCURVE",
+"288 289 OFFCURVE",
+"288 408 CURVE SMOOTH",
+"288 536 OFFCURVE",
+"242 593 OFFCURVE",
+"150 601 CURVE",
+"118 530 LINE",
+"193 497 LINE",
+"208 481 OFFCURVE",
+"213 446 OFFCURVE",
+"213 403 CURVE SMOOTH",
+"213 335 OFFCURVE",
+"201 268 OFFCURVE",
+"176 202 CURVE SMOOTH",
+"152 137 OFFCURVE",
+"112 60 OFFCURVE",
+"56 -28 CURVE",
+"115 -63 LINE",
+"135 -31 LINE",
+"155 0 LINE",
+"403 0 LINE"
+);
+}
+);
+width = 403;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072C.loclSYRN.MediLiga2;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{230, -79}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{367, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-70, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"164 117 LINE",
+"194 74 OFFCURVE",
+"219 44 OFFCURVE",
+"238 26 CURVE",
+"258 9 OFFCURVE",
+"281 0 OFFCURVE",
+"308 0 CURVE",
+"308 76 LINE",
+"288 76 OFFCURVE",
+"262 102 OFFCURVE",
+"214 174 CURVE",
+"81 367 LINE",
+"23 324 LINE",
+"126 172 LINE",
+"9 9 LINE",
+"-149 227 LINE",
+"-180 147 LINE",
+"-20 -70 LINE",
+"31 -70 LINE"
+);
+}
+);
+width = 308;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ.MediLigaLong;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{146, -195}";
+},
+{
+name = top;
+position = "{112, 735}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"329 -5 LINE SMOOTH",
+"346 -5 OFFCURVE",
+"368 3 OFFCURVE",
+"368 32 CURVE SMOOTH",
+"368 46 OFFCURVE",
+"359 71 OFFCURVE",
+"320 71 CURVE SMOOTH",
+"273 71 LINE SMOOTH",
+"221 71 OFFCURVE",
+"183 101 OFFCURVE",
+"183 155 CURVE SMOOTH",
+"183 674 LINE",
+"110 674 LINE",
+"110 141 LINE SMOOTH",
+"110 40 OFFCURVE",
+"95 -29 OFFCURVE",
+"75 -64 CURVE",
+"135 -94 LINE",
+"157 -65 OFFCURVE",
+"170 -22 OFFCURVE",
+"178 35 CURVE",
+"181 35 LINE",
+"196 9 OFFCURVE",
+"235 -5 OFFCURVE",
+"280 -5 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = uni0710.loclSYRJ.FinaLigaLong;
+}
+);
+layerId = UUID0;
+width = 320;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.MediLong;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{362, -98}";
+},
+{
+name = top;
+position = "{317, 706}";
+}
+);
+components = (
+{
+name = uni0720.loclSYRJ.Medi;
+transform = "{1, 0, 0, 1, 170, 0}";
+},
+{
+name = Stretch2.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 684;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071B.loclSYRJ.MediLong;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{489, -381}";
+},
+{
+name = top;
+position = "{449, 664}";
+}
+);
+components = (
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 158, 0}";
+},
+{
+name = uni071B.loclSYRJ.Medi;
+transform = "{1, 0, 0, 1, 292, 0}";
+},
+{
+name = Stretch2.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 898;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071C.loclSYRJ.MediLong;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{489, -381}";
+},
+{
+name = top;
+position = "{449, 664}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 246, 20}";
+},
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 158, 0}";
+},
+{
+name = uni071B.loclSYRJ.Medi;
+transform = "{1, 0, 0, 1, 292, 0}";
+},
+{
+name = Stretch2.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 898;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072B.loclSYRN.MediM;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{237, -98}";
+}
+);
+components = (
+{
+name = uni072B.loclSYRN.MediN;
+transform = "{1, 0, 0, 1, 31, 0}";
+},
+{
+name = Stretch3.loclSYRN;
+}
+);
+layerId = UUID0;
+width = 522;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ.MediN;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{95, -98}";
+},
+{
+name = top;
+position = "{49, 707}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"197 0 LINE SMOOTH",
+"268 0 OFFCURVE",
+"305 11 OFFCURVE",
+"324 35 CURVE",
+"349 14 OFFCURVE",
+"377 0 OFFCURVE",
+"416 0 CURVE",
+"416 76 LINE",
+"395 76 OFFCURVE",
+"376 87 OFFCURVE",
+"357 109 CURVE SMOOTH",
+"-154 693 LINE",
+"-211 642 LINE",
+"275 87 LINE",
+"255 75 OFFCURVE",
+"224 76 OFFCURVE",
+"208 76 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"197 0 LINE SMOOTH",
+"268 0 OFFCURVE",
+"305 11 OFFCURVE",
+"324 35 CURVE",
+"349 14 OFFCURVE",
+"377 0 OFFCURVE",
+"416 0 CURVE",
+"416 76 LINE",
+"395 76 OFFCURVE",
+"376 87 OFFCURVE",
+"357 109 CURVE SMOOTH",
+"-154 693 LINE",
+"-211 642 LINE",
+"275 87 LINE",
+"255 75 OFFCURVE",
+"224 76 OFFCURVE",
+"208 76 CURVE SMOOTH"
+);
+}
+);
+width = 416;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ.MediN;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{116, -98}";
+},
+{
+name = top;
+position = "{113, 537}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"83 412 LINE",
+"92 362 OFFCURVE",
+"97 285 OFFCURVE",
+"97 239 CURVE SMOOTH",
+"97 211 OFFCURVE",
+"96 140 OFFCURVE",
+"90 118 CURVE",
+"81 89 OFFCURVE",
+"63 76 OFFCURVE",
+"22 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"9 0 LINE SMOOTH",
+"61 0 OFFCURVE",
+"94 10 OFFCURVE",
+"125 41 CURVE",
+"148 10 OFFCURVE",
+"190 0 OFFCURVE",
+"255 0 CURVE SMOOTH",
+"269 0 LINE",
+"269 76 LINE",
+"259 76 LINE SMOOTH",
+"234 76 OFFCURVE",
+"174 78 OFFCURVE",
+"161 99 CURVE",
+"170 141 OFFCURVE",
+"170 202 OFFCURVE",
+"170 242 CURVE SMOOTH",
+"170 293 OFFCURVE",
+"166 381 OFFCURVE",
+"155 423 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"97 262 LINE",
+"97 229 OFFCURVE",
+"97 214 OFFCURVE",
+"97 202 CURVE SMOOTH",
+"97 181 OFFCURVE",
+"96 143 OFFCURVE",
+"90 121 CURVE SMOOTH",
+"82 92 OFFCURVE",
+"63 76 OFFCURVE",
+"22 76 CURVE SMOOTH",
+"-47 76 LINE SMOOTH",
+"-68 76 OFFCURVE",
+"-86 61 OFFCURVE",
+"-86 38 CURVE SMOOTH",
+"-86 14 OFFCURVE",
+"-68 0 OFFCURVE",
+"-47 0 CURVE SMOOTH",
+"1 0 LINE SMOOTH",
+"54 0 OFFCURVE",
+"94 11 OFFCURVE",
+"125 41 CURVE",
+"154 10 OFFCURVE",
+"190 0 OFFCURVE",
+"269 0 CURVE",
+"269 76 LINE",
+"212 76 OFFCURVE",
+"173 84 OFFCURVE",
+"160 99 CURVE",
+"167 123 OFFCURVE",
+"170 171 OFFCURVE",
+"170 199 CURVE SMOOTH",
+"170 210 OFFCURVE",
+"170 238 OFFCURVE",
+"166 268 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"97 262 LINE",
+"97 229 OFFCURVE",
+"97 214 OFFCURVE",
+"97 202 CURVE SMOOTH",
+"97 181 OFFCURVE",
+"96 143 OFFCURVE",
+"90 121 CURVE SMOOTH",
+"82 92 OFFCURVE",
+"63 76 OFFCURVE",
+"22 76 CURVE SMOOTH",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"9 0 LINE SMOOTH",
+"62 0 OFFCURVE",
+"94 11 OFFCURVE",
+"125 41 CURVE",
+"154 10 OFFCURVE",
+"190 0 OFFCURVE",
+"269 0 CURVE",
+"269 76 LINE",
+"212 76 OFFCURVE",
+"173 84 OFFCURVE",
+"160 99 CURVE",
+"167 123 OFFCURVE",
+"170 171 OFFCURVE",
+"170 199 CURVE SMOOTH",
+"170 210 OFFCURVE",
+"170 238 OFFCURVE",
+"166 268 CURVE"
+);
+}
+);
+width = 269;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0712.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{426, -91}";
+}
+);
+hints = (
+{
+place = "{348, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"358 0 LINE",
+"375 46 LINE",
+"377 46 LINE",
+"401 13 OFFCURVE",
+"438 0 OFFCURVE",
+"485 0 CURVE SMOOTH",
+"526 0 LINE",
+"526 76 LINE",
+"492 76 LINE",
+"431 78 OFFCURVE",
+"426 94 OFFCURVE",
+"421 170 CURVE",
+"421 426 LINE",
+"197 426 LINE SMOOTH",
+"121 426 OFFCURVE",
+"44 433 OFFCURVE",
+"20 438 CURVE",
+"20 367 LINE",
+"49 359 OFFCURVE",
+"125 353 OFFCURVE",
+"202 353 CURVE SMOOTH",
+"348 353 LINE",
+"348 164 LINE SMOOTH",
+"348 128 OFFCURVE",
+"352 99 OFFCURVE",
+"361 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 526;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0725.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{149, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{515, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"232 0 LINE",
+"251 46 LINE",
+"253 46 LINE",
+"282 14 OFFCURVE",
+"308 0 OFFCURVE",
+"336 0 CURVE",
+"336 76 LINE",
+"321 76 OFFCURVE",
+"307 94 OFFCURVE",
+"263 159 CURVE",
+"14 515 LINE",
+"-51 471 LINE",
+"191 125 LINE",
+"202 108 OFFCURVE",
+"218 88 OFFCURVE",
+"229 76 CURVE"
+);
+}
+);
+width = 336;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{145, -91}";
+}
+);
+hints = (
+{
+place = "{299, 97}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"284 0 LINE",
+"284 76 LINE",
+"268 76 OFFCURVE",
+"260 91 OFFCURVE",
+"237 134 CURVE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"177 0 LINE",
+"195 46 LINE",
+"197 46 LINE",
+"299 -152 LINE",
+"299 -240 LINE",
+"396 -240 LINE",
+"396 -141 LINE",
+"349 -141 LINE",
+"276 0 LINE"
+);
+}
+);
+width = 284;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{71, -98}";
+}
+);
+hints = (
+{
+place = "{150, 71}";
+},
+{
+place = "{299, 97}";
+},
+{
+horizontal = 1;
+place = "{432, 59}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"299 -240 LINE",
+"396 -240 LINE",
+"396 -141 LINE",
+"349 -141 LINE",
+"276 0 LINE",
+"284 0 LINE",
+"284 76 LINE",
+"268 76 OFFCURVE",
+"260 91 OFFCURVE",
+"237 134 CURVE",
+"82 436 LINE",
+"85 437 LINE",
+"96 433 OFFCURVE",
+"108 432 OFFCURVE",
+"117 432 CURVE SMOOTH",
+"184 432 OFFCURVE",
+"221 476 OFFCURVE",
+"221 540 CURVE SMOOTH",
+"221 569 OFFCURVE",
+"211 600 OFFCURVE",
+"194 632 CURVE SMOOTH",
+"163 693 LINE",
+"100 660 LINE",
+"132 598 LINE",
+"145 575 OFFCURVE",
+"150 554 OFFCURVE",
+"150 537 CURVE SMOOTH",
+"150 508 OFFCURVE",
+"129 491 OFFCURVE",
+"97 491 CURVE SMOOTH",
+"64 491 OFFCURVE",
+"46 508 OFFCURVE",
+"31 535 CURVE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"177 0 LINE",
+"195 46 LINE",
+"197 46 LINE",
+"299 -152 LINE"
+);
+}
+);
+width = 284;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0720.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{73, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"285 0 LINE",
+"285 76 LINE",
+"275 76 OFFCURVE",
+"266 83 OFFCURVE",
+"257 98 CURVE SMOOTH",
+"238 134 LINE",
+"-51 693 LINE",
+"-121 659 LINE",
+"180 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"178 0 LINE",
+"196 45 LINE",
+"198 45 LINE",
+"218 17 OFFCURVE",
+"241 0 OFFCURVE",
+"278 0 CURVE SMOOTH"
+);
+}
+);
+width = 285;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0721.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{403, -98}";
+}
+);
+hints = (
+{
+place = "{199, 69}";
+},
+{
+place = "{535, 72}";
+},
+{
+horizontal = 1;
+place = "{-5, 81}";
+},
+{
+horizontal = 1;
+place = "{342, 72}";
+},
+{
+horizontal = 1;
+place = "{480, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"231 0 LINE",
+"249 46 LINE",
+"251 46 LINE",
+"286 12 OFFCURVE",
+"336 -5 OFFCURVE",
+"402 -5 CURVE SMOOTH",
+"470 -5 OFFCURVE",
+"519 13 OFFCURVE",
+"554 46 CURVE",
+"557 46 LINE",
+"578 15 OFFCURVE",
+"613 0 OFFCURVE",
+"661 0 CURVE SMOOTH",
+"675 0 LINE",
+"675 76 LINE",
+"661 76 LINE SMOOTH",
+"626 76 OFFCURVE",
+"604 87 OFFCURVE",
+"597 114 CURVE",
+"604 135 OFFCURVE",
+"607 159 OFFCURVE",
+"607 185 CURVE SMOOTH",
+"607 252 OFFCURVE",
+"589 306 OFFCURVE",
+"552 349 CURVE SMOOTH",
+"516 392 OFFCURVE",
+"467 414 OFFCURVE",
+"406 414 CURVE SMOOTH",
+"322 414 OFFCURVE",
+"255 370 OFFCURVE",
+"220 291 CURVE",
+"127 362 LINE SMOOTH",
+"47 423 OFFCURVE",
+"14 456 OFFCURVE",
+"-10 480 CURVE",
+"-59 424 LINE",
+"-30 395 OFFCURVE",
+"27 346 OFFCURVE",
+"110 282 CURVE",
+"201 214 LINE",
+"200 205 OFFCURVE",
+"199 195 OFFCURVE",
+"199 185 CURVE SMOOTH",
+"199 142 OFFCURVE",
+"208 105 OFFCURVE",
+"227 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 108 OFFCURVE",
+"494 66 OFFCURVE",
+"402 66 CURVE SMOOTH",
+"311 66 OFFCURVE",
+"268 108 OFFCURVE",
+"268 187 CURVE SMOOTH",
+"268 275 OFFCURVE",
+"322 342 OFFCURVE",
+"402 342 CURVE SMOOTH",
+"483 342 OFFCURVE",
+"535 279 OFFCURVE",
+"535 187 CURVE SMOOTH"
+);
+}
+);
+width = 675;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072B.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{207, -98}";
+}
+);
+hints = (
+{
+place = "{172, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{340, 74}";
+},
+{
+horizontal = 1;
+place = "{440, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"183 0 LINE",
+"200 46 LINE",
+"202 46 LINE",
+"226 13 OFFCURVE",
+"262 0 OFFCURVE",
+"310 0 CURVE SMOOTH",
+"491 0 LINE",
+"491 76 LINE",
+"316 76 LINE",
+"257 78 OFFCURVE",
+"251 94 OFFCURVE",
+"246 170 CURVE",
+"246 340 LINE",
+"282 341 OFFCURVE",
+"317 344 OFFCURVE",
+"352 349 CURVE SMOOTH",
+"387 354 OFFCURVE",
+"411 361 OFFCURVE",
+"425 369 CURVE",
+"411 440 LINE",
+"384 428 OFFCURVE",
+"314 414 OFFCURVE",
+"209 414 CURVE SMOOTH",
+"104 414 OFFCURVE",
+"34 428 OFFCURVE",
+"7 440 CURVE",
+"-7 369 LINE",
+"7 361 OFFCURVE",
+"31 354 OFFCURVE",
+"66 349 CURVE SMOOTH",
+"101 344 OFFCURVE",
+"136 341 OFFCURVE",
+"172 340 CURVE",
+"172 164 LINE SMOOTH",
+"172 128 OFFCURVE",
+"177 99 OFFCURVE",
+"186 76 CURVE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH"
+);
+}
+);
+width = 491;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071B.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{73, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-285, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"577 -3 LINE",
+"577 76 LINE",
+"266 76 LINE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"218 0 LINE",
+"365 -285 LINE",
+"395 -285 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 0 LINE",
+"522 0 LINE",
+"402 -188 LINE"
+);
+}
+);
+width = 523;
+}
+);
+},
+{
+color = 7;
+glyphname = uni071C.loclSYRN.MediN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{73, -98}";
+}
+);
+hints = (
+{
+place = "{362, 78}";
+},
+{
+horizontal = 1;
+place = "{-120, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-300, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"591 -3 LINE",
+"591 76 LINE",
+"266 76 LINE",
+"-51 693 LINE",
+"-121 659 LINE",
+"179 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"218 0 LINE",
+"373 -300 LINE",
+"402 -300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"372 -207 OFFCURVE",
+"348 -174 OFFCURVE",
+"324 -129 CURVE SMOOTH",
+"301 -84 OFFCURVE",
+"289 -41 OFFCURVE",
+"289 0 CURVE",
+"540 0 LINE",
+"523 -43 OFFCURVE",
+"499 -89 OFFCURVE",
+"467 -136 CURVE SMOOTH",
+"436 -183 OFFCURVE",
+"412 -214 OFFCURVE",
+"396 -227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 -120 LINE",
+"440 -120 LINE",
+"440 -41 LINE",
+"362 -41 LINE"
+);
+}
+);
+width = 538;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0712.loclSYRN.MediQR;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{475, -91}";
+}
+);
+components = (
+{
+name = uni0712.loclSYRN.Medi;
+},
+{
+name = Stretch5.loclSYRN;
+transform = "{1, 0, 0, 1, 562, 0}";
+}
+);
+layerId = UUID0;
+width = 672;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0726.loclSYRN.MediQR;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{474, -89}";
+}
+);
+components = (
+{
+name = uni0726.loclSYRN.Medi;
+},
+{
+name = Stretch5.loclSYRN;
+transform = "{1, 0, 0, 1, 551, 0}";
+}
+);
+layerId = UUID0;
+width = 661;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN.MediW;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{242, -91}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRN.Medi;
+},
+{
+name = Stretch2.loclSYRN;
+transform = "{1, 0, 0, 1, 382, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0714.loclSYRN.MediW;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{242, -91}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 55, 139}";
+},
+{
+name = uni0713.loclSYRN.Medi;
+},
+{
+name = Stretch2.loclSYRN;
+transform = "{1, 0, 0, 1, 382, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN.MediW;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{169, -98}";
+}
+);
+components = (
+{
+name = uni072E.loclSYRN.Medi;
+},
+{
+name = Stretch2.loclSYRN;
+transform = "{1, 0, 0, 1, 382, 0}";
+}
+);
+layerId = UUID0;
+width = 518;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0722.loclSYRN.MediW;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{173, -98}";
+}
+);
+components = (
+{
+name = uni0722.loclSYRN.Medi;
+},
+{
+name = Stretch.loclSYRN;
+transform = "{1, 0, 0, 1, 335, 0}";
+}
+);
+layerId = UUID0;
+width = 412;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN.MediWN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{145, -91}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRN.MediN;
+},
+{
+name = Stretch2.loclSYRN;
+transform = "{1, 0, 0, 1, 284, 0}";
+}
+);
+layerId = UUID0;
+width = 420;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN.MediWN;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{71, -98}";
+}
+);
+components = (
+{
+name = uni072E.loclSYRN.MediN;
+},
+{
+name = Stretch2.loclSYRN;
+transform = "{1, 0, 0, 1, 284, 0}";
+}
+);
+layerId = UUID0;
+width = 420;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0713.loclSYRJ.MediWide;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{492, 161}";
+},
+{
+name = RU;
+position = "{677, -477}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{373, 357}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRJ.Medi;
+},
+{
+name = Stretch.loclSYRJ;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = UUID0;
+width = 729;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0714.loclSYRJ.MediWide;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{492, 161}";
+},
+{
+name = RU;
+position = "{677, -476}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{375, 357}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 194, 39}";
+},
+{
+name = uni0713.loclSYRJ.Medi;
+},
+{
+name = Stretch.loclSYRJ;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = UUID0;
+width = 729;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072E.loclSYRJ.MediWide;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{527, 390}";
+},
+{
+name = RU;
+position = "{677, -477}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{213, 401}";
+}
+);
+components = (
+{
+name = uni072E.loclSYRJ.Medi;
+},
+{
+name = Stretch.loclSYRJ;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = UUID0;
+width = 729;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0713.loclSYRJ.MediWide2;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{492, 161}";
+},
+{
+name = RU;
+position = "{677, -477}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{373, 357}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRJ.Medi;
+},
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = UUID0;
+width = 802;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0714.loclSYRJ.MediWide2;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{492, 161}";
+},
+{
+name = RU;
+position = "{677, -476}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{375, 357}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 194, 39}";
+},
+{
+name = uni0713.loclSYRJ.Medi;
+},
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = UUID0;
+width = 802;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072E.loclSYRJ.MediWide2;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{527, 390}";
+},
+{
+name = RU;
+position = "{677, -477}";
+},
+{
+name = bottom;
+position = "{428, -444}";
+},
+{
+name = top;
+position = "{213, 401}";
+}
+);
+components = (
+{
+name = uni072E.loclSYRJ.Medi;
+},
+{
+name = Stretch2.loclSYRJ;
+transform = "{1, 0, 0, 1, 631, 0}";
+}
+);
+layerId = UUID0;
+width = 802;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0715.loclSYRJ.QR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{355, 298}";
+},
+{
+name = RU;
+position = "{303, -63}";
+},
+{
+name = bottom;
+position = "{154, -405}";
+},
+{
+name = top;
+position = "{196, 468}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"123 -293 OFFCURVE",
+"143 -309 OFFCURVE",
+"172 -309 CURVE SMOOTH",
+"205 -309 OFFCURVE",
+"224 -290 OFFCURVE",
+"224 -253 CURVE SMOOTH",
+"224 -216 OFFCURVE",
+"205 -196 OFFCURVE",
+"172 -196 CURVE SMOOTH",
+"141 -196 OFFCURVE",
+"123 -216 OFFCURVE",
+"123 -253 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"115 280 OFFCURVE",
+"76 205 OFFCURVE",
+"76 153 CURVE SMOOTH",
+"76 104 OFFCURVE",
+"100 72 OFFCURVE",
+"149 32 CURVE SMOOTH",
+"176 10 LINE",
+"156 -21 OFFCURVE",
+"132 -57 OFFCURVE",
+"101 -89 CURVE",
+"148 -130 LINE",
+"223 -53 OFFCURVE",
+"306 42 OFFCURVE",
+"306 135 CURVE SMOOTH",
+"306 212 OFFCURVE",
+"262 280 OFFCURVE",
+"190 280 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 172, -317}";
+},
+{
+name = uni0716.loclSYRJ.QR;
+}
+);
+layerId = UUID0;
+width = 395;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0716.loclSYRJ.QR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{355, 309}";
+},
+{
+name = RU;
+position = "{303, -63}";
+},
+{
+name = bottom;
+position = "{170, -303}";
+},
+{
+name = top;
+position = "{196, 456}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"314 237 OFFCURVE",
+"260 284 OFFCURVE",
+"195 284 CURVE SMOOTH",
+"120 284 OFFCURVE",
+"76 210 OFFCURVE",
+"76 158 CURVE SMOOTH",
+"76 97 OFFCURVE",
+"116 62 OFFCURVE",
+"149 38 CURVE SMOOTH",
+"165 27 OFFCURVE",
+"179 16 OFFCURVE",
+"181 4 CURVE",
+"157 -27 OFFCURVE",
+"123 -58 OFFCURVE",
+"92 -87 CURVE",
+"143 -130 LINE",
+"226 -62 OFFCURVE",
+"314 37 OFFCURVE",
+"314 145 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"236 232 OFFCURVE",
+"258 195 OFFCURVE",
+"258 149 CURVE SMOOTH",
+"258 117 OFFCURVE",
+"243 80 OFFCURVE",
+"213 44 CURVE",
+"176 78 LINE SMOOTH",
+"144 108 OFFCURVE",
+"132 131 OFFCURVE",
+"132 164 CURVE SMOOTH",
+"132 195 OFFCURVE",
+"150 232 OFFCURVE",
+"193 232 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"115 280 OFFCURVE",
+"76 205 OFFCURVE",
+"76 153 CURVE SMOOTH",
+"76 104 OFFCURVE",
+"100 72 OFFCURVE",
+"149 32 CURVE SMOOTH",
+"176 10 LINE",
+"156 -21 OFFCURVE",
+"132 -57 OFFCURVE",
+"101 -89 CURVE",
+"148 -130 LINE",
+"223 -53 OFFCURVE",
+"306 42 OFFCURVE",
+"306 135 CURVE SMOOTH",
+"306 212 OFFCURVE",
+"262 280 OFFCURVE",
+"190 280 CURVE SMOOTH"
+);
+}
+);
+width = 395;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072F.loclSYRJ.QR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{365, 309}";
+},
+{
+name = RU;
+position = "{312, -76}";
+},
+{
+name = bottom;
+position = "{190, -364}";
+},
+{
+name = top;
+position = "{195, 477}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-50 -141 OFFCURVE",
+"-30 -157 OFFCURVE",
+"-1 -157 CURVE SMOOTH",
+"32 -157 OFFCURVE",
+"51 -138 OFFCURVE",
+"51 -101 CURVE SMOOTH",
+"51 -64 OFFCURVE",
+"32 -44 OFFCURVE",
+"-1 -44 CURVE SMOOTH",
+"-32 -44 OFFCURVE",
+"-50 -64 OFFCURVE",
+"-50 -101 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"29 -306 OFFCURVE",
+"49 -322 OFFCURVE",
+"78 -322 CURVE SMOOTH",
+"111 -322 OFFCURVE",
+"130 -303 OFFCURVE",
+"130 -266 CURVE SMOOTH",
+"130 -229 OFFCURVE",
+"111 -209 OFFCURVE",
+"78 -209 CURVE SMOOTH",
+"47 -209 OFFCURVE",
+"29 -229 OFFCURVE",
+"29 -266 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"123 280 OFFCURVE",
+"84 205 OFFCURVE",
+"84 153 CURVE SMOOTH",
+"84 104 OFFCURVE",
+"108 72 OFFCURVE",
+"157 32 CURVE SMOOTH",
+"184 10 LINE",
+"164 -21 OFFCURVE",
+"140 -57 OFFCURVE",
+"109 -89 CURVE",
+"156 -130 LINE",
+"231 -53 OFFCURVE",
+"314 42 OFFCURVE",
+"314 135 CURVE SMOOTH",
+"314 212 OFFCURVE",
+"270 280 OFFCURVE",
+"198 280 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, -1, -160}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 78, -325}";
+},
+{
+name = uni0716.loclSYRJ.QR;
+transform = "{1, 0, 0, 1, 8, 0}";
+}
+);
+layerId = UUID0;
+width = 404;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072A.loclSYRJ.QR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{338, 458}";
+},
+{
+name = RU;
+position = "{303, -88}";
+},
+{
+name = bottom;
+position = "{168, -302}";
+},
+{
+name = top;
+position = "{198, 637}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 200, 363}";
+},
+{
+name = uni0716.loclSYRJ.QR;
+}
+);
+layerId = UUID0;
+width = 395;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0710.loclSYRJ;
+lastChange = "2017-09-08 19:30:45 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{129, -196}";
+},
+{
+name = top;
+position = "{141, 735}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"138 680 LINE",
+"90 623 LINE",
+"139 574 OFFCURVE",
+"163 544 OFFCURVE",
+"163 487 CURVE SMOOTH",
+"163 442 OFFCURVE",
+"149 389 OFFCURVE",
+"124 326 CURVE",
+"90 246 OFFCURVE",
+"73 171 OFFCURVE",
+"73 103 CURVE SMOOTH",
+"73 44 OFFCURVE",
+"81 -29 OFFCURVE",
+"115 -90 CURVE",
+"128 -90 LINE",
+"179 -53 LINE",
+"152 19 OFFCURVE",
+"148 64 OFFCURVE",
+"148 114 CURVE SMOOTH",
+"148 155 OFFCURVE",
+"152 203 OFFCURVE",
+"187 296 CURVE",
+"227 395 OFFCURVE",
+"234 448 OFFCURVE",
+"234 498 CURVE SMOOTH",
+"234 567 OFFCURVE",
+"213 622 OFFCURVE",
+"143 680 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"138 680 LINE",
+"95 624 LINE",
+"144 575 OFFCURVE",
+"160 544 OFFCURVE",
+"160 487 CURVE SMOOTH",
+"160 442 OFFCURVE",
+"150 394 OFFCURVE",
+"124 326 CURVE SMOOTH",
+"93 246 OFFCURVE",
+"73 171 OFFCURVE",
+"73 103 CURVE SMOOTH",
+"73 44 OFFCURVE",
+"81 -29 OFFCURVE",
+"115 -90 CURVE",
+"128 -90 LINE",
+"179 -53 LINE",
+"152 19 OFFCURVE",
+"148 64 OFFCURVE",
+"148 114 CURVE SMOOTH",
+"148 155 OFFCURVE",
+"153 203 OFFCURVE",
+"187 296 CURVE SMOOTH",
+"225 401 OFFCURVE",
+"231 448 OFFCURVE",
+"231 498 CURVE SMOOTH",
+"231 567 OFFCURVE",
+"213 622 OFFCURVE",
+"143 680 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"138 680 LINE",
+"90 623 LINE",
+"139 574 OFFCURVE",
+"163 544 OFFCURVE",
+"163 487 CURVE SMOOTH",
+"163 442 OFFCURVE",
+"149 389 OFFCURVE",
+"124 326 CURVE",
+"90 246 OFFCURVE",
+"73 171 OFFCURVE",
+"73 103 CURVE SMOOTH",
+"73 44 OFFCURVE",
+"81 -29 OFFCURVE",
+"115 -90 CURVE",
+"128 -90 LINE",
+"179 -53 LINE",
+"152 19 OFFCURVE",
+"148 64 OFFCURVE",
+"148 114 CURVE SMOOTH",
+"148 155 OFFCURVE",
+"152 203 OFFCURVE",
+"187 296 CURVE",
+"227 395 OFFCURVE",
+"234 448 OFFCURVE",
+"234 498 CURVE SMOOTH",
+"234 567 OFFCURVE",
+"213 622 OFFCURVE",
+"143 680 CURVE"
+);
+}
+);
+width = 303;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0712.loclSYRJ;
+lastChange = "2017-09-08 19:31:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{749, 439}";
+},
+{
+name = RU;
+position = "{748, -68}";
+},
+{
+name = bottom;
+position = "{436, -98}";
+},
+{
+name = top;
+position = "{495, 513}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"664 0 LINE SMOOTH",
+"785 0 OFFCURVE",
+"823 60 OFFCURVE",
+"823 131 CURVE SMOOTH",
+"823 232 OFFCURVE",
+"770 302 OFFCURVE",
+"686 356 CURVE",
+"627 394 OFFCURVE",
+"562 414 OFFCURVE",
+"481 414 CURVE SMOOTH",
+"444 414 OFFCURVE",
+"375 402 OFFCURVE",
+"343 387 CURVE",
+"359 326 LINE",
+"397 337 OFFCURVE",
+"448 339 OFFCURVE",
+"471 339 CURVE SMOOTH",
+"607 339 OFFCURVE",
+"749 250 OFFCURVE",
+"749 134 CURVE SMOOTH",
+"749 107 OFFCURVE",
+"734 76 OFFCURVE",
+"679 76 CURVE SMOOTH",
+"282 76 LINE SMOOTH",
+"168 76 OFFCURVE",
+"127 139 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"136 0 OFFCURVE",
+"273 0 CURVE SMOOTH"
+);
+}
+);
+width = 891;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072D.loclSYRJ;
+lastChange = "2017-09-08 19:35:54 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{434, -98}";
+},
+{
+name = top;
+position = "{415, 661}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"664 0 LINE SMOOTH",
+"785 0 OFFCURVE",
+"823 60 OFFCURVE",
+"823 131 CURVE SMOOTH",
+"823 317 OFFCURVE",
+"643 411 OFFCURVE",
+"485 411 CURVE SMOOTH",
+"470 411 OFFCURVE",
+"454 410 OFFCURVE",
+"439 408 CURVE",
+"439 412 LINE",
+"463 434 OFFCURVE",
+"526 495 OFFCURVE",
+"549 520 CURVE SMOOTH",
+"599 574 LINE",
+"545 618 LINE",
+"343 387 LINE",
+"359 333 LINE",
+"399 338 OFFCURVE",
+"437 339 OFFCURVE",
+"461 339 CURVE SMOOTH",
+"617 339 OFFCURVE",
+"749 254 OFFCURVE",
+"749 134 CURVE SMOOTH",
+"749 107 OFFCURVE",
+"734 76 OFFCURVE",
+"679 76 CURVE SMOOTH",
+"282 76 LINE SMOOTH",
+"168 76 OFFCURVE",
+"127 139 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"136 0 OFFCURVE",
+"273 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"664 0 LINE SMOOTH",
+"785 0 OFFCURVE",
+"823 60 OFFCURVE",
+"823 131 CURVE SMOOTH",
+"823 317 OFFCURVE",
+"643 411 OFFCURVE",
+"485 411 CURVE SMOOTH",
+"470 411 OFFCURVE",
+"454 410 OFFCURVE",
+"439 408 CURVE",
+"439 412 LINE",
+"463 434 OFFCURVE",
+"526 495 OFFCURVE",
+"549 520 CURVE SMOOTH",
+"599 574 LINE",
+"545 618 LINE",
+"343 387 LINE",
+"359 333 LINE",
+"399 338 OFFCURVE",
+"437 339 OFFCURVE",
+"461 339 CURVE SMOOTH",
+"617 339 OFFCURVE",
+"749 254 OFFCURVE",
+"749 134 CURVE SMOOTH",
+"749 107 OFFCURVE",
+"734 76 OFFCURVE",
+"679 76 CURVE SMOOTH",
+"282 76 LINE SMOOTH",
+"168 76 OFFCURVE",
+"127 139 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"136 0 OFFCURVE",
+"273 0 CURVE SMOOTH"
+);
+}
+);
+width = 891;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0715.loclSYRJ;
+lastChange = "2017-09-08 19:31:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{347, 298}";
+},
+{
+name = RU;
+position = "{295, -63}";
+},
+{
+name = bottom;
+position = "{146, -394}";
+},
+{
+name = top;
+position = "{188, 386}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 172, -317}";
+},
+{
+name = uni0716.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 365;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0716.loclSYRJ;
+lastChange = "2017-09-08 19:31:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{347, 309}";
+},
+{
+name = RU;
+position = "{295, -63}";
+},
+{
+name = bottom;
+position = "{154, -216}";
+},
+{
+name = top;
+position = "{188, 386}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"306 237 OFFCURVE",
+"252 284 OFFCURVE",
+"187 284 CURVE SMOOTH",
+"112 284 OFFCURVE",
+"68 210 OFFCURVE",
+"68 158 CURVE SMOOTH",
+"68 97 OFFCURVE",
+"108 62 OFFCURVE",
+"141 38 CURVE SMOOTH",
+"157 27 OFFCURVE",
+"171 16 OFFCURVE",
+"173 4 CURVE",
+"149 -27 OFFCURVE",
+"115 -58 OFFCURVE",
+"84 -87 CURVE",
+"135 -130 LINE",
+"218 -62 OFFCURVE",
+"306 37 OFFCURVE",
+"306 145 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"236 232 OFFCURVE",
+"258 195 OFFCURVE",
+"258 149 CURVE SMOOTH",
+"258 117 OFFCURVE",
+"243 80 OFFCURVE",
+"213 44 CURVE",
+"176 78 LINE SMOOTH",
+"144 108 OFFCURVE",
+"132 131 OFFCURVE",
+"132 164 CURVE SMOOTH",
+"132 195 OFFCURVE",
+"150 232 OFFCURVE",
+"193 232 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"115 280 OFFCURVE",
+"76 205 OFFCURVE",
+"76 153 CURVE SMOOTH",
+"76 104 OFFCURVE",
+"100 72 OFFCURVE",
+"149 32 CURVE SMOOTH",
+"176 10 LINE",
+"156 -21 OFFCURVE",
+"132 -57 OFFCURVE",
+"101 -89 CURVE",
+"148 -130 LINE",
+"223 -53 OFFCURVE",
+"306 42 OFFCURVE",
+"306 135 CURVE SMOOTH",
+"306 212 OFFCURVE",
+"262 280 OFFCURVE",
+"190 280 CURVE SMOOTH"
+);
+}
+);
+width = 365;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072F.loclSYRJ;
+lastChange = "2017-09-08 19:41:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{365, 309}";
+},
+{
+name = RU;
+position = "{312, -112}";
+},
+{
+name = bottom;
+position = "{190, -364}";
+},
+{
+name = top;
+position = "{196, 387}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"416 -157 OFFCURVE",
+"436 -173 OFFCURVE",
+"465 -173 CURVE SMOOTH",
+"498 -173 OFFCURVE",
+"517 -154 OFFCURVE",
+"517 -117 CURVE SMOOTH",
+"517 -80 OFFCURVE",
+"498 -60 OFFCURVE",
+"465 -60 CURVE SMOOTH",
+"434 -60 OFFCURVE",
+"416 -80 OFFCURVE",
+"416 -117 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"494 -321 OFFCURVE",
+"514 -337 OFFCURVE",
+"543 -337 CURVE SMOOTH",
+"576 -337 OFFCURVE",
+"595 -318 OFFCURVE",
+"595 -281 CURVE SMOOTH",
+"595 -244 OFFCURVE",
+"576 -224 OFFCURVE",
+"543 -224 CURVE SMOOTH",
+"512 -224 OFFCURVE",
+"494 -244 OFFCURVE",
+"494 -281 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"606 196 OFFCURVE",
+"570 155 OFFCURVE",
+"570 107 CURVE SMOOTH",
+"570 61 OFFCURVE",
+"592 32 OFFCURVE",
+"636 7 CURVE",
+"631 -18 OFFCURVE",
+"603 -67 OFFCURVE",
+"573 -109 CURVE",
+"615 -145 LINE",
+"655 -105 OFFCURVE",
+"690 -48 OFFCURVE",
+"709 -3 CURVE",
+"731 -6 OFFCURVE",
+"760 -7 OFFCURVE",
+"769 -7 CURVE",
+"769 69 LINE",
+"760 69 OFFCURVE",
+"740 70 OFFCURVE",
+"726 76 CURVE",
+"727 85 OFFCURVE",
+"727 89 OFFCURVE",
+"727 93 CURVE SMOOTH",
+"727 151 OFFCURVE",
+"700 196 OFFCURVE",
+"649 196 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, -1, -160}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 78, -325}";
+},
+{
+name = uni0716.loclSYRJ;
+transform = "{1, 0, 0, 1, 8, 0}";
+}
+);
+layerId = UUID0;
+width = 383;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0725.loclSYRJ;
+lastChange = "2017-09-08 19:40:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{414, -98}";
+},
+{
+name = top;
+position = "{314, 525}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"478 -17 OFFCURVE",
+"511 39 OFFCURVE",
+"521 82 CURVE",
+"524 82 LINE",
+"561 39 OFFCURVE",
+"617 -4 OFFCURVE",
+"682 -10 CURVE",
+"701 56 LINE",
+"655 67 OFFCURVE",
+"621 85 OFFCURVE",
+"562 153 CURVE SMOOTH",
+"314 436 LINE",
+"257 384 LINE",
+"457 156 LINE SMOOTH",
+"466 146 OFFCURVE",
+"469 135 OFFCURVE",
+"469 123 CURVE SMOOTH",
+"469 90 OFFCURVE",
+"440 59 OFFCURVE",
+"394 59 CURVE SMOOTH",
+"357 59 OFFCURVE",
+"329 88 OFFCURVE",
+"298 124 CURVE SMOOTH",
+"57 397 LINE",
+"0 346 LINE",
+"232 82 LINE SMOOTH",
+"296 9 OFFCURVE",
+"339 -17 OFFCURVE",
+"390 -17 CURVE SMOOTH"
+);
+}
+);
+width = 750;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074F.loclSYRJ;
+lastChange = "2017-09-08 19:40:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{324, -98}";
+},
+{
+name = top;
+position = "{325, 584}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"582 -3 LINE",
+"647 40 LINE",
+"524 229 LINE",
+"526 231 LINE",
+"576 233 OFFCURVE",
+"616 269 OFFCURVE",
+"616 327 CURVE SMOOTH",
+"616 388 OFFCURVE",
+"574 421 OFFCURVE",
+"520 421 CURVE SMOOTH",
+"482 421 OFFCURVE",
+"453 405 OFFCURVE",
+"437 372 CURVE",
+"433 372 LINE",
+"351 500 LINE",
+"287 458 LINE",
+"516 100 LINE",
+"504 76 OFFCURVE",
+"456 76 OFFCURVE",
+"436 76 CURVE SMOOTH",
+"291 76 LINE SMOOTH",
+"167 76 OFFCURVE",
+"127 101 OFFCURVE",
+"125 182 CURVE",
+"61 178 LINE",
+"59 172 OFFCURVE",
+"59 156 OFFCURVE",
+"59 152 CURVE SMOOTH",
+"59 37 OFFCURVE",
+"134 0 OFFCURVE",
+"287 0 CURVE SMOOTH",
+"425 0 LINE SMOOTH",
+"498 0 OFFCURVE",
+"535 12 OFFCURVE",
+"553 38 CURVE",
+"556 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 293 OFFCURVE",
+"548 274 OFFCURVE",
+"520 274 CURVE SMOOTH",
+"492 274 OFFCURVE",
+"471 293 OFFCURVE",
+"471 326 CURVE SMOOTH",
+"471 358 OFFCURVE",
+"490 377 OFFCURVE",
+"520 377 CURVE SMOOTH",
+"547 377 OFFCURVE",
+"568 358 OFFCURVE",
+"568 326 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"582 -3 LINE",
+"647 40 LINE",
+"524 229 LINE",
+"526 231 LINE",
+"576 233 OFFCURVE",
+"616 269 OFFCURVE",
+"616 327 CURVE SMOOTH",
+"616 388 OFFCURVE",
+"574 421 OFFCURVE",
+"520 421 CURVE SMOOTH",
+"482 421 OFFCURVE",
+"453 405 OFFCURVE",
+"437 372 CURVE",
+"433 372 LINE",
+"351 500 LINE",
+"287 458 LINE",
+"516 100 LINE",
+"504 76 OFFCURVE",
+"456 76 OFFCURVE",
+"436 76 CURVE SMOOTH",
+"294 76 LINE SMOOTH",
+"170 76 OFFCURVE",
+"127 101 OFFCURVE",
+"125 182 CURVE",
+"61 178 LINE",
+"59 172 OFFCURVE",
+"59 164 OFFCURVE",
+"59 160 CURVE SMOOTH",
+"59 45 OFFCURVE",
+"134 0 OFFCURVE",
+"280 0 CURVE SMOOTH",
+"425 0 LINE SMOOTH",
+"498 0 OFFCURVE",
+"535 12 OFFCURVE",
+"553 38 CURVE",
+"556 38 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 293 OFFCURVE",
+"548 274 OFFCURVE",
+"520 274 CURVE SMOOTH",
+"492 274 OFFCURVE",
+"471 293 OFFCURVE",
+"471 326 CURVE SMOOTH",
+"471 358 OFFCURVE",
+"490 377 OFFCURVE",
+"520 377 CURVE SMOOTH",
+"547 377 OFFCURVE",
+"568 358 OFFCURVE",
+"568 326 CURVE SMOOTH"
+);
+}
+);
+width = 696;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0713.loclSYRJ;
+lastChange = "2017-09-08 19:31:27 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{507, 161}";
+},
+{
+name = RU;
+position = "{693, -477}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{390, 356}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"523 -328 LINE SMOOTH",
+"584 -373 OFFCURVE",
+"634 -391 OFFCURVE",
+"683 -391 CURVE SMOOTH",
+"794 -391 OFFCURVE",
+"843 -319 OFFCURVE",
+"843 -259 CURVE SMOOTH",
+"843 -220 OFFCURVE",
+"828 -189 OFFCURVE",
+"787 -159 CURVE SMOOTH",
+"389 139 LINE",
+"344 76 LINE",
+"744 -220 LINE SMOOTH",
+"759 -231 OFFCURVE",
+"767 -244 OFFCURVE",
+"767 -259 CURVE SMOOTH",
+"767 -292 OFFCURVE",
+"731 -315 OFFCURVE",
+"685 -315 CURVE SMOOTH",
+"642 -315 OFFCURVE",
+"610 -296 OFFCURVE",
+"580 -273 CURVE SMOOTH",
+"214 0 LINE",
+"157 42 OFFCURVE",
+"132 85 OFFCURVE",
+"132 138 CURVE SMOOTH",
+"132 161 OFFCURVE",
+"137 178 OFFCURVE",
+"147 199 CURVE",
+"91 234 LINE",
+"70 207 OFFCURVE",
+"59 169 OFFCURVE",
+"59 130 CURVE SMOOTH",
+"59 60 OFFCURVE",
+"93 -5 OFFCURVE",
+"165 -60 CURVE"
+);
+}
+);
+width = 848;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0714.loclSYRJ;
+lastChange = "2017-09-08 19:31:32 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{507, 161}";
+},
+{
+name = RU;
+position = "{693, -477}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{391, 357}";
+}
+);
+components = (
+{
+name = DotEncl.loclSYRJ;
+transform = "{1, 0, 0, 1, 210, 39}";
+},
+{
+name = uni0713.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 848;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072E.loclSYRJ;
+lastChange = "2017-09-08 19:40:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{530, 391}";
+},
+{
+name = RU;
+position = "{693, -514}";
+},
+{
+name = bottom;
+position = "{443, -444}";
+},
+{
+name = top;
+position = "{229, 401}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"474 75 LINE",
+"544 79 OFFCURVE",
+"592 126 OFFCURVE",
+"592 194 CURVE SMOOTH",
+"592 251 OFFCURVE",
+"546 285 OFFCURVE",
+"490 328 CURVE SMOOTH",
+"440 365 LINE",
+"396 306 LINE",
+"447 268 LINE SMOOTH",
+"491 234 OFFCURVE",
+"517 216 OFFCURVE",
+"517 186 CURVE SMOOTH",
+"517 139 OFFCURVE",
+"472 125 OFFCURVE",
+"437 125 CURVE SMOOTH",
+"418 125 OFFCURVE",
+"402 130 OFFCURVE",
+"386 142 CURVE SMOOTH",
+"366 156 LINE",
+"321 93 LINE",
+"744 -220 LINE SMOOTH",
+"759 -231 OFFCURVE",
+"767 -244 OFFCURVE",
+"767 -259 CURVE SMOOTH",
+"767 -292 OFFCURVE",
+"731 -315 OFFCURVE",
+"685 -315 CURVE SMOOTH",
+"642 -315 OFFCURVE",
+"610 -296 OFFCURVE",
+"580 -273 CURVE SMOOTH",
+"214 0 LINE",
+"157 42 OFFCURVE",
+"132 85 OFFCURVE",
+"132 138 CURVE SMOOTH",
+"132 161 OFFCURVE",
+"137 178 OFFCURVE",
+"147 199 CURVE",
+"91 234 LINE",
+"70 207 OFFCURVE",
+"59 169 OFFCURVE",
+"59 130 CURVE SMOOTH",
+"59 60 OFFCURVE",
+"92 -5 OFFCURVE",
+"165 -60 CURVE SMOOTH",
+"523 -328 LINE SMOOTH",
+"584 -373 OFFCURVE",
+"634 -391 OFFCURVE",
+"683 -391 CURVE SMOOTH",
+"794 -391 OFFCURVE",
+"843 -319 OFFCURVE",
+"843 -259 CURVE SMOOTH",
+"843 -220 OFFCURVE",
+"828 -189 OFFCURVE",
+"787 -159 CURVE SMOOTH",
+"530 33 LINE SMOOTH",
+"513 46 OFFCURVE",
+"494 58 OFFCURVE",
+"474 71 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"474 75 LINE",
+"544 79 OFFCURVE",
+"592 126 OFFCURVE",
+"592 194 CURVE SMOOTH",
+"592 251 OFFCURVE",
+"547 286 OFFCURVE",
+"490 328 CURVE SMOOTH",
+"440 365 LINE",
+"396 306 LINE",
+"447 268 LINE SMOOTH",
+"493 234 OFFCURVE",
+"517 214 OFFCURVE",
+"517 186 CURVE SMOOTH",
+"517 139 OFFCURVE",
+"472 125 OFFCURVE",
+"437 125 CURVE SMOOTH",
+"418 125 OFFCURVE",
+"402 130 OFFCURVE",
+"386 142 CURVE SMOOTH",
+"366 156 LINE",
+"321 93 LINE",
+"744 -220 LINE SMOOTH",
+"759 -231 OFFCURVE",
+"767 -244 OFFCURVE",
+"767 -259 CURVE SMOOTH",
+"767 -292 OFFCURVE",
+"731 -315 OFFCURVE",
+"685 -315 CURVE SMOOTH",
+"642 -315 OFFCURVE",
+"610 -296 OFFCURVE",
+"580 -273 CURVE SMOOTH",
+"214 0 LINE",
+"157 42 OFFCURVE",
+"132 85 OFFCURVE",
+"132 138 CURVE SMOOTH",
+"132 161 OFFCURVE",
+"137 178 OFFCURVE",
+"147 199 CURVE",
+"91 234 LINE",
+"70 207 OFFCURVE",
+"59 169 OFFCURVE",
+"59 130 CURVE SMOOTH",
+"59 60 OFFCURVE",
+"92 -5 OFFCURVE",
+"165 -60 CURVE SMOOTH",
+"523 -328 LINE SMOOTH",
+"584 -373 OFFCURVE",
+"634 -391 OFFCURVE",
+"683 -391 CURVE SMOOTH",
+"794 -391 OFFCURVE",
+"843 -319 OFFCURVE",
+"843 -259 CURVE SMOOTH",
+"843 -220 OFFCURVE",
+"828 -189 OFFCURVE",
+"787 -159 CURVE SMOOTH",
+"530 33 LINE SMOOTH",
+"513 46 OFFCURVE",
+"494 58 OFFCURVE",
+"474 71 CURVE"
+);
+}
+);
+width = 848;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0717.loclSYRJ;
+lastChange = "2017-09-08 19:31:37 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{333, -98}";
+},
+{
+name = top;
+position = "{341, 507}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"566 280 LINE",
+"570 266 OFFCURVE",
+"575 229 OFFCURVE",
+"575 189 CURVE SMOOTH",
+"575 121 OFFCURVE",
+"564 43 OFFCURVE",
+"556 4 CURVE",
+"620 -7 LINE",
+"638 56 OFFCURVE",
+"644 122 OFFCURVE",
+"644 201 CURVE SMOOTH",
+"644 261 OFFCURVE",
+"630 346 OFFCURVE",
+"606 399 CURVE",
+"549 387 LINE",
+"527 344 OFFCURVE",
+"501 295 OFFCURVE",
+"475 260 CURVE",
+"472 260 LINE",
+"449 354 OFFCURVE",
+"366 417 OFFCURVE",
+"251 417 CURVE SMOOTH",
+"139 417 OFFCURVE",
+"45 337 OFFCURVE",
+"45 211 CURVE SMOOTH",
+"45 87 OFFCURVE",
+"132 0 OFFCURVE",
+"260 0 CURVE SMOOTH",
+"372 0 OFFCURVE",
+"456 62 OFFCURVE",
+"477 158 CURVE",
+"508 195 OFFCURVE",
+"544 244 OFFCURVE",
+"562 279 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 76 OFFCURVE",
+"117 137 OFFCURVE",
+"117 216 CURVE SMOOTH",
+"117 294 OFFCURVE",
+"178 344 OFFCURVE",
+"251 344 CURVE SMOOTH",
+"348 344 OFFCURVE",
+"409 286 OFFCURVE",
+"409 208 CURVE SMOOTH",
+"409 119 OFFCURVE",
+"343 76 OFFCURVE",
+"270 76 CURVE SMOOTH"
+);
+}
+);
+width = 717;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071A.loclSYRJ;
+lastChange = "2017-09-08 19:31:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{402, -98}";
+},
+{
+name = top;
+position = "{528, 366}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1865 -295 LINE SMOOTH",
+"1852 -295 OFFCURVE",
+"1843 -271 OFFCURVE",
+"1832 -237 CURVE SMOOTH",
+"1813 -176 OFFCURVE",
+"1802 -143 OFFCURVE",
+"1766 -143 CURVE SMOOTH",
+"1741 -143 OFFCURVE",
+"1728 -156 OFFCURVE",
+"1719 -176 CURVE SMOOTH",
+"1698 -221 OFFCURVE",
+"1682 -257 OFFCURVE",
+"1663 -280 CURVE SMOOTH",
+"1641 -307 OFFCURVE",
+"1608 -316 OFFCURVE",
+"1580 -316 CURVE SMOOTH",
+"1492 -316 OFFCURVE",
+"1465 -252 OFFCURVE",
+"1463 -171 CURVE",
+"1399 -175 LINE",
+"1397 -181 OFFCURVE",
+"1397 -197 OFFCURVE",
+"1397 -201 CURVE SMOOTH",
+"1397 -316 OFFCURVE",
+"1450 -391 OFFCURVE",
+"1581 -391 CURVE SMOOTH",
+"1627 -391 OFFCURVE",
+"1688 -384 OFFCURVE",
+"1749 -336 CURVE",
+"1782 -372 OFFCURVE",
+"1819 -384 OFFCURVE",
+"1855 -384 CURVE SMOOTH",
+"1893 -384 OFFCURVE",
+"1924 -371 OFFCURVE",
+"1956 -336 CURVE",
+"1983 -368 OFFCURVE",
+"2001 -379 OFFCURVE",
+"2023 -379 CURVE SMOOTH",
+"2073 -379 OFFCURVE",
+"2074 -337 OFFCURVE",
+"2074 -323 CURVE SMOOTH",
+"2074 -303 OFFCURVE",
+"2057 -233 OFFCURVE",
+"2036 -185 CURVE",
+"2019 -150 OFFCURVE",
+"2001 -143 OFFCURVE",
+"1981 -143 CURVE SMOOTH",
+"1947 -143 OFFCURVE",
+"1941 -162 OFFCURVE",
+"1911 -234 CURVE SMOOTH",
+"1894 -275 OFFCURVE",
+"1879 -295 OFFCURVE",
+"1867 -295 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1942 145 OFFCURVE",
+"1924 104 OFFCURVE",
+"1910 77 CURVE",
+"1870 77 LINE",
+"1861 82 OFFCURVE",
+"1849 99 OFFCURVE",
+"1819 149 CURVE SMOOTH",
+"1791 195 OFFCURVE",
+"1781 204 OFFCURVE",
+"1759 204 CURVE SMOOTH",
+"1738 204 OFFCURVE",
+"1728 195 OFFCURVE",
+"1716 177 CURVE SMOOTH",
+"1689 136 LINE SMOOTH",
+"1659 91 OFFCURVE",
+"1620 76 OFFCURVE",
+"1582 76 CURVE SMOOTH",
+"1561 76 OFFCURVE",
+"1543 61 OFFCURVE",
+"1543 38 CURVE SMOOTH",
+"1543 14 OFFCURVE",
+"1561 0 OFFCURVE",
+"1582 0 CURVE SMOOTH",
+"1650 0 OFFCURVE",
+"1713 20 OFFCURVE",
+"1757 70 CURVE",
+"1800 16 OFFCURVE",
+"1838 0 OFFCURVE",
+"1895 0 CURVE SMOOTH",
+"1971 0 OFFCURVE",
+"2047 41 OFFCURVE",
+"2047 120 CURVE SMOOTH",
+"2047 163 OFFCURVE",
+"2034 206 OFFCURVE",
+"1999 206 CURVE SMOOTH",
+"1980 206 OFFCURVE",
+"1965 198 OFFCURVE",
+"1953 170 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1942 145 OFFCURVE",
+"1924 104 OFFCURVE",
+"1910 77 CURVE",
+"1870 77 LINE",
+"1861 82 OFFCURVE",
+"1849 99 OFFCURVE",
+"1819 149 CURVE SMOOTH",
+"1791 195 OFFCURVE",
+"1781 204 OFFCURVE",
+"1759 204 CURVE SMOOTH",
+"1738 204 OFFCURVE",
+"1728 195 OFFCURVE",
+"1716 177 CURVE SMOOTH",
+"1689 136 LINE SMOOTH",
+"1659 91 OFFCURVE",
+"1620 76 OFFCURVE",
+"1582 76 CURVE SMOOTH",
+"1561 76 OFFCURVE",
+"1543 61 OFFCURVE",
+"1543 38 CURVE SMOOTH",
+"1543 14 OFFCURVE",
+"1561 0 OFFCURVE",
+"1582 0 CURVE SMOOTH",
+"1650 0 OFFCURVE",
+"1713 20 OFFCURVE",
+"1757 70 CURVE",
+"1800 16 OFFCURVE",
+"1838 0 OFFCURVE",
+"1895 0 CURVE SMOOTH",
+"1971 0 OFFCURVE",
+"2047 41 OFFCURVE",
+"2047 120 CURVE SMOOTH",
+"2047 163 OFFCURVE",
+"2034 206 OFFCURVE",
+"1999 206 CURVE SMOOTH",
+"1980 206 OFFCURVE",
+"1965 198 OFFCURVE",
+"1953 170 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1946 153 OFFCURVE",
+"1924 104 OFFCURVE",
+"1910 77 CURVE",
+"1870 77 LINE",
+"1861 82 OFFCURVE",
+"1849 99 OFFCURVE",
+"1819 149 CURVE SMOOTH",
+"1791 195 OFFCURVE",
+"1781 204 OFFCURVE",
+"1759 204 CURVE SMOOTH",
+"1738 204 OFFCURVE",
+"1728 195 OFFCURVE",
+"1716 177 CURVE SMOOTH",
+"1689 136 LINE SMOOTH",
+"1659 91 OFFCURVE",
+"1620 76 OFFCURVE",
+"1582 76 CURVE SMOOTH",
+"1561 76 OFFCURVE",
+"1543 61 OFFCURVE",
+"1543 38 CURVE SMOOTH",
+"1543 14 OFFCURVE",
+"1561 0 OFFCURVE",
+"1582 0 CURVE SMOOTH",
+"1650 0 OFFCURVE",
+"1713 20 OFFCURVE",
+"1757 70 CURVE",
+"1800 16 OFFCURVE",
+"1838 0 OFFCURVE",
+"1895 0 CURVE SMOOTH",
+"1971 0 OFFCURVE",
+"2051 49 OFFCURVE",
+"2051 128 CURVE SMOOTH",
+"2051 171 OFFCURVE",
+"2038 214 OFFCURVE",
+"2003 214 CURVE SMOOTH",
+"1984 214 OFFCURVE",
+"1969 206 OFFCURVE",
+"1957 178 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1292 150 OFFCURVE",
+"1259 90 OFFCURVE",
+"1245 77 CURVE",
+"1219 77 LINE",
+"1210 82 OFFCURVE",
+"1198 99 OFFCURVE",
+"1168 149 CURVE SMOOTH",
+"1140 195 OFFCURVE",
+"1130 204 OFFCURVE",
+"1108 204 CURVE SMOOTH",
+"1087 204 OFFCURVE",
+"1077 195 OFFCURVE",
+"1065 177 CURVE SMOOTH",
+"1038 136 LINE SMOOTH",
+"1008 91 OFFCURVE",
+"969 76 OFFCURVE",
+"931 76 CURVE SMOOTH",
+"910 76 OFFCURVE",
+"892 61 OFFCURVE",
+"892 38 CURVE SMOOTH",
+"892 14 OFFCURVE",
+"910 0 OFFCURVE",
+"931 0 CURVE SMOOTH",
+"999 0 OFFCURVE",
+"1062 20 OFFCURVE",
+"1106 70 CURVE",
+"1149 16 OFFCURVE",
+"1178 0 OFFCURVE",
+"1235 0 CURVE SMOOTH",
+"1319 0 OFFCURVE",
+"1394 56 OFFCURVE",
+"1394 138 CURVE SMOOTH",
+"1394 176 OFFCURVE",
+"1382 210 OFFCURVE",
+"1351 210 CURVE SMOOTH",
+"1332 210 OFFCURVE",
+"1319 200 OFFCURVE",
+"1305 174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1149 16 OFFCURVE",
+"1187 0 OFFCURVE",
+"1244 0 CURVE SMOOTH",
+"1320 0 OFFCURVE",
+"1400 49 OFFCURVE",
+"1400 128 CURVE SMOOTH",
+"1400 171 OFFCURVE",
+"1387 214 OFFCURVE",
+"1352 214 CURVE SMOOTH",
+"1333 214 OFFCURVE",
+"1318 206 OFFCURVE",
+"1306 178 CURVE SMOOTH",
+"1295 153 OFFCURVE",
+"1273 104 OFFCURVE",
+"1259 77 CURVE",
+"1219 77 LINE",
+"1210 82 OFFCURVE",
+"1198 99 OFFCURVE",
+"1168 149 CURVE SMOOTH",
+"1140 195 OFFCURVE",
+"1130 204 OFFCURVE",
+"1108 204 CURVE SMOOTH",
+"1087 204 OFFCURVE",
+"1077 195 OFFCURVE",
+"1065 177 CURVE SMOOTH",
+"1038 136 LINE SMOOTH",
+"1008 91 OFFCURVE",
+"979 69 OFFCURVE",
+"940 69 CURVE SMOOTH",
+"852 69 OFFCURVE",
+"825 132 OFFCURVE",
+"823 213 CURVE",
+"759 209 LINE",
+"757 203 OFFCURVE",
+"757 187 OFFCURVE",
+"757 183 CURVE SMOOTH",
+"757 68 OFFCURVE",
+"810 -7 OFFCURVE",
+"941 -7 CURVE SMOOTH",
+"1009 -7 OFFCURVE",
+"1062 20 OFFCURVE",
+"1106 70 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1149 16 OFFCURVE",
+"1178 0 OFFCURVE",
+"1235 0 CURVE SMOOTH",
+"1319 0 OFFCURVE",
+"1394 56 OFFCURVE",
+"1394 138 CURVE SMOOTH",
+"1394 176 OFFCURVE",
+"1382 210 OFFCURVE",
+"1351 210 CURVE SMOOTH",
+"1332 210 OFFCURVE",
+"1319 200 OFFCURVE",
+"1305 174 CURVE SMOOTH",
+"1292 150 OFFCURVE",
+"1259 90 OFFCURVE",
+"1245 77 CURVE",
+"1219 77 LINE",
+"1210 82 OFFCURVE",
+"1198 99 OFFCURVE",
+"1168 149 CURVE SMOOTH",
+"1140 195 OFFCURVE",
+"1130 204 OFFCURVE",
+"1108 204 CURVE SMOOTH",
+"1087 204 OFFCURVE",
+"1077 195 OFFCURVE",
+"1065 177 CURVE SMOOTH",
+"1038 136 LINE SMOOTH",
+"1008 91 OFFCURVE",
+"979 69 OFFCURVE",
+"940 69 CURVE SMOOTH",
+"852 69 OFFCURVE",
+"825 132 OFFCURVE",
+"823 213 CURVE",
+"759 209 LINE",
+"757 203 OFFCURVE",
+"757 187 OFFCURVE",
+"757 183 CURVE SMOOTH",
+"757 68 OFFCURVE",
+"810 -7 OFFCURVE",
+"941 -7 CURVE SMOOTH",
+"1009 -7 OFFCURVE",
+"1062 20 OFFCURVE",
+"1106 70 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 203 OFFCURVE",
+"377 195 OFFCURVE",
+"364 177 CURVE SMOOTH",
+"335 137 LINE SMOOTH",
+"321 118 OFFCURVE",
+"306 100 OFFCURVE",
+"289 91 CURVE SMOOTH",
+"270 80 OFFCURVE",
+"249 76 OFFCURVE",
+"229 76 CURVE SMOOTH",
+"208 76 OFFCURVE",
+"190 61 OFFCURVE",
+"190 38 CURVE SMOOTH",
+"190 14 OFFCURVE",
+"208 0 OFFCURVE",
+"229 0 CURVE SMOOTH",
+"259 0 OFFCURVE",
+"287 3 OFFCURVE",
+"314 12 CURVE SMOOTH",
+"336 19 OFFCURVE",
+"357 30 OFFCURVE",
+"376 44 CURVE SMOOTH",
+"386 52 OFFCURVE",
+"395 60 OFFCURVE",
+"404 70 CURVE",
+"447 16 OFFCURVE",
+"476 0 OFFCURVE",
+"533 0 CURVE SMOOTH",
+"576 0 OFFCURVE",
+"626 22 OFFCURVE",
+"653 60 CURVE SMOOTH",
+"672 87 OFFCURVE",
+"683 112 OFFCURVE",
+"683 143 CURVE SMOOTH",
+"683 177 OFFCURVE",
+"671 210 OFFCURVE",
+"640 210 CURVE SMOOTH",
+"621 210 OFFCURVE",
+"608 200 OFFCURVE",
+"594 174 CURVE SMOOTH",
+"554 102 OFFCURVE",
+"542 82 OFFCURVE",
+"529 82 CURVE SMOOTH",
+"525 82 LINE SMOOTH",
+"513 82 OFFCURVE",
+"506 92 OFFCURVE",
+"470 149 CURVE SMOOTH",
+"441 195 OFFCURVE",
+"430 203 OFFCURVE",
+"408 203 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"447 16 OFFCURVE",
+"476 0 OFFCURVE",
+"533 0 CURVE SMOOTH",
+"576 0 OFFCURVE",
+"626 22 OFFCURVE",
+"653 60 CURVE SMOOTH",
+"672 87 OFFCURVE",
+"683 112 OFFCURVE",
+"683 143 CURVE SMOOTH",
+"683 177 OFFCURVE",
+"671 210 OFFCURVE",
+"640 210 CURVE SMOOTH",
+"621 210 OFFCURVE",
+"608 200 OFFCURVE",
+"594 174 CURVE SMOOTH",
+"554 102 OFFCURVE",
+"542 82 OFFCURVE",
+"529 82 CURVE SMOOTH",
+"525 82 LINE SMOOTH",
+"513 82 OFFCURVE",
+"506 92 OFFCURVE",
+"470 149 CURVE SMOOTH",
+"441 195 OFFCURVE",
+"430 203 OFFCURVE",
+"408 203 CURVE",
+"387 203 OFFCURVE",
+"379 195 OFFCURVE",
+"367 177 CURVE SMOOTH",
+"340 136 LINE SMOOTH",
+"310 91 OFFCURVE",
+"285 69 OFFCURVE",
+"236 69 CURVE SMOOTH",
+"154 69 OFFCURVE",
+"127 122 OFFCURVE",
+"125 203 CURVE",
+"61 199 LINE",
+"59 193 OFFCURVE",
+"59 177 OFFCURVE",
+"59 173 CURVE SMOOTH",
+"59 58 OFFCURVE",
+"126 -7 OFFCURVE",
+"236 -7 CURVE SMOOTH",
+"304 -7 OFFCURVE",
+"360 20 OFFCURVE",
+"404 70 CURVE"
+);
+}
+);
+width = 772;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071F.loclSYRJ;
+lastChange = "2017-09-08 19:31:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{499, 279}";
+},
+{
+name = RU;
+position = "{494, -65}";
+},
+{
+name = bottom;
+position = "{392, -244}";
+},
+{
+name = top;
+position = "{299, 426}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1356 204 LINE",
+"1355 199 OFFCURVE",
+"1354 187 OFFCURVE",
+"1354 183 CURVE SMOOTH",
+"1354 76 OFFCURVE",
+"1445 8 OFFCURVE",
+"1568 -1 CURVE",
+"1377 -369 LINE",
+"1444 -399 LINE",
+"1651 0 LINE",
+"1874 0 LINE",
+"1874 76 LINE",
+"1765 76 LINE",
+"1761 127 OFFCURVE",
+"1754 185 OFFCURVE",
+"1698 185 CURVE SMOOTH",
+"1659 185 OFFCURVE",
+"1634 140 OFFCURVE",
+"1605 81 CURVE SMOOTH",
+"1601 73 LINE",
+"1595 73 LINE SMOOTH",
+"1492 73 OFFCURVE",
+"1425 120 OFFCURVE",
+"1421 208 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1356 204 LINE",
+"1355 199 OFFCURVE",
+"1354 187 OFFCURVE",
+"1354 183 CURVE SMOOTH",
+"1354 76 OFFCURVE",
+"1442 9 OFFCURVE",
+"1569 1 CURVE",
+"1377 -369 LINE",
+"1444 -399 LINE",
+"1651 0 LINE",
+"1663 0 OFFCURVE",
+"1690 0 OFFCURVE",
+"1706 3 CURVE SMOOTH",
+"1768 12 OFFCURVE",
+"1790 53 OFFCURVE",
+"1790 102 CURVE SMOOTH",
+"1790 150 OFFCURVE",
+"1763 208 OFFCURVE",
+"1716 208 CURVE SMOOTH",
+"1676 208 OFFCURVE",
+"1659 182 OFFCURVE",
+"1605 82 CURVE",
+"1601 73 LINE",
+"1596 73 LINE SMOOTH",
+"1498 73 OFFCURVE",
+"1425 120 OFFCURVE",
+"1421 208 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1402 -7 OFFCURVE",
+"1334 54 OFFCURVE",
+"1334 181 CURVE SMOOTH",
+"1334 185 OFFCURVE",
+"1334 199 OFFCURVE",
+"1336 204 CURVE",
+"1400 208 LINE",
+"1402 118 OFFCURVE",
+"1445 69 OFFCURVE",
+"1548 69 CURVE SMOOTH",
+"1584 69 OFFCURVE",
+"1606 70 OFFCURVE",
+"1624 72 CURVE",
+"1631 86 OFFCURVE",
+"1652 143 OFFCURVE",
+"1663 168 CURVE SMOOTH",
+"1675 196 OFFCURVE",
+"1691 203 OFFCURVE",
+"1710 203 CURVE SMOOTH",
+"1745 203 OFFCURVE",
+"1761 157 OFFCURVE",
+"1761 114 CURVE SMOOTH",
+"1761 56 OFFCURVE",
+"1731 16 OFFCURVE",
+"1658 0 CURVE SMOOTH",
+"1631 -6 OFFCURVE",
+"1593 -7 OFFCURVE",
+"1556 -7 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 204 LINE",
+"658 199 OFFCURVE",
+"657 187 OFFCURVE",
+"657 183 CURVE SMOOTH",
+"657 76 OFFCURVE",
+"748 8 OFFCURVE",
+"871 -1 CURVE",
+"680 -369 LINE",
+"741 -399 LINE",
+"951 0 LINE",
+"1177 0 LINE",
+"1177 76 LINE",
+"1060 76 LINE",
+"1062 85 OFFCURVE",
+"1064 100 OFFCURVE",
+"1064 114 CURVE SMOOTH",
+"1064 162 OFFCURVE",
+"1048 203 OFFCURVE",
+"1009 203 CURVE SMOOTH",
+"973 203 OFFCURVE",
+"954 169 OFFCURVE",
+"916 96 CURVE SMOOTH",
+"904 73 LINE",
+"898 73 LINE SMOOTH",
+"795 73 OFFCURVE",
+"728 120 OFFCURVE",
+"724 208 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 204 LINE",
+"658 199 OFFCURVE",
+"657 187 OFFCURVE",
+"657 183 CURVE SMOOTH",
+"657 76 OFFCURVE",
+"748 8 OFFCURVE",
+"871 -1 CURVE",
+"680 -369 LINE",
+"741 -399 LINE",
+"951 0 LINE",
+"1177 0 LINE",
+"1177 76 LINE",
+"1060 76 LINE",
+"1062 85 OFFCURVE",
+"1064 100 OFFCURVE",
+"1064 114 CURVE SMOOTH",
+"1064 162 OFFCURVE",
+"1048 203 OFFCURVE",
+"1009 203 CURVE SMOOTH",
+"973 203 OFFCURVE",
+"954 169 OFFCURVE",
+"916 96 CURVE SMOOTH",
+"904 73 LINE",
+"898 73 LINE SMOOTH",
+"795 73 OFFCURVE",
+"728 120 OFFCURVE",
+"724 208 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"61 204 LINE",
+"60 199 OFFCURVE",
+"59 187 OFFCURVE",
+"59 183 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"147 9 OFFCURVE",
+"274 1 CURVE",
+"82 -369 LINE",
+"143 -399 LINE",
+"354 0 LINE",
+"413 8 OFFCURVE",
+"466 30 OFFCURVE",
+"466 114 CURVE SMOOTH",
+"466 162 OFFCURVE",
+"450 203 OFFCURVE",
+"411 203 CURVE SMOOTH",
+"375 203 OFFCURVE",
+"356 169 OFFCURVE",
+"318 96 CURVE SMOOTH",
+"306 73 LINE",
+"301 73 LINE SMOOTH",
+"203 73 OFFCURVE",
+"130 120 OFFCURVE",
+"126 208 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"61 194 LINE",
+"60 189 OFFCURVE",
+"59 177 OFFCURVE",
+"59 173 CURVE SMOOTH",
+"59 67 OFFCURVE",
+"141 14 OFFCURVE",
+"264 2 CURVE SMOOTH",
+"274 1 LINE",
+"82 -369 LINE",
+"143 -399 LINE",
+"354 0 LINE",
+"413 8 OFFCURVE",
+"466 30 OFFCURVE",
+"466 114 CURVE SMOOTH",
+"466 162 OFFCURVE",
+"450 203 OFFCURVE",
+"411 203 CURVE SMOOTH",
+"375 203 OFFCURVE",
+"356 169 OFFCURVE",
+"318 96 CURVE SMOOTH",
+"306 73 LINE",
+"301 73 LINE SMOOTH",
+"203 73 OFFCURVE",
+"130 110 OFFCURVE",
+"126 198 CURVE"
+);
+}
+);
+width = 540;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074E.loclSYRJ;
+lastChange = "2017-09-08 19:40:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{412, -98}";
+},
+{
+name = top;
+position = "{360, 667}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"531 613 LINE",
+"601 584 LINE SMOOTH",
+"652 563 OFFCURVE",
+"669 538 OFFCURVE",
+"669 508 CURVE SMOOTH",
+"669 470 OFFCURVE",
+"642 454 OFFCURVE",
+"612 450 CURVE",
+"573 471 OFFCURVE",
+"522 486 OFFCURVE",
+"458 486 CURVE",
+"444 416 LINE",
+"472 414 LINE SMOOTH",
+"572 404 OFFCURVE",
+"697 339 OFFCURVE",
+"697 195 CURVE SMOOTH",
+"697 83 OFFCURVE",
+"613 76 OFFCURVE",
+"523 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"517 0 LINE SMOOTH",
+"671 0 OFFCURVE",
+"769 42 OFFCURVE",
+"769 188 CURVE SMOOTH",
+"769 290 OFFCURVE",
+"729 359 OFFCURVE",
+"669 406 CURVE",
+"669 409 LINE",
+"718 427 OFFCURVE",
+"745 469 OFFCURVE",
+"745 521 CURVE SMOOTH",
+"745 581 OFFCURVE",
+"696 623 OFFCURVE",
+"631 649 CURVE SMOOTH",
+"561 678 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"531 613 LINE",
+"601 584 LINE SMOOTH",
+"652 563 OFFCURVE",
+"669 538 OFFCURVE",
+"669 508 CURVE SMOOTH",
+"669 470 OFFCURVE",
+"642 454 OFFCURVE",
+"612 450 CURVE",
+"573 471 OFFCURVE",
+"522 486 OFFCURVE",
+"458 486 CURVE",
+"444 416 LINE",
+"472 414 LINE SMOOTH",
+"572 404 OFFCURVE",
+"697 339 OFFCURVE",
+"697 195 CURVE SMOOTH",
+"697 83 OFFCURVE",
+"613 76 OFFCURVE",
+"523 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"517 0 LINE SMOOTH",
+"671 0 OFFCURVE",
+"769 42 OFFCURVE",
+"769 188 CURVE SMOOTH",
+"769 290 OFFCURVE",
+"729 359 OFFCURVE",
+"669 406 CURVE",
+"669 409 LINE",
+"718 427 OFFCURVE",
+"745 469 OFFCURVE",
+"745 521 CURVE SMOOTH",
+"745 581 OFFCURVE",
+"696 623 OFFCURVE",
+"631 649 CURVE SMOOTH",
+"561 678 LINE"
+);
+}
+);
+width = 837;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0720.loclSYRJ;
+lastChange = "2017-09-08 19:40:48 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{423, -98}";
+},
+{
+name = top;
+position = "{126, 734}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"511 -17 OFFCURVE",
+"548 40 OFFCURVE",
+"557 82 CURVE",
+"560 82 LINE",
+"602 33 LINE",
+"641 -12 LINE",
+"700 38 LINE",
+"125 693 LINE",
+"68 642 LINE",
+"491 160 LINE SMOOTH",
+"499 150 OFFCURVE",
+"505 138 OFFCURVE",
+"505 123 CURVE SMOOTH",
+"505 90 OFFCURVE",
+"477 59 OFFCURVE",
+"431 59 CURVE SMOOTH",
+"390 59 OFFCURVE",
+"361 88 OFFCURVE",
+"330 124 CURVE SMOOTH",
+"-136 654 LINE",
+"-193 603 LINE",
+"264 82 LINE SMOOTH",
+"328 9 OFFCURVE",
+"376 -17 OFFCURVE",
+"427 -17 CURVE SMOOTH"
+);
+}
+);
+width = 749;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0721.loclSYRJ;
+lastChange = "2017-09-08 19:40:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{421, -98}";
+},
+{
+name = top;
+position = "{352, 520}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"287 422 OFFCURVE",
+"212 375 OFFCURVE",
+"189 301 CURVE",
+"184 301 LINE",
+"163 355 OFFCURVE",
+"139 406 OFFCURVE",
+"109 448 CURVE",
+"49 406 LINE",
+"127 264 OFFCURVE",
+"172 158 OFFCURVE",
+"172 -22 CURVE SMOOTH",
+"172 -176 OFFCURVE",
+"130 -310 OFFCURVE",
+"101 -381 CURVE",
+"171 -399 LINE",
+"221 -288 OFFCURVE",
+"243 -171 OFFCURVE",
+"243 -55 CURVE SMOOTH",
+"243 -7 OFFCURVE",
+"237 35 OFFCURVE",
+"229 69 CURVE",
+"233 70 LINE",
+"266 21 OFFCURVE",
+"312 -4 OFFCURVE",
+"383 -4 CURVE SMOOTH",
+"497 -4 OFFCURVE",
+"595 72 OFFCURVE",
+"595 209 CURVE SMOOTH",
+"595 330 OFFCURVE",
+"517 422 OFFCURVE",
+"375 422 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"277 69 OFFCURVE",
+"222 165 OFFCURVE",
+"222 224 CURVE SMOOTH",
+"222 296 OFFCURVE",
+"287 349 OFFCURVE",
+"375 349 CURVE SMOOTH",
+"472 349 OFFCURVE",
+"521 294 OFFCURVE",
+"521 210 CURVE SMOOTH",
+"521 117 OFFCURVE",
+"459 69 OFFCURVE",
+"383 69 CURVE SMOOTH"
+);
+}
+);
+width = 653;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0722.loclSYRJ;
+lastChange = "2017-09-08 19:35:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{223, -413}";
+},
+{
+name = top;
+position = "{186, 365}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"687 -341 LINE",
+"579 -194 OFFCURVE",
+"529 -120 OFFCURVE",
+"486 12 CURVE",
+"464 83 OFFCURVE",
+"450 142 OFFCURVE",
+"442 193 CURVE",
+"371 172 LINE",
+"398 -56 OFFCURVE",
+"500 -234 OFFCURVE",
+"627 -381 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"687 -341 LINE",
+"579 -194 OFFCURVE",
+"529 -120 OFFCURVE",
+"486 12 CURVE",
+"464 83 OFFCURVE",
+"453 130 OFFCURVE",
+"445 181 CURVE",
+"374 164 LINE",
+"401 -64 OFFCURVE",
+"500 -234 OFFCURVE",
+"627 -381 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"689 -343 LINE",
+"555 -159 OFFCURVE",
+"442 12 OFFCURVE",
+"356 177 CURVE",
+"291 139 LINE",
+"350 0 OFFCURVE",
+"545 -277 OFFCURVE",
+"627 -381 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"488 -367 LINE",
+"387 -249 OFFCURVE",
+"250 -63 OFFCURVE",
+"189 25 CURVE",
+"196 29 LINE",
+"227 4 OFFCURVE",
+"276 0 OFFCURVE",
+"325 0 CURVE SMOOTH",
+"334 0 LINE",
+"334 76 LINE",
+"324 76 LINE SMOOTH",
+"275 76 OFFCURVE",
+"268 77 OFFCURVE",
+"252 83 CURVE SMOOTH",
+"245 86 OFFCURVE",
+"230 92 OFFCURVE",
+"202 119 CURVE SMOOTH",
+"182 139 OFFCURVE",
+"170 143 OFFCURVE",
+"151 143 CURVE SMOOTH",
+"117 143 OFFCURVE",
+"102 108 OFFCURVE",
+"102 70 CURVE SMOOTH",
+"102 45 OFFCURVE",
+"114 7 OFFCURVE",
+"134 -23 CURVE SMOOTH",
+"203 -125 OFFCURVE",
+"340 -301 OFFCURVE",
+"433 -405 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"468 -343 LINE",
+"329 -166 OFFCURVE",
+"208 0 OFFCURVE",
+"101 160 CURVE",
+"36 118 LINE",
+"120 -18 OFFCURVE",
+"323 -287 OFFCURVE",
+"408 -384 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"468 -343 LINE",
+"329 -166 OFFCURVE",
+"200 19 OFFCURVE",
+"93 179 CURVE",
+"28 137 LINE",
+"112 1 OFFCURVE",
+"323 -287 OFFCURVE",
+"408 -384 CURVE"
+);
+}
+);
+width = 332;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0726.loclSYRJ;
+lastChange = "2017-09-08 19:40:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{743, 547}";
+},
+{
+name = RU;
+position = "{700, -69}";
+},
+{
+name = bottom;
+position = "{417, -98}";
+},
+{
+name = top;
+position = "{501, 633}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"851 0 LINE",
+"851 76 LINE",
+"780 76 LINE SMOOTH",
+"761 76 OFFCURVE",
+"736 76 OFFCURVE",
+"712 74 CURVE",
+"711 78 LINE",
+"750 108 OFFCURVE",
+"769 157 OFFCURVE",
+"769 217 CURVE SMOOTH",
+"769 401 OFFCURVE",
+"632 533 OFFCURVE",
+"503 533 CURVE SMOOTH",
+"397 533 OFFCURVE",
+"303 464 OFFCURVE",
+"303 349 CURVE SMOOTH",
+"303 229 OFFCURVE",
+"400 187 OFFCURVE",
+"500 187 CURVE SMOOTH",
+"567 187 OFFCURVE",
+"642 215 OFFCURVE",
+"690 264 CURVE",
+"693 264 LINE",
+"696 248 OFFCURVE",
+"697 231 OFFCURVE",
+"697 214 CURVE SMOOTH",
+"697 103 OFFCURVE",
+"613 76 OFFCURVE",
+"523 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"183 76 OFFCURVE",
+"125 137 OFFCURVE",
+"125 216 CURVE SMOOTH",
+"125 220 LINE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"422 260 OFFCURVE",
+"376 293 OFFCURVE",
+"376 356 CURVE SMOOTH",
+"376 416 OFFCURVE",
+"431 457 OFFCURVE",
+"503 457 CURVE SMOOTH",
+"572 457 OFFCURVE",
+"637 410 OFFCURVE",
+"672 333 CURVE",
+"631 285 OFFCURVE",
+"562 260 OFFCURVE",
+"502 260 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"697 103 OFFCURVE",
+"613 76 OFFCURVE",
+"523 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"183 76 OFFCURVE",
+"125 137 OFFCURVE",
+"125 216 CURVE SMOOTH",
+"125 220 LINE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"517 0 LINE SMOOTH",
+"671 0 OFFCURVE",
+"769 61 OFFCURVE",
+"769 208 CURVE SMOOTH",
+"769 401 OFFCURVE",
+"632 533 OFFCURVE",
+"503 533 CURVE SMOOTH",
+"397 533 OFFCURVE",
+"303 464 OFFCURVE",
+"303 349 CURVE SMOOTH",
+"303 229 OFFCURVE",
+"400 187 OFFCURVE",
+"500 187 CURVE SMOOTH",
+"567 187 OFFCURVE",
+"642 215 OFFCURVE",
+"690 264 CURVE",
+"693 264 LINE",
+"696 248 OFFCURVE",
+"697 231 OFFCURVE",
+"697 214 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"572 457 OFFCURVE",
+"637 410 OFFCURVE",
+"672 333 CURVE",
+"631 285 OFFCURVE",
+"562 260 OFFCURVE",
+"502 260 CURVE SMOOTH",
+"422 260 OFFCURVE",
+"376 293 OFFCURVE",
+"376 356 CURVE SMOOTH",
+"376 416 OFFCURVE",
+"431 457 OFFCURVE",
+"503 457 CURVE SMOOTH"
+);
+}
+);
+width = 837;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0729.loclSYRJ;
+lastChange = "2017-09-08 19:40:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{439, -98}";
+},
+{
+name = top;
+position = "{567, 516}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"436 417 OFFCURVE",
+"336 343 OFFCURVE",
+"336 217 CURVE SMOOTH",
+"336 160 OFFCURVE",
+"356 116 OFFCURVE",
+"395 78 CURVE",
+"395 74 LINE",
+"374 76 OFFCURVE",
+"350 76 OFFCURVE",
+"334 76 CURVE SMOOTH",
+"287 76 LINE SMOOTH",
+"173 76 OFFCURVE",
+"127 125 OFFCURVE",
+"127 198 CURVE SMOOTH",
+"127 206 LINE",
+"61 202 LINE",
+"60 196 OFFCURVE",
+"59 175 OFFCURVE",
+"59 171 CURVE SMOOTH",
+"59 62 OFFCURVE",
+"142 0 OFFCURVE",
+"278 0 CURVE SMOOTH",
+"559 0 LINE SMOOTH",
+"690 0 OFFCURVE",
+"783 75 OFFCURVE",
+"783 206 CURVE SMOOTH",
+"783 326 OFFCURVE",
+"691 417 OFFCURVE",
+"549 417 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 76 OFFCURVE",
+"409 141 OFFCURVE",
+"409 220 CURVE SMOOTH",
+"409 298 OFFCURVE",
+"473 344 OFFCURVE",
+"549 344 CURVE SMOOTH",
+"646 344 OFFCURVE",
+"710 286 OFFCURVE",
+"710 207 CURVE SMOOTH",
+"710 119 OFFCURVE",
+"644 76 OFFCURVE",
+"569 76 CURVE SMOOTH"
+);
+}
+);
+width = 833;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0727.loclSYRJ;
+lastChange = "2017-09-08 19:40:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{519, -98}";
+},
+{
+name = top;
+position = "{564, 622}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"831 76 LINE",
+"713 76 LINE SMOOTH",
+"562 76 OFFCURVE",
+"395 77 OFFCURVE",
+"395 259 CURVE SMOOTH",
+"395 369 OFFCURVE",
+"484 442 OFFCURVE",
+"574 442 CURVE SMOOTH",
+"666 442 OFFCURVE",
+"714 401 OFFCURVE",
+"714 340 CURVE SMOOTH",
+"714 290 OFFCURVE",
+"679 260 OFFCURVE",
+"626 260 CURVE SMOOTH",
+"593 260 OFFCURVE",
+"556 279 OFFCURVE",
+"551 324 CURVE",
+"491 317 LINE",
+"491 243 OFFCURVE",
+"551 194 OFFCURVE",
+"629 194 CURVE SMOOTH",
+"726 194 OFFCURVE",
+"785 262 OFFCURVE",
+"785 342 CURVE SMOOTH",
+"785 436 OFFCURVE",
+"706 518 OFFCURVE",
+"571 518 CURVE SMOOTH",
+"442 518 OFFCURVE",
+"321 401 OFFCURVE",
+"321 253 CURVE SMOOTH",
+"321 164 OFFCURVE",
+"351 110 OFFCURVE",
+"405 77 CURVE",
+"404 74 LINE",
+"381 75 OFFCURVE",
+"357 76 OFFCURVE",
+"336 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"831 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"831 76 LINE",
+"713 76 LINE SMOOTH",
+"562 76 OFFCURVE",
+"395 77 OFFCURVE",
+"395 259 CURVE SMOOTH",
+"395 369 OFFCURVE",
+"484 442 OFFCURVE",
+"574 442 CURVE SMOOTH",
+"666 442 OFFCURVE",
+"714 401 OFFCURVE",
+"714 340 CURVE SMOOTH",
+"714 290 OFFCURVE",
+"679 260 OFFCURVE",
+"626 260 CURVE SMOOTH",
+"593 260 OFFCURVE",
+"556 279 OFFCURVE",
+"551 324 CURVE",
+"491 317 LINE",
+"491 243 OFFCURVE",
+"551 194 OFFCURVE",
+"629 194 CURVE SMOOTH",
+"726 194 OFFCURVE",
+"785 262 OFFCURVE",
+"785 342 CURVE SMOOTH",
+"785 436 OFFCURVE",
+"706 518 OFFCURVE",
+"571 518 CURVE SMOOTH",
+"442 518 OFFCURVE",
+"321 401 OFFCURVE",
+"321 253 CURVE SMOOTH",
+"321 164 OFFCURVE",
+"351 110 OFFCURVE",
+"405 77 CURVE",
+"404 74 LINE",
+"381 75 OFFCURVE",
+"357 76 OFFCURVE",
+"336 76 CURVE SMOOTH",
+"301 76 LINE SMOOTH",
+"178 76 OFFCURVE",
+"127 140 OFFCURVE",
+"125 220 CURVE",
+"61 216 LINE",
+"59 210 OFFCURVE",
+"59 194 OFFCURVE",
+"59 190 CURVE SMOOTH",
+"59 76 OFFCURVE",
+"145 0 OFFCURVE",
+"297 0 CURVE SMOOTH",
+"831 0 LINE"
+);
+}
+);
+width = 890;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072A.loclSYRJ;
+lastChange = "2017-09-08 19:40:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{330, 458}";
+},
+{
+name = RU;
+position = "{295, -112}";
+},
+{
+name = bottom;
+position = "{156, -216}";
+},
+{
+name = top;
+position = "{192, 553}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 192, 363}";
+},
+{
+name = uni0716.loclSYRJ;
+}
+);
+layerId = UUID0;
+width = 365;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0728.loclSYRJ;
+lastChange = "2017-09-08 19:40:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{36, -445}";
+},
+{
+name = top;
+position = "{129, 366}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1054 195 LINE",
+"1073 167 OFFCURVE",
+"1078 140 OFFCURVE",
+"1078 116 CURVE SMOOTH",
+"1078 47 OFFCURVE",
+"1025 8 OFFCURVE",
+"1025 -63 CURVE SMOOTH",
+"1025 -87 OFFCURVE",
+"1034 -112 OFFCURVE",
+"1046 -134 CURVE SMOOTH",
+"1060 -160 OFFCURVE",
+"1087 -210 OFFCURVE",
+"1087 -248 CURVE SMOOTH",
+"1087 -281 OFFCURVE",
+"1068 -308 OFFCURVE",
+"1005 -308 CURVE SMOOTH",
+"937 -308 OFFCURVE",
+"854 -268 OFFCURVE",
+"804 -231 CURVE",
+"765 -284 LINE",
+"830 -343 OFFCURVE",
+"928 -381 OFFCURVE",
+"1002 -381 CURVE SMOOTH",
+"1098 -381 OFFCURVE",
+"1159 -333 OFFCURVE",
+"1159 -249 CURVE SMOOTH",
+"1159 -210 OFFCURVE",
+"1145 -171 OFFCURVE",
+"1128 -135 CURVE SMOOTH",
+"1109 -96 OFFCURVE",
+"1098 -74 OFFCURVE",
+"1098 -51 CURVE SMOOTH",
+"1098 -21 OFFCURVE",
+"1111 1 OFFCURVE",
+"1124 28 CURVE SMOOTH",
+"1138 56 OFFCURVE",
+"1151 87 OFFCURVE",
+"1151 127 CURVE SMOOTH",
+"1151 160 OFFCURVE",
+"1142 195 OFFCURVE",
+"1116 231 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"504 195 LINE",
+"523 167 OFFCURVE",
+"528 140 OFFCURVE",
+"528 116 CURVE SMOOTH",
+"528 87 OFFCURVE",
+"519 63 OFFCURVE",
+"508 40 CURVE SMOOTH",
+"489 1 OFFCURVE",
+"478 -23 OFFCURVE",
+"478 -62 CURVE SMOOTH",
+"478 -86 OFFCURVE",
+"489 -118 OFFCURVE",
+"501 -143 CURVE SMOOTH",
+"514 -169 OFFCURVE",
+"537 -214 OFFCURVE",
+"537 -248 CURVE SMOOTH",
+"537 -281 OFFCURVE",
+"518 -308 OFFCURVE",
+"455 -308 CURVE SMOOTH",
+"387 -308 OFFCURVE",
+"304 -268 OFFCURVE",
+"254 -231 CURVE",
+"215 -284 LINE",
+"280 -343 OFFCURVE",
+"378 -381 OFFCURVE",
+"452 -381 CURVE SMOOTH",
+"548 -381 OFFCURVE",
+"609 -333 OFFCURVE",
+"609 -249 CURVE SMOOTH",
+"609 -210 OFFCURVE",
+"595 -171 OFFCURVE",
+"578 -135 CURVE SMOOTH",
+"559 -96 OFFCURVE",
+"549 -74 OFFCURVE",
+"549 -51 CURVE SMOOTH",
+"549 -24 OFFCURVE",
+"561 1 OFFCURVE",
+"574 28 CURVE SMOOTH",
+"588 56 OFFCURVE",
+"601 87 OFFCURVE",
+"601 127 CURVE SMOOTH",
+"601 160 OFFCURVE",
+"592 195 OFFCURVE",
+"566 231 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"102 179 LINE",
+"119 146 OFFCURVE",
+"122 126 OFFCURVE",
+"122 102 CURVE SMOOTH",
+"122 80 OFFCURVE",
+"112 52 OFFCURVE",
+"101 27 CURVE SMOOTH",
+"84 -12 OFFCURVE",
+"76 -34 OFFCURVE",
+"76 -73 CURVE SMOOTH",
+"76 -97 OFFCURVE",
+"84 -126 OFFCURVE",
+"97 -155 CURVE SMOOTH",
+"109 -181 OFFCURVE",
+"127 -214 OFFCURVE",
+"127 -248 CURVE SMOOTH",
+"127 -281 OFFCURVE",
+"108 -308 OFFCURVE",
+"45 -308 CURVE SMOOTH",
+"-23 -308 OFFCURVE",
+"-106 -268 OFFCURVE",
+"-156 -231 CURVE",
+"-195 -284 LINE",
+"-130 -343 OFFCURVE",
+"-32 -381 OFFCURVE",
+"42 -381 CURVE SMOOTH",
+"138 -381 OFFCURVE",
+"199 -333 OFFCURVE",
+"199 -249 CURVE SMOOTH",
+"199 -217 OFFCURVE",
+"190 -181 OFFCURVE",
+"173 -143 CURVE SMOOTH",
+"155 -104 OFFCURVE",
+"148 -83 OFFCURVE",
+"148 -60 CURVE SMOOTH",
+"148 -33 OFFCURVE",
+"155 -16 OFFCURVE",
+"167 11 CURVE SMOOTH",
+"180 41 OFFCURVE",
+"195 78 OFFCURVE",
+"195 113 CURVE SMOOTH",
+"195 143 OFFCURVE",
+"189 182 OFFCURVE",
+"165 216 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"102 179 LINE",
+"119 146 OFFCURVE",
+"122 126 OFFCURVE",
+"122 102 CURVE SMOOTH",
+"122 80 OFFCURVE",
+"112 52 OFFCURVE",
+"101 27 CURVE SMOOTH",
+"84 -12 OFFCURVE",
+"76 -34 OFFCURVE",
+"76 -73 CURVE SMOOTH",
+"76 -97 OFFCURVE",
+"84 -127 OFFCURVE",
+"98 -156 CURVE SMOOTH",
+"123 -208 OFFCURVE",
+"127 -227 OFFCURVE",
+"127 -247 CURVE SMOOTH",
+"127 -280 OFFCURVE",
+"105 -308 OFFCURVE",
+"42 -308 CURVE SMOOTH",
+"-26 -308 OFFCURVE",
+"-106 -268 OFFCURVE",
+"-156 -231 CURVE",
+"-195 -284 LINE",
+"-130 -343 OFFCURVE",
+"-31 -381 OFFCURVE",
+"43 -381 CURVE SMOOTH",
+"139 -381 OFFCURVE",
+"199 -326 OFFCURVE",
+"199 -245 CURVE SMOOTH",
+"199 -213 OFFCURVE",
+"191 -180 OFFCURVE",
+"173 -143 CURVE SMOOTH",
+"154 -104 OFFCURVE",
+"148 -83 OFFCURVE",
+"148 -60 CURVE SMOOTH",
+"148 -33 OFFCURVE",
+"155 -16 OFFCURVE",
+"167 11 CURVE SMOOTH",
+"180 41 OFFCURVE",
+"195 78 OFFCURVE",
+"195 113 CURVE SMOOTH",
+"195 143 OFFCURVE",
+"189 182 OFFCURVE",
+"165 216 CURVE"
+);
+}
+);
+width = 258;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0723.loclSYRJ;
+lastChange = "2017-09-08 19:40:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{551, -98}";
+},
+{
+name = top;
+position = "{681, 477}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"529 0 LINE",
+"679 0 LINE",
+"794 0 LINE",
+"929 0 OFFCURVE",
+"1016 66 OFFCURVE",
+"1016 203 CURVE SMOOTH",
+"1016 322 OFFCURVE",
+"941 403 OFFCURVE",
+"827 403 CURVE SMOOTH",
+"767 403 OFFCURVE",
+"711 376 OFFCURVE",
+"682 320 CURVE",
+"679 320 LINE",
+"647 370 OFFCURVE",
+"592 399 OFFCURVE",
+"521 399 CURVE SMOOTH",
+"423 399 OFFCURVE",
+"336 335 OFFCURVE",
+"336 212 CURVE SMOOTH",
+"336 156 OFFCURVE",
+"352 113 OFFCURVE",
+"385 78 CURVE",
+"385 74 LINE",
+"364 76 OFFCURVE",
+"339 76 OFFCURVE",
+"324 76 CURVE SMOOTH",
+"287 76 LINE SMOOTH",
+"173 76 OFFCURVE",
+"127 125 OFFCURVE",
+"127 198 CURVE SMOOTH",
+"127 206 LINE",
+"61 202 LINE",
+"60 196 OFFCURVE",
+"59 175 OFFCURVE",
+"59 171 CURVE SMOOTH",
+"59 62 OFFCURVE",
+"142 0 OFFCURVE",
+"278 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 76 OFFCURVE",
+"407 138 OFFCURVE",
+"407 216 CURVE SMOOTH",
+"407 292 OFFCURVE",
+"462 326 OFFCURVE",
+"522 326 CURVE SMOOTH",
+"609 326 OFFCURVE",
+"652 266 OFFCURVE",
+"652 168 CURVE SMOOTH",
+"652 81 OFFCURVE",
+"587 76 OFFCURVE",
+"534 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"761 76 OFFCURVE",
+"708 95 OFFCURVE",
+"708 202 CURVE SMOOTH",
+"708 295 OFFCURVE",
+"773 330 OFFCURVE",
+"827 330 CURVE SMOOTH",
+"903 330 OFFCURVE",
+"945 285 OFFCURVE",
+"945 209 CURVE SMOOTH",
+"945 110 OFFCURVE",
+"875 76 OFFCURVE",
+"812 76 CURVE SMOOTH"
+);
+}
+);
+width = 1075;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0724.loclSYRJ;
+lastChange = "2017-09-08 19:40:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{381, -243}";
+},
+{
+name = top;
+position = "{404, 476}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"490 403 OFFCURVE",
+"434 376 OFFCURVE",
+"405 320 CURVE",
+"401 320 LINE",
+"370 370 OFFCURVE",
+"315 399 OFFCURVE",
+"244 399 CURVE SMOOTH",
+"146 399 OFFCURVE",
+"59 335 OFFCURVE",
+"59 212 CURVE SMOOTH",
+"59 91 OFFCURVE",
+"129 0 OFFCURVE",
+"283 0 CURVE SMOOTH",
+"367 0 LINE",
+"363 -57 OFFCURVE",
+"357 -118 OFFCURVE",
+"355 -159 CURVE",
+"421 -159 LINE",
+"427 -114 OFFCURVE",
+"433 -59 OFFCURVE",
+"437 0 CURVE",
+"517 0 LINE SMOOTH",
+"651 0 OFFCURVE",
+"739 66 OFFCURVE",
+"739 203 CURVE SMOOTH",
+"739 322 OFFCURVE",
+"664 403 OFFCURVE",
+"549 403 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 71 OFFCURVE",
+"130 138 OFFCURVE",
+"130 216 CURVE SMOOTH",
+"130 292 OFFCURVE",
+"185 326 OFFCURVE",
+"245 326 CURVE SMOOTH",
+"332 326 OFFCURVE",
+"375 266 OFFCURVE",
+"375 168 CURVE SMOOTH",
+"375 81 OFFCURVE",
+"310 71 OFFCURVE",
+"256 71 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"484 71 OFFCURVE",
+"431 95 OFFCURVE",
+"431 202 CURVE SMOOTH",
+"431 295 OFFCURVE",
+"496 330 OFFCURVE",
+"550 330 CURVE SMOOTH",
+"625 330 OFFCURVE",
+"668 285 OFFCURVE",
+"668 209 CURVE SMOOTH",
+"668 109 OFFCURVE",
+"597 71 OFFCURVE",
+"535 71 CURVE SMOOTH"
+);
+}
+);
+width = 797;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072B.loclSYRJ;
+lastChange = "2017-09-08 19:36:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{460, -98}";
+},
+{
+name = top;
+position = "{478, 452}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"179 -294 OFFCURVE",
+"147 -231 OFFCURVE",
+"147 -157 CURVE SMOOTH",
+"147 -150 LINE",
+"81 -154 LINE",
+"80 -159 OFFCURVE",
+"79 -181 OFFCURVE",
+"79 -184 CURVE SMOOTH",
+"79 -299 OFFCURVE",
+"153 -370 OFFCURVE",
+"270 -370 CURVE SMOOTH",
+"329 -370 OFFCURVE",
+"395 -360 OFFCURVE",
+"473 -330 CURVE",
+"528 -360 OFFCURVE",
+"593 -370 OFFCURVE",
+"629 -370 CURVE SMOOTH",
+"686 -370 OFFCURVE",
+"735 -351 OFFCURVE",
+"761 -326 CURVE",
+"729 -277 LINE",
+"715 -287 OFFCURVE",
+"700 -296 OFFCURVE",
+"676 -296 CURVE SMOOTH",
+"643 -296 OFFCURVE",
+"611 -279 OFFCURVE",
+"588 -254 CURVE",
+"610 -230 OFFCURVE",
+"624 -205 OFFCURVE",
+"624 -160 CURVE SMOOTH",
+"624 -74 OFFCURVE",
+"554 -19 OFFCURVE",
+"480 -19 CURVE SMOOTH",
+"382 -19 OFFCURVE",
+"323 -78 OFFCURVE",
+"323 -170 CURVE SMOOTH",
+"323 -203 OFFCURVE",
+"332 -229 OFFCURVE",
+"351 -256 CURVE",
+"343 -285 OFFCURVE",
+"301 -294 OFFCURVE",
+"270 -294 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 -80 OFFCURVE",
+"340 -128 OFFCURVE",
+"303 -291 CURVE",
+"292 -293 OFFCURVE",
+"262 -294 OFFCURVE",
+"242 -294 CURVE SMOOTH",
+"221 -294 OFFCURVE",
+"203 -309 OFFCURVE",
+"203 -332 CURVE SMOOTH",
+"203 -356 OFFCURVE",
+"221 -370 OFFCURVE",
+"242 -370 CURVE SMOOTH",
+"428 -370 LINE SMOOTH",
+"516 -370 OFFCURVE",
+"588 -367 OFFCURVE",
+"624 -334 CURVE",
+"627 -334 LINE",
+"664 -362 OFFCURVE",
+"718 -373 OFFCURVE",
+"750 -373 CURVE",
+"750 -297 LINE",
+"724 -297 OFFCURVE",
+"687 -288 OFFCURVE",
+"649 -243 CURVE SMOOTH",
+"591 -176 LINE SMOOTH",
+"539 -116 OFFCURVE",
+"503 -80 OFFCURVE",
+"451 -80 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 -370 LINE SMOOTH",
+"516 -370 OFFCURVE",
+"588 -367 OFFCURVE",
+"624 -334 CURVE",
+"627 -334 LINE",
+"664 -362 OFFCURVE",
+"718 -373 OFFCURVE",
+"750 -373 CURVE",
+"750 -297 LINE",
+"724 -297 OFFCURVE",
+"687 -288 OFFCURVE",
+"649 -243 CURVE SMOOTH",
+"591 -176 LINE SMOOTH",
+"539 -116 OFFCURVE",
+"503 -80 OFFCURVE",
+"451 -80 CURVE SMOOTH",
+"374 -80 OFFCURVE",
+"339 -129 OFFCURVE",
+"302 -294 CURVE",
+"257 -294 LINE SMOOTH",
+"166 -294 OFFCURVE",
+"127 -235 OFFCURVE",
+"127 -157 CURVE SMOOTH",
+"127 -150 LINE",
+"61 -154 LINE",
+"60 -159 OFFCURVE",
+"59 -181 OFFCURVE",
+"59 -184 CURVE SMOOTH",
+"59 -299 OFFCURVE",
+"127 -370 OFFCURVE",
+"280 -370 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 -261 LINE SMOOTH",
+"516 -261 OFFCURVE",
+"588 -258 OFFCURVE",
+"624 -225 CURVE",
+"627 -225 LINE",
+"664 -253 OFFCURVE",
+"718 -264 OFFCURVE",
+"750 -264 CURVE",
+"750 -188 LINE",
+"724 -188 OFFCURVE",
+"687 -179 OFFCURVE",
+"649 -134 CURVE SMOOTH",
+"591 -67 LINE SMOOTH",
+"539 -7 OFFCURVE",
+"503 29 OFFCURVE",
+"451 29 CURVE SMOOTH",
+"374 29 OFFCURVE",
+"339 -20 OFFCURVE",
+"302 -185 CURVE",
+"257 -185 LINE SMOOTH",
+"166 -185 OFFCURVE",
+"127 -126 OFFCURVE",
+"127 -48 CURVE SMOOTH",
+"127 -41 LINE",
+"61 -45 LINE",
+"60 -50 OFFCURVE",
+"59 -72 OFFCURVE",
+"59 -75 CURVE SMOOTH",
+"59 -190 OFFCURVE",
+"127 -261 OFFCURVE",
+"280 -261 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 0 LINE SMOOTH",
+"516 0 OFFCURVE",
+"588 3 OFFCURVE",
+"624 36 CURVE",
+"627 36 LINE",
+"664 8 OFFCURVE",
+"701 0 OFFCURVE",
+"723 0 CURVE",
+"723 76 LINE",
+"714 76 OFFCURVE",
+"687 82 OFFCURVE",
+"649 127 CURVE SMOOTH",
+"591 194 LINE SMOOTH",
+"539 254 OFFCURVE",
+"503 290 OFFCURVE",
+"451 290 CURVE SMOOTH",
+"374 290 OFFCURVE",
+"324 230 OFFCURVE",
+"318 76 CURVE",
+"257 76 LINE SMOOTH",
+"166 76 OFFCURVE",
+"127 135 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"127 0 OFFCURVE",
+"280 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 0 LINE SMOOTH",
+"516 0 OFFCURVE",
+"588 3 OFFCURVE",
+"624 36 CURVE",
+"627 36 LINE",
+"664 8 OFFCURVE",
+"701 0 OFFCURVE",
+"723 0 CURVE",
+"723 76 LINE",
+"714 76 OFFCURVE",
+"687 82 OFFCURVE",
+"649 127 CURVE SMOOTH",
+"591 194 LINE SMOOTH",
+"539 254 OFFCURVE",
+"503 290 OFFCURVE",
+"451 290 CURVE SMOOTH",
+"374 290 OFFCURVE",
+"324 230 OFFCURVE",
+"318 76 CURVE",
+"257 76 LINE SMOOTH",
+"166 76 OFFCURVE",
+"127 135 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"127 0 OFFCURVE",
+"280 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"428 0 LINE SMOOTH",
+"516 0 OFFCURVE",
+"588 3 OFFCURVE",
+"627 36 CURVE",
+"664 8 OFFCURVE",
+"718 -3 OFFCURVE",
+"750 -3 CURVE",
+"750 73 LINE",
+"724 73 OFFCURVE",
+"687 82 OFFCURVE",
+"649 127 CURVE SMOOTH",
+"591 194 LINE SMOOTH",
+"539 254 OFFCURVE",
+"503 290 OFFCURVE",
+"451 290 CURVE SMOOTH",
+"374 290 OFFCURVE",
+"324 230 OFFCURVE",
+"318 76 CURVE",
+"257 76 LINE SMOOTH",
+"166 76 OFFCURVE",
+"127 135 OFFCURVE",
+"127 213 CURVE SMOOTH",
+"127 220 LINE",
+"61 216 LINE",
+"60 211 OFFCURVE",
+"59 189 OFFCURVE",
+"59 186 CURVE SMOOTH",
+"59 71 OFFCURVE",
+"127 0 OFFCURVE",
+"280 0 CURVE SMOOTH"
+);
+}
+);
+width = 810;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072C.loclSYRJ;
+lastChange = "2017-09-08 19:39:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{342, 485}";
+},
+{
+name = RU;
+position = "{410, -60}";
+},
+{
+name = bottom;
+position = "{181, -98}";
+},
+{
+name = top;
+position = "{155, 685}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"117 597 LINE",
+"121 573 OFFCURVE",
+"129 497 OFFCURVE",
+"129 410 CURVE SMOOTH",
+"129 264 OFFCURVE",
+"115 121 OFFCURVE",
+"68 18 CURVE",
+"81 -24 LINE",
+"109 -19 OFFCURVE",
+"170 -15 OFFCURVE",
+"211 -15 CURVE SMOOTH",
+"229 -15 OFFCURVE",
+"292 -18 OFFCURVE",
+"327 -29 CURVE",
+"348 37 LINE",
+"312 57 OFFCURVE",
+"261 61 OFFCURVE",
+"231 61 CURVE SMOOTH",
+"217 61 OFFCURVE",
+"187 59 OFFCURVE",
+"152 49 CURVE",
+"150 52 LINE",
+"171 104 OFFCURVE",
+"204 230 OFFCURVE",
+"204 407 CURVE SMOOTH",
+"204 475 OFFCURVE",
+"203 540 OFFCURVE",
+"187 610 CURVE"
+);
+}
+);
+width = 396;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071B.loclSYRJ;
+lastChange = "2017-09-08 19:31:55 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{286, -381}";
+},
+{
+name = top;
+position = "{298, 690}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"88 228 LINE",
+"49 172 LINE",
+"83 119 OFFCURVE",
+"123 83 OFFCURVE",
+"174 56 CURVE",
+"140 2 OFFCURVE",
+"117 -58 OFFCURVE",
+"117 -134 CURVE SMOOTH",
+"117 -244 OFFCURVE",
+"189 -316 OFFCURVE",
+"290 -316 CURVE SMOOTH",
+"393 -316 OFFCURVE",
+"473 -248 OFFCURVE",
+"473 -127 CURVE SMOOTH",
+"473 -7 OFFCURVE",
+"394 41 OFFCURVE",
+"282 89 CURVE",
+"313 133 OFFCURVE",
+"347 176 OFFCURVE",
+"376 221 CURVE SMOOTH",
+"448 334 OFFCURVE",
+"464 437 OFFCURVE",
+"464 490 CURVE SMOOTH",
+"464 554 OFFCURVE",
+"454 602 OFFCURVE",
+"401 655 CURVE",
+"397 655 LINE",
+"349 594 LINE",
+"380 559 OFFCURVE",
+"391 527 OFFCURVE",
+"391 484 CURVE SMOOTH",
+"391 424 OFFCURVE",
+"360 338 OFFCURVE",
+"313 258 CURVE SMOOTH",
+"280 204 OFFCURVE",
+"248 160 OFFCURVE",
+"218 119 CURVE",
+"175 137 OFFCURVE",
+"119 190 OFFCURVE",
+"93 228 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 -200 OFFCURVE",
+"356 -243 OFFCURVE",
+"292 -243 CURVE SMOOTH",
+"221 -243 OFFCURVE",
+"187 -185 OFFCURVE",
+"187 -124 CURVE SMOOTH",
+"187 -69 OFFCURVE",
+"209 -18 OFFCURVE",
+"240 27 CURVE",
+"333 -12 OFFCURVE",
+"402 -44 OFFCURVE",
+"402 -125 CURVE SMOOTH"
+);
+}
+);
+width = 526;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071C.loclSYRJ;
+lastChange = "2017-09-08 19:32:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{288, -381}";
+},
+{
+name = top;
+position = "{299, 689}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"254 -143 OFFCURVE",
+"270 -157 OFFCURVE",
+"292 -157 CURVE SMOOTH",
+"312 -157 OFFCURVE",
+"329 -143 OFFCURVE",
+"329 -116 CURVE SMOOTH",
+"329 -89 OFFCURVE",
+"312 -75 OFFCURVE",
+"292 -75 CURVE SMOOTH",
+"270 -75 OFFCURVE",
+"254 -89 OFFCURVE",
+"254 -116 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"88 228 LINE",
+"49 172 LINE",
+"83 119 OFFCURVE",
+"123 83 OFFCURVE",
+"174 56 CURVE",
+"140 2 OFFCURVE",
+"117 -58 OFFCURVE",
+"117 -134 CURVE SMOOTH",
+"117 -244 OFFCURVE",
+"189 -316 OFFCURVE",
+"290 -316 CURVE SMOOTH",
+"393 -316 OFFCURVE",
+"473 -248 OFFCURVE",
+"473 -127 CURVE SMOOTH",
+"473 -7 OFFCURVE",
+"394 41 OFFCURVE",
+"282 89 CURVE",
+"313 133 OFFCURVE",
+"347 176 OFFCURVE",
+"376 221 CURVE SMOOTH",
+"448 334 OFFCURVE",
+"464 437 OFFCURVE",
+"464 490 CURVE SMOOTH",
+"464 554 OFFCURVE",
+"454 602 OFFCURVE",
+"401 655 CURVE",
+"397 655 LINE",
+"349 594 LINE",
+"380 559 OFFCURVE",
+"391 527 OFFCURVE",
+"391 484 CURVE SMOOTH",
+"391 424 OFFCURVE",
+"360 338 OFFCURVE",
+"313 258 CURVE SMOOTH",
+"280 204 OFFCURVE",
+"248 160 OFFCURVE",
+"218 119 CURVE",
+"175 137 OFFCURVE",
+"119 190 OFFCURVE",
+"93 228 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 -200 OFFCURVE",
+"356 -243 OFFCURVE",
+"292 -243 CURVE SMOOTH",
+"221 -243 OFFCURVE",
+"187 -185 OFFCURVE",
+"187 -124 CURVE SMOOTH",
+"187 -69 OFFCURVE",
+"209 -18 OFFCURVE",
+"240 27 CURVE",
+"333 -12 OFFCURVE",
+"402 -44 OFFCURVE",
+"402 -125 CURVE SMOOTH"
+);
+}
+);
+width = 526;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0718.loclSYRJ;
+lastChange = "2017-09-08 19:32:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{254, -98}";
+},
+{
+name = top;
+position = "{264, 507}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"137 408 OFFCURVE",
+"45 335 OFFCURVE",
+"45 212 CURVE SMOOTH",
+"45 91 OFFCURVE",
+"133 0 OFFCURVE",
+"256 0 CURVE SMOOTH",
+"377 0 OFFCURVE",
+"468 69 OFFCURVE",
+"468 196 CURVE SMOOTH",
+"468 314 OFFCURVE",
+"377 408 OFFCURVE",
+"246 408 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"170 76 OFFCURVE",
+"118 138 OFFCURVE",
+"118 216 CURVE SMOOTH",
+"118 291 OFFCURVE",
+"177 335 OFFCURVE",
+"246 335 CURVE SMOOTH",
+"337 335 OFFCURVE",
+"395 275 OFFCURVE",
+"395 198 CURVE SMOOTH",
+"395 113 OFFCURVE",
+"334 76 OFFCURVE",
+"265 76 CURVE SMOOTH"
+);
+}
+);
+width = 518;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071D.loclSYRJ;
+lastChange = "2017-09-08 19:32:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{272, -98}";
+},
+{
+name = top;
+position = "{318, 341}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1114 69 OFFCURVE",
+"1096 54 OFFCURVE",
+"1096 31 CURVE SMOOTH",
+"1096 7 OFFCURVE",
+"1114 -7 OFFCURVE",
+"1135 -7 CURVE SMOOTH",
+"1172 -7 LINE SMOOTH",
+"1223 -7 OFFCURVE",
+"1263 -7 OFFCURVE",
+"1299 -1 CURVE SMOOTH",
+"1357 10 OFFCURVE",
+"1386 52 OFFCURVE",
+"1386 104 CURVE SMOOTH",
+"1386 149 OFFCURVE",
+"1372 213 OFFCURVE",
+"1328 213 CURVE SMOOTH",
+"1299 213 OFFCURVE",
+"1286 204 OFFCURVE",
+"1273 175 CURVE SMOOTH",
+"1263 150 OFFCURVE",
+"1250 101 OFFCURVE",
+"1244 72 CURVE",
+"1226 70 OFFCURVE",
+"1204 69 OFFCURVE",
+"1135 69 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1114 69 OFFCURVE",
+"1096 54 OFFCURVE",
+"1096 31 CURVE SMOOTH",
+"1096 7 OFFCURVE",
+"1114 -7 OFFCURVE",
+"1135 -7 CURVE SMOOTH",
+"1172 -7 LINE SMOOTH",
+"1223 -7 OFFCURVE",
+"1263 -7 OFFCURVE",
+"1299 -1 CURVE SMOOTH",
+"1357 10 OFFCURVE",
+"1386 52 OFFCURVE",
+"1386 104 CURVE SMOOTH",
+"1386 149 OFFCURVE",
+"1372 213 OFFCURVE",
+"1328 213 CURVE SMOOTH",
+"1299 213 OFFCURVE",
+"1286 204 OFFCURVE",
+"1273 175 CURVE SMOOTH",
+"1263 150 OFFCURVE",
+"1250 101 OFFCURVE",
+"1244 72 CURVE",
+"1226 70 OFFCURVE",
+"1204 69 OFFCURVE",
+"1135 69 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 204 LINE",
+"609 199 OFFCURVE",
+"609 185 OFFCURVE",
+"609 181 CURVE SMOOTH",
+"609 54 OFFCURVE",
+"677 -7 OFFCURVE",
+"831 -7 CURVE SMOOTH",
+"882 -7 OFFCURVE",
+"918 -7 OFFCURVE",
+"954 0 CURVE SMOOTH",
+"1012 11 OFFCURVE",
+"1041 52 OFFCURVE",
+"1041 105 CURVE SMOOTH",
+"1041 149 OFFCURVE",
+"1027 210 OFFCURVE",
+"983 210 CURVE SMOOTH",
+"954 210 OFFCURVE",
+"940 201 OFFCURVE",
+"928 172 CURVE SMOOTH",
+"918 148 OFFCURVE",
+"904 101 OFFCURVE",
+"899 72 CURVE",
+"881 70 OFFCURVE",
+"859 69 OFFCURVE",
+"823 69 CURVE SMOOTH",
+"720 69 OFFCURVE",
+"677 118 OFFCURVE",
+"675 208 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 -7 LINE SMOOTH",
+"417 -7 OFFCURVE",
+"486 35 OFFCURVE",
+"486 114 CURVE SMOOTH",
+"486 157 OFFCURVE",
+"470 203 OFFCURVE",
+"435 203 CURVE SMOOTH",
+"416 203 OFFCURVE",
+"400 196 OFFCURVE",
+"388 168 CURVE SMOOTH",
+"377 143 OFFCURVE",
+"356 86 OFFCURVE",
+"349 72 CURVE",
+"331 70 OFFCURVE",
+"320 69 OFFCURVE",
+"251 69 CURVE SMOOTH",
+"230 69 OFFCURVE",
+"212 54 OFFCURVE",
+"212 31 CURVE SMOOTH",
+"212 7 OFFCURVE",
+"230 -7 OFFCURVE",
+"251 -7 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"331 70 OFFCURVE",
+"318 69 OFFCURVE",
+"282 69 CURVE SMOOTH",
+"179 69 OFFCURVE",
+"127 113 OFFCURVE",
+"125 198 CURVE",
+"61 194 LINE",
+"59 189 OFFCURVE",
+"59 175 OFFCURVE",
+"59 171 CURVE SMOOTH",
+"59 79 OFFCURVE",
+"113 -7 OFFCURVE",
+"267 -7 CURVE SMOOTH",
+"304 -7 OFFCURVE",
+"356 -6 OFFCURVE",
+"383 0 CURVE SMOOTH",
+"456 16 OFFCURVE",
+"486 56 OFFCURVE",
+"486 114 CURVE SMOOTH",
+"486 157 OFFCURVE",
+"470 203 OFFCURVE",
+"435 203 CURVE SMOOTH",
+"416 203 OFFCURVE",
+"400 196 OFFCURVE",
+"388 168 CURVE SMOOTH",
+"377 143 OFFCURVE",
+"356 86 OFFCURVE",
+"349 72 CURVE"
+);
+}
+);
+width = 559;
+}
+);
+},
+{
+color = 5;
+glyphname = uni071E.loclSYRJ;
+lastChange = "2017-09-08 19:32:39 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"264 570 OFFCURVE",
+"284 554 OFFCURVE",
+"313 554 CURVE SMOOTH",
+"346 554 OFFCURVE",
+"365 573 OFFCURVE",
+"365 610 CURVE SMOOTH",
+"365 647 OFFCURVE",
+"346 667 OFFCURVE",
+"313 667 CURVE SMOOTH",
+"282 667 OFFCURVE",
+"264 647 OFFCURVE",
+"264 610 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"338 709 OFFCURVE",
+"358 693 OFFCURVE",
+"387 693 CURVE SMOOTH",
+"420 693 OFFCURVE",
+"439 712 OFFCURVE",
+"439 749 CURVE SMOOTH",
+"439 786 OFFCURVE",
+"420 806 OFFCURVE",
+"387 806 CURVE SMOOTH",
+"356 806 OFFCURVE",
+"338 786 OFFCURVE",
+"338 749 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 570 OFFCURVE",
+"431 554 OFFCURVE",
+"460 554 CURVE SMOOTH",
+"493 554 OFFCURVE",
+"512 573 OFFCURVE",
+"512 610 CURVE SMOOTH",
+"512 647 OFFCURVE",
+"493 667 OFFCURVE",
+"460 667 CURVE SMOOTH",
+"429 667 OFFCURVE",
+"411 647 OFFCURVE",
+"411 610 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-362 500 OFFCURVE",
+"-487 419 OFFCURVE",
+"-487 254 CURVE SMOOTH",
+"-487 84 OFFCURVE",
+"-362 -5 OFFCURVE",
+"-230 -5 CURVE SMOOTH",
+"-99 -5 OFFCURVE",
+"-20 61 OFFCURVE",
+"20 157 CURVE",
+"56 207 OFFCURVE",
+"85 247 OFFCURVE",
+"98 279 CURVE",
+"102 278 LINE",
+"101 214 OFFCURVE",
+"92 83 OFFCURVE",
+"77 11 CURVE",
+"228 -12 LINE",
+"233 10 OFFCURVE",
+"238 33 OFFCURVE",
+"242 57 CURVE",
+"246 57 LINE",
+"265 32 OFFCURVE",
+"302 0 OFFCURVE",
+"363 0 CURVE",
+"363 165 LINE",
+"309 165 OFFCURVE",
+"275 174 OFFCURVE",
+"257 200 CURVE",
+"258 219 OFFCURVE",
+"258 239 OFFCURVE",
+"258 258 CURVE SMOOTH",
+"258 316 OFFCURVE",
+"247 422 OFFCURVE",
+"218 491 CURVE",
+"85 473 LINE",
+"80 456 OFFCURVE",
+"43 391 OFFCURVE",
+"15 350 CURVE",
+"11 350 LINE",
+"-34 456 OFFCURVE",
+"-134 500 OFFCURVE",
+"-243 500 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-287 165 OFFCURVE",
+"-329 204 OFFCURVE",
+"-329 254 CURVE SMOOTH",
+"-329 306 OFFCURVE",
+"-289 330 OFFCURVE",
+"-235 330 CURVE SMOOTH",
+"-157 330 OFFCURVE",
+"-112 289 OFFCURVE",
+"-112 245 CURVE SMOOTH",
+"-112 193 OFFCURVE",
+"-158 165 OFFCURVE",
+"-215 165 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-203 -248 OFFCURVE",
+"-160 -275 OFFCURVE",
+"-115 -275 CURVE SMOOTH",
+"-66 -275 OFFCURVE",
+"-22 -249 OFFCURVE",
+"-22 -174 CURVE SMOOTH",
+"-22 -96 OFFCURVE",
+"-66 -72 OFFCURVE",
+"-115 -72 CURVE SMOOTH",
+"-161 -72 OFFCURVE",
+"-203 -98 OFFCURVE",
+"-203 -174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 165 OFFCURVE",
+"323 131 OFFCURVE",
+"323 82 CURVE SMOOTH",
+"323 32 OFFCURVE",
+"339 0 OFFCURVE",
+"363 0 CURVE SMOOTH",
+"404 0 LINE SMOOTH",
+"499 0 OFFCURVE",
+"535 6 OFFCURVE",
+"569 12 CURVE SMOOTH",
+"636 24 OFFCURVE",
+"687 83 OFFCURVE",
+"687 163 CURVE SMOOTH",
+"687 242 OFFCURVE",
+"659 325 OFFCURVE",
+"588 325 CURVE SMOOTH",
+"542 325 OFFCURVE",
+"522 302 OFFCURVE",
+"507 269 CURVE SMOOTH",
+"496 244 OFFCURVE",
+"486 196 OFFCURVE",
+"482 168 CURVE",
+"454 165 OFFCURVE",
+"416 165 OFFCURVE",
+"363 165 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-254 573 OFFCURVE",
+"-221 552 OFFCURVE",
+"-185 552 CURVE SMOOTH",
+"-145 552 OFFCURVE",
+"-111 572 OFFCURVE",
+"-111 628 CURVE SMOOTH",
+"-111 687 OFFCURVE",
+"-145 706 OFFCURVE",
+"-185 706 CURVE SMOOTH",
+"-221 706 OFFCURVE",
+"-254 686 OFFCURVE",
+"-254 628 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-77 573 OFFCURVE",
+"-44 552 OFFCURVE",
+"-8 552 CURVE SMOOTH",
+"32 552 OFFCURVE",
+"66 572 OFFCURVE",
+"66 628 CURVE SMOOTH",
+"66 687 OFFCURVE",
+"32 706 OFFCURVE",
+"-8 706 CURVE SMOOTH",
+"-44 706 OFFCURVE",
+"-77 686 OFFCURVE",
+"-77 628 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-151 729 OFFCURVE",
+"-124 714 OFFCURVE",
+"-96 714 CURVE SMOOTH",
+"-63 714 OFFCURVE",
+"-36 729 OFFCURVE",
+"-36 774 CURVE SMOOTH",
+"-36 821 OFFCURVE",
+"-63 836 OFFCURVE",
+"-96 836 CURVE SMOOTH",
+"-124 836 OFFCURVE",
+"-151 820 OFFCURVE",
+"-151 774 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = uni071D.loclSYRJ.Init;
+transform = "{1, 0, 0, 1, 742, 0}";
+},
+{
+name = uni0717.loclSYRJ.Fina;
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 388, -213}";
+},
+{
+name = Dot11.loclSYRJ;
+transform = "{1, 0, 0, 1, 460, 551}";
+},
+{
+name = Dot11.loclSYRJ;
+transform = "{1, 0, 0, 1, 313, 551}";
+},
+{
+name = Dot111.loclSYRJ;
+transform = "{1, 0, 0, 1, 387, 690}";
+}
+);
+layerId = UUID0;
+width = 1050;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0719.loclSYRJ;
+lastChange = "2017-09-08 19:32:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{109, -195}";
+},
+{
+name = top;
+position = "{134, 537}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 416 LINE",
+"98 141 LINE SMOOTH",
+"98 40 OFFCURVE",
+"83 -29 OFFCURVE",
+"63 -64 CURVE",
+"123 -94 LINE",
+"158 -50 OFFCURVE",
+"171 31 OFFCURVE",
+"171 142 CURVE SMOOTH",
+"171 416 LINE"
+);
+}
+);
+width = 264;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0710.loclSYRN;
+lastChange = "2017-09-08 19:30:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{183, -98}";
+}
+);
+hints = (
+{
+place = "{194, 72}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{601, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"312 0 LINE",
+"312 76 LINE",
+"222 76 LINE",
+"171 75 LINE",
+"163 74 OFFCURVE",
+"157 74 OFFCURVE",
+"154 74 CURVE",
+"154 78 LINE",
+"188 124 OFFCURVE",
+"215 177 OFFCURVE",
+"235 237 CURVE SMOOTH",
+"256 297 OFFCURVE",
+"266 356 OFFCURVE",
+"266 413 CURVE SMOOTH",
+"266 545 OFFCURVE",
+"222 593 OFFCURVE",
+"133 601 CURVE",
+"99 530 LINE",
+"171 497 LINE",
+"186 480 OFFCURVE",
+"194 438 OFFCURVE",
+"194 403 CURVE SMOOTH",
+"194 347 OFFCURVE",
+"182 288 OFFCURVE",
+"157 227 CURVE SMOOTH",
+"133 166 OFFCURVE",
+"101 110 OFFCURVE",
+"60 60 CURVE",
+"58 0 LINE"
+);
+}
+);
+width = 371;
+}
+);
+leftKerningGroup = uni0710;
+rightKerningGroup = uni0710;
+},
+{
+color = 7;
+glyphname = uni0712.loclSYRN;
+lastChange = "2017-09-08 19:32:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{712, -81}";
+}
+);
+hints = (
+{
+place = "{634, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"668 0 LINE",
+"708 54 LINE",
+"708 426 LINE",
+"484 426 LINE SMOOTH",
+"446 426 OFFCURVE",
+"410 427 OFFCURVE",
+"375 430 CURVE SMOOTH",
+"341 433 OFFCURVE",
+"318 435 OFFCURVE",
+"306 438 CURVE",
+"306 367 LINE",
+"335 359 OFFCURVE",
+"412 353 OFFCURVE",
+"489 353 CURVE SMOOTH",
+"634 353 LINE",
+"634 76 LINE"
+);
+}
+);
+width = 776;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072D.loclSYRN;
+lastChange = "2017-09-08 19:39:42 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{392, -98}";
+}
+);
+hints = (
+{
+place = "{634, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{632, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"349 360 LINE",
+"370 355 OFFCURVE",
+"414 353 OFFCURVE",
+"471 353 CURVE SMOOTH",
+"516 353 LINE",
+"634 353 LINE",
+"634 76 LINE",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"668 0 LINE",
+"708 54 LINE",
+"708 426 LINE",
+"518 426 LINE",
+"470 425 LINE SMOOTH",
+"449 425 OFFCURVE",
+"429 423 OFFCURVE",
+"421 423 CURVE",
+"421 427 LINE",
+"459 464 LINE",
+"479 484 LINE",
+"498 503 LINE",
+"575 587 LINE",
+"516 632 LINE",
+"324 414 LINE"
+);
+}
+);
+width = 776;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0715.loclSYRN;
+lastChange = "2017-09-08 19:32:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{475, -81}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 259, -195}";
+},
+{
+name = uni0716.loclSYRN;
+}
+);
+layerId = UUID0;
+width = 521;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni0716.loclSYRN;
+lastChange = "2017-09-08 19:32:55 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{475, -82}";
+}
+);
+hints = (
+{
+place = "{378, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{356, 74}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"451 0 LINE",
+"452 12 OFFCURVE",
+"452 24 OFFCURVE",
+"452 37 CURVE SMOOTH",
+"452 72 LINE SMOOTH",
+"452 320 OFFCURVE",
+"375 430 OFFCURVE",
+"211 430 CURVE SMOOTH",
+"163 430 OFFCURVE",
+"119 418 OFFCURVE",
+"90 399 CURVE",
+"90 331 LINE",
+"133 350 OFFCURVE",
+"169 356 OFFCURVE",
+"202 356 CURVE SMOOTH",
+"321 356 OFFCURVE",
+"378 272 OFFCURVE",
+"378 76 CURVE",
+"78 76 LINE",
+"78 0 LINE"
+);
+}
+);
+width = 521;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni072F.loclSYRN;
+lastChange = "2017-09-08 19:39:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{437, -98}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 97, -12}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 187, -176}";
+},
+{
+name = uni0716.loclSYRN;
+transform = "{1, 0, 0, 1, 173, 0}";
+}
+);
+layerId = UUID0;
+width = 694;
+}
+);
+rightKerningGroup = uni072F;
+},
+{
+color = 7;
+glyphname = uni0725.loclSYRN;
+lastChange = "2017-09-08 19:39:47 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{366, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{-5, 81}";
+},
+{
+horizontal = 1;
+place = "{515, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"534 0 LINE",
+"553 46 LINE",
+"555 46 LINE",
+"584 13 OFFCURVE",
+"615 -5 OFFCURVE",
+"663 -5 CURVE SMOOTH",
+"715 -5 OFFCURVE",
+"764 25 OFFCURVE",
+"785 82 CURVE",
+"748 131 LINE",
+"745 131 LINE",
+"728 95 OFFCURVE",
+"702 71 OFFCURVE",
+"666 71 CURVE SMOOTH",
+"651 71 OFFCURVE",
+"637 75 OFFCURVE",
+"624 84 CURVE SMOOTH",
+"611 93 OFFCURVE",
+"591 118 OFFCURVE",
+"564 159 CURVE",
+"316 515 LINE",
+"251 471 LINE",
+"492 125 LINE SMOOTH",
+"503 108 OFFCURVE",
+"519 88 OFFCURVE",
+"531 76 CURVE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH"
+);
+}
+);
+width = 833;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074F.loclSYRN;
+lastChange = "2017-09-08 19:39:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{324, -97}";
+}
+);
+hints = (
+{
+place = "{471, 97}";
+},
+{
+place = "{568, 48}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{377, 44}";
+},
+{
+horizontal = 1;
+place = "{-3, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{500, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"428 0 LINE",
+"503 0 OFFCURVE",
+"539 14 OFFCURVE",
+"556 38 CURVE",
+"559 38 LINE",
+"584 -3 LINE",
+"647 40 LINE",
+"524 229 LINE",
+"526 231 LINE",
+"578 234 OFFCURVE",
+"616 271 OFFCURVE",
+"616 327 CURVE SMOOTH",
+"616 384 OFFCURVE",
+"577 421 OFFCURVE",
+"520 421 CURVE SMOOTH",
+"481 421 OFFCURVE",
+"453 404 OFFCURVE",
+"437 372 CURVE",
+"433 372 LINE",
+"351 500 LINE",
+"289 458 LINE",
+"519 100 LINE",
+"511 83 OFFCURVE",
+"486 76 OFFCURVE",
+"438 76 CURVE SMOOTH",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 358 OFFCURVE",
+"491 377 OFFCURVE",
+"520 377 CURVE SMOOTH",
+"548 377 OFFCURVE",
+"568 358 OFFCURVE",
+"568 326 CURVE SMOOTH",
+"568 293 OFFCURVE",
+"548 274 OFFCURVE",
+"520 274 CURVE SMOOTH",
+"492 274 OFFCURVE",
+"471 293 OFFCURVE",
+"471 326 CURVE SMOOTH"
+);
+}
+);
+width = 696;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0713.loclSYRN;
+lastChange = "2017-09-08 19:32:59 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{655, -91}";
+}
+);
+hints = (
+{
+place = "{810, 96}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"810 -240 LINE",
+"906 -240 LINE",
+"906 -141 LINE",
+"860 -141 LINE",
+"429 693 LINE",
+"358 659 LINE",
+"659 76 LINE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"731 0 LINE",
+"810 -152 LINE"
+);
+}
+);
+width = 833;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+color = 7;
+glyphname = uni0714.loclSYRN;
+lastChange = "2017-09-08 19:33:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{655, -91}";
+}
+);
+components = (
+{
+name = uni0713.loclSYRN;
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 456, 139}";
+}
+);
+layerId = UUID0;
+width = 833;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+color = 7;
+glyphname = uni072E.loclSYRN;
+lastChange = "2017-09-08 19:39:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{433, -98}";
+}
+);
+hints = (
+{
+place = "{630, 71}";
+},
+{
+place = "{810, 96}";
+},
+{
+horizontal = 1;
+place = "{432, 59}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-240, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"810 -240 LINE",
+"906 -240 LINE",
+"906 -141 LINE",
+"860 -141 LINE",
+"561 436 LINE",
+"564 437 LINE",
+"575 433 OFFCURVE",
+"588 432 OFFCURVE",
+"597 432 CURVE SMOOTH",
+"664 432 OFFCURVE",
+"701 476 OFFCURVE",
+"701 540 CURVE SMOOTH",
+"701 569 OFFCURVE",
+"690 600 OFFCURVE",
+"674 632 CURVE SMOOTH",
+"642 693 LINE",
+"579 660 LINE",
+"612 598 LINE SMOOTH",
+"624 575 OFFCURVE",
+"630 554 OFFCURVE",
+"630 537 CURVE SMOOTH",
+"630 508 OFFCURVE",
+"608 491 OFFCURVE",
+"577 491 CURVE SMOOTH",
+"542 491 OFFCURVE",
+"525 508 OFFCURVE",
+"510 535 CURVE",
+"429 693 LINE",
+"358 659 LINE",
+"659 76 LINE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"731 0 LINE",
+"810 -152 LINE"
+);
+}
+);
+width = 833;
+}
+);
+leftKerningGroup = uni0713;
+},
+{
+color = 7;
+glyphname = uni0717.loclSYRN;
+lastChange = "2017-09-08 19:33:05 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{398, -98}";
+}
+);
+hints = (
+{
+place = "{68, 74}";
+},
+{
+place = "{409, 69}";
+},
+{
+place = "{619, 68}";
+},
+{
+horizontal = 1;
+place = "{-1, 75}";
+},
+{
+horizontal = 1;
+place = "{354, 72}";
+},
+{
+horizontal = 1;
+place = "{-30, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{434, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"224 426 LINE",
+"177 426 OFFCURVE",
+"140 406 OFFCURVE",
+"111 366 CURVE SMOOTH",
+"82 327 OFFCURVE",
+"68 280 OFFCURVE",
+"68 226 CURVE SMOOTH",
+"68 159 OFFCURVE",
+"86 104 OFFCURVE",
+"122 62 CURVE SMOOTH",
+"159 20 OFFCURVE",
+"207 -1 OFFCURVE",
+"267 -1 CURVE SMOOTH",
+"338 -1 OFFCURVE",
+"390 20 OFFCURVE",
+"425 63 CURVE SMOOTH",
+"460 106 OFFCURVE",
+"478 182 OFFCURVE",
+"478 290 CURVE SMOOTH",
+"478 307 OFFCURVE",
+"475 333 OFFCURVE",
+"472 353 CURVE",
+"619 356 LINE",
+"619 -30 LINE",
+"687 -30 LINE",
+"687 434 LINE",
+"678 431 OFFCURVE",
+"651 429 OFFCURVE",
+"606 428 CURVE SMOOTH",
+"561 427 OFFCURVE",
+"514 426 OFFCURVE",
+"465 426 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"403 353 LINE",
+"407 336 OFFCURVE",
+"409 312 OFFCURVE",
+"409 292 CURVE SMOOTH",
+"409 230 OFFCURVE",
+"404 185 OFFCURVE",
+"395 157 CURVE SMOOTH",
+"386 129 OFFCURVE",
+"372 108 OFFCURVE",
+"352 94 CURVE SMOOTH",
+"332 81 OFFCURVE",
+"306 74 OFFCURVE",
+"275 74 CURVE SMOOTH",
+"188 74 OFFCURVE",
+"142 129 OFFCURVE",
+"142 233 CURVE SMOOTH",
+"142 301 OFFCURVE",
+"181 353 OFFCURVE",
+"229 353 CURVE SMOOTH"
+);
+}
+);
+width = 755;
+}
+);
+rightKerningGroup = uni0717;
+},
+{
+color = 7;
+glyphname = uni071A.loclSYRN;
+lastChange = "2017-09-08 19:33:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{580, -98}";
+}
+);
+hints = (
+{
+place = "{403, 60}";
+},
+{
+place = "{620, 58}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-9, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{237, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"460 0 LINE",
+"466 148 LINE",
+"468 148 LINE",
+"496 116 LINE SMOOTH",
+"545 61 OFFCURVE",
+"578 27 OFFCURVE",
+"593 15 CURVE",
+"609 4 OFFCURVE",
+"626 -2 OFFCURVE",
+"645 -2 CURVE SMOOTH",
+"656 -2 OFFCURVE",
+"668 -1 OFFCURVE",
+"676 0 CURVE",
+"681 146 LINE",
+"683 146 LINE",
+"820 -9 LINE",
+"876 38 LINE",
+"683 237 LINE",
+"623 237 LINE",
+"617 83 LINE",
+"612 86 OFFCURVE",
+"607 91 OFFCURVE",
+"600 98 CURVE SMOOTH",
+"578 119 LINE SMOOTH",
+"562 134 OFFCURVE",
+"546 151 OFFCURVE",
+"535 164 CURVE SMOOTH",
+"468 237 LINE",
+"407 237 LINE",
+"400 76 LINE",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH"
+);
+}
+);
+width = 939;
+}
+);
+leftKerningGroup = uni071A;
+},
+{
+color = 7;
+glyphname = uni071F.loclSYRN;
+lastChange = "2017-09-08 19:33:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{538, -331}";
+}
+);
+hints = (
+{
+place = "{546, 77}";
+},
+{
+horizontal = 1;
+place = "{172, 74}";
+},
+{
+horizontal = 1;
+place = "{372, 73}";
+},
+{
+horizontal = 1;
+place = "{-339, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"299 0 LINE",
+"340 121 OFFCURVE",
+"386 172 OFFCURVE",
+"447 172 CURVE SMOOTH",
+"510 172 OFFCURVE",
+"546 134 OFFCURVE",
+"546 67 CURVE SMOOTH",
+"546 20 OFFCURVE",
+"530 -32 OFFCURVE",
+"499 -87 CURVE SMOOTH",
+"468 -143 OFFCURVE",
+"416 -212 OFFCURVE",
+"343 -295 CURVE",
+"393 -339 LINE",
+"544 -186 OFFCURVE",
+"623 -48 OFFCURVE",
+"623 72 CURVE SMOOTH",
+"623 184 OFFCURVE",
+"558 246 OFFCURVE",
+"449 246 CURVE SMOOTH",
+"370 246 OFFCURVE",
+"309 193 OFFCURVE",
+"274 101 CURVE",
+"270 101 LINE",
+"258 122 OFFCURVE",
+"242 151 OFFCURVE",
+"229 178 CURVE SMOOTH",
+"184 265 LINE",
+"167 298 LINE",
+"157 319 LINE",
+"154 329 LINE",
+"152 332 OFFCURVE",
+"151 335 OFFCURVE",
+"151 338 CURVE SMOOTH",
+"151 347 OFFCURVE",
+"155 359 OFFCURVE",
+"163 372 CURVE",
+"420 372 LINE",
+"420 445 LINE",
+"115 445 LINE",
+"68 335 LINE",
+"84 297 OFFCURVE",
+"110 245 OFFCURVE",
+"145 179 CURVE SMOOTH",
+"181 113 OFFCURVE",
+"215 53 OFFCURVE",
+"248 0 CURVE"
+);
+}
+);
+width = 691;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074E.loclSYRN;
+lastChange = "2017-09-08 19:39:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{392, -96}";
+}
+);
+hints = (
+{
+place = "{490, 75}";
+},
+{
+place = "{634, 74}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{654, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"668 0 LINE",
+"708 54 LINE",
+"708 426 LINE",
+"600 426 LINE SMOOTH",
+"577 426 OFFCURVE",
+"555 425 OFFCURVE",
+"532 424 CURVE",
+"530 427 LINE",
+"553 442 OFFCURVE",
+"565 472 OFFCURVE",
+"565 505 CURVE SMOOTH",
+"565 562 OFFCURVE",
+"531 601 OFFCURVE",
+"451 629 CURVE SMOOTH",
+"376 654 LINE",
+"354 586 LINE",
+"421 564 LINE SMOOTH",
+"469 548 OFFCURVE",
+"490 531 OFFCURVE",
+"490 491 CURVE SMOOTH",
+"490 450 OFFCURVE",
+"471 427 OFFCURVE",
+"411 427 CURVE SMOOTH",
+"402 427 OFFCURVE",
+"384 427 OFFCURVE",
+"364 430 CURVE",
+"334 432 LINE SMOOTH",
+"323 433 OFFCURVE",
+"314 435 OFFCURVE",
+"307 436 CURVE",
+"307 364 LINE",
+"330 359 OFFCURVE",
+"400 353 OFFCURVE",
+"489 353 CURVE SMOOTH",
+"634 353 LINE",
+"634 76 LINE"
+);
+}
+);
+width = 776;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0720.loclSYRN;
+lastChange = "2017-09-08 19:36:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{396, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"705 0 LINE",
+"751 69 LINE",
+"429 693 LINE",
+"358 659 LINE",
+"659 76 LINE"
+);
+}
+);
+width = 800;
+}
+);
+leftKerningGroup = uni0720;
+},
+{
+color = 7;
+glyphname = uni0721.loclSYRN;
+lastChange = "2017-09-08 19:36:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{435, -99}";
+}
+);
+hints = (
+{
+place = "{563, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{-159, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"198 -159 LINE",
+"246 0 LINE",
+"597 0 LINE",
+"636 54 LINE",
+"636 426 LINE",
+"271 426 LINE SMOOTH",
+"230 426 OFFCURVE",
+"186 427 OFFCURVE",
+"137 430 CURVE SMOOTH",
+"89 433 OFFCURVE",
+"60 436 OFFCURVE",
+"49 438 CURVE",
+"49 367 LINE",
+"60 364 OFFCURVE",
+"90 360 OFFCURVE",
+"137 357 CURVE SMOOTH",
+"185 354 OFFCURVE",
+"231 353 OFFCURVE",
+"274 353 CURVE SMOOTH",
+"282 353 LINE",
+"132 -139 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 353 LINE",
+"563 353 LINE",
+"563 76 LINE",
+"269 76 LINE"
+);
+}
+);
+width = 705;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0722.loclSYRN;
+lastChange = "2017-09-08 19:36:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{179, -184}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{145, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-381, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"713 -330 LINE",
+"691 -309 OFFCURVE",
+"659 -281 OFFCURVE",
+"618 -246 CURVE SMOOTH",
+"577 -211 OFFCURVE",
+"541 -181 OFFCURVE",
+"508 -154 CURVE SMOOTH",
+"421 -83 LINE SMOOTH",
+"366 -38 OFFCURVE",
+"309 9 OFFCURVE",
+"254 53 CURVE SMOOTH",
+"187 106 LINE",
+"137 145 LINE",
+"60 53 LINE",
+"145 -17 LINE",
+"177 20 LINE",
+"355 -123 LINE",
+"419 -174 LINE",
+"488 -230 LINE",
+"557 -287 LINE",
+"619 -338 LINE",
+"670 -381 LINE"
+);
+}
+);
+width = 427;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0726.loclSYRN;
+lastChange = "2017-09-08 19:36:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{645, -81}";
+}
+);
+hints = (
+{
+place = "{225, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{199, 71}";
+},
+{
+horizontal = 1;
+place = "{589, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"469 565 LINE",
+"310 538 OFFCURVE",
+"225 464 OFFCURVE",
+"225 359 CURVE SMOOTH",
+"225 260 OFFCURVE",
+"294 199 OFFCURVE",
+"407 199 CURVE SMOOTH",
+"566 199 LINE",
+"599 76 LINE",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"648 0 LINE",
+"681 66 LINE",
+"541 589 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 270 LINE",
+"341 270 OFFCURVE",
+"304 300 OFFCURVE",
+"304 367 CURVE SMOOTH",
+"304 434 OFFCURVE",
+"365 477 OFFCURVE",
+"488 494 CURVE",
+"547 270 LINE"
+);
+}
+);
+width = 740;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0729.loclSYRN;
+lastChange = "2017-09-08 19:39:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{483, -99}";
+}
+);
+hints = (
+{
+place = "{392, 73}";
+},
+{
+place = "{743, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{353, 73}";
+},
+{
+horizontal = 1;
+place = "{438, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"392 0 LINE",
+"409 46 LINE",
+"411 46 LINE",
+"430 17 OFFCURVE",
+"460 0 OFFCURVE",
+"508 0 CURVE SMOOTH",
+"777 0 LINE",
+"816 54 LINE",
+"816 438 LINE",
+"791 433 OFFCURVE",
+"723 426 OFFCURVE",
+"663 426 CURVE SMOOTH",
+"545 426 LINE SMOOTH",
+"485 426 OFFCURVE",
+"417 433 OFFCURVE",
+"392 438 CURVE",
+"392 128 LINE SMOOTH",
+"392 108 OFFCURVE",
+"394 91 OFFCURVE",
+"398 76 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"658 353 LINE",
+"682 353 OFFCURVE",
+"714 353 OFFCURVE",
+"743 357 CURVE",
+"743 76 LINE",
+"520 76 LINE SMOOTH",
+"473 76 OFFCURVE",
+"465 90 OFFCURVE",
+"465 135 CURVE SMOOTH",
+"465 357 LINE",
+"494 354 OFFCURVE",
+"526 353 OFFCURVE",
+"550 353 CURVE SMOOTH"
+);
+}
+);
+width = 884;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0727.loclSYRN;
+lastChange = "2017-09-08 19:39:21 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{420, -98}";
+}
+);
+hints = (
+{
+place = "{249, 74}";
+},
+{
+place = "{340, 82}";
+},
+{
+place = "{402, 59}";
+},
+{
+place = "{525, 81}";
+},
+{
+place = "{597, 70}";
+},
+{
+horizontal = 1;
+place = "{0, 70}";
+},
+{
+horizontal = 1;
+place = "{189, 66}";
+},
+{
+horizontal = 1;
+place = "{423, 74}";
+},
+{
+horizontal = 1;
+place = "{585, 86}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"665 0 LINE",
+"687 70 LINE",
+"664 70 LINE SMOOTH",
+"449 70 OFFCURVE",
+"323 145 OFFCURVE",
+"323 285 CURVE SMOOTH",
+"323 326 OFFCURVE",
+"337 360 OFFCURVE",
+"366 385 CURVE SMOOTH",
+"395 410 OFFCURVE",
+"430 423 OFFCURVE",
+"473 423 CURVE SMOOTH",
+"545 423 OFFCURVE",
+"597 388 OFFCURVE",
+"597 333 CURVE SMOOTH",
+"597 285 OFFCURVE",
+"572 255 OFFCURVE",
+"525 255 CURVE SMOOTH",
+"488 255 OFFCURVE",
+"461 278 OFFCURVE",
+"461 319 CURVE",
+"402 319 LINE",
+"402 310 LINE SMOOTH",
+"402 234 OFFCURVE",
+"449 189 OFFCURVE",
+"525 189 CURVE SMOOTH",
+"617 189 OFFCURVE",
+"667 246 OFFCURVE",
+"667 339 CURVE SMOOTH",
+"667 384 OFFCURVE",
+"648 422 OFFCURVE",
+"611 452 CURVE SMOOTH",
+"574 482 OFFCURVE",
+"528 497 OFFCURVE",
+"473 497 CURVE SMOOTH",
+"408 497 OFFCURVE",
+"355 477 OFFCURVE",
+"312 436 CURVE SMOOTH",
+"270 396 OFFCURVE",
+"249 345 OFFCURVE",
+"249 282 CURVE SMOOTH",
+"249 191 OFFCURVE",
+"288 120 OFFCURVE",
+"356 77 CURVE",
+"355 74 LINE",
+"332 75 OFFCURVE",
+"308 76 OFFCURVE",
+"287 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 585 LINE",
+"422 585 LINE",
+"422 671 LINE",
+"340 671 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 585 LINE",
+"606 585 LINE",
+"606 671 LINE",
+"525 671 LINE"
+);
+}
+);
+width = 755;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072A.loclSYRN;
+lastChange = "2017-09-08 19:39:24 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{257, -98}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 249, 505}";
+},
+{
+name = uni0716.loclSYRN;
+}
+);
+layerId = UUID0;
+width = 521;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni0728.loclSYRN;
+lastChange = "2017-09-08 19:39:27 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{262, -443}";
+}
+);
+hints = (
+{
+place = "{83, 63}";
+},
+{
+horizontal = 1;
+place = "{-381, 68}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{0, 193}";
+},
+{
+horizontal = 1;
+place = "{194, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"337 -323 LINE",
+"280 -316 OFFCURVE",
+"226 -313 OFFCURVE",
+"183 -313 CURVE SMOOTH",
+"69 -313 LINE",
+"69 -381 LINE",
+"445 -381 LINE",
+"459 -322 LINE",
+"256 -221 OFFCURVE",
+"146 -72 OFFCURVE",
+"146 92 CURVE",
+"143 111 LINE",
+"146 112 LINE",
+"167 44 OFFCURVE",
+"222 0 OFFCURVE",
+"290 0 CURVE SMOOTH",
+"364 0 OFFCURVE",
+"414 36 OFFCURVE",
+"440 107 CURVE",
+"443 107 LINE",
+"476 0 LINE",
+"540 21 LINE",
+"480 193 LINE",
+"419 193 LINE",
+"398 110 OFFCURVE",
+"355 76 OFFCURVE",
+"295 76 CURVE SMOOTH",
+"262 76 OFFCURVE",
+"233 88 OFFCURVE",
+"209 113 CURVE SMOOTH",
+"185 138 OFFCURVE",
+"170 165 OFFCURVE",
+"165 194 CURVE",
+"101 192 LINE",
+"86 148 OFFCURVE",
+"83 107 OFFCURVE",
+"83 62 CURVE SMOOTH",
+"83 -20 OFFCURVE",
+"107 -97 OFFCURVE",
+"155 -168 CURVE SMOOTH",
+"203 -239 OFFCURVE",
+"264 -290 OFFCURVE",
+"338 -319 CURVE"
+);
+}
+);
+width = 587;
+}
+);
+rightKerningGroup = uni0728;
+},
+{
+color = 7;
+glyphname = uni0723.loclSYRN;
+lastChange = "2017-09-08 19:39:29 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{591, -98}";
+}
+);
+hints = (
+{
+place = "{293, 75}";
+},
+{
+place = "{578, 69}";
+},
+{
+place = "{856, 75}";
+},
+{
+horizontal = 1;
+place = "{0, 70}";
+},
+{
+horizontal = 1;
+place = "{317, 75}";
+},
+{
+horizontal = 1;
+place = "{405, 71}";
+},
+{
+horizontal = 1;
+place = "{-2, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 76 LINE",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"465 0 LINE",
+"506 28 LINE",
+"559 9 OFFCURVE",
+"617 -2 OFFCURVE",
+"677 -2 CURVE SMOOTH",
+"840 -2 OFFCURVE",
+"931 79 OFFCURVE",
+"931 231 CURVE SMOOTH",
+"931 278 OFFCURVE",
+"916 317 OFFCURVE",
+"885 347 CURVE SMOOTH",
+"854 377 OFFCURVE",
+"817 392 OFFCURVE",
+"773 392 CURVE SMOOTH",
+"717 392 OFFCURVE",
+"680 375 OFFCURVE",
+"651 340 CURVE",
+"647 341 LINE",
+"646 425 OFFCURVE",
+"578 476 OFFCURVE",
+"475 476 CURVE SMOOTH",
+"426 476 OFFCURVE",
+"383 457 OFFCURVE",
+"347 418 CURVE SMOOTH",
+"311 379 OFFCURVE",
+"293 334 OFFCURVE",
+"293 283 CURVE SMOOTH",
+"293 187 OFFCURVE",
+"333 121 OFFCURVE",
+"414 74 CURVE",
+"411 71 LINE",
+"388 73 LINE",
+"316 75 LINE",
+"296 76 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 109 OFFCURVE",
+"603 153 OFFCURVE",
+"642 218 CURVE SMOOTH",
+"681 284 OFFCURVE",
+"722 317 OFFCURVE",
+"765 317 CURVE SMOOTH",
+"821 317 OFFCURVE",
+"856 281 OFFCURVE",
+"856 225 CURVE SMOOTH",
+"856 128 OFFCURVE",
+"792 70 OFFCURVE",
+"687 70 CURVE SMOOTH",
+"636 70 OFFCURVE",
+"597 76 OFFCURVE",
+"560 88 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"408 146 OFFCURVE",
+"368 206 OFFCURVE",
+"368 286 CURVE SMOOTH",
+"368 355 OFFCURVE",
+"417 405 OFFCURVE",
+"482 405 CURVE SMOOTH",
+"542 405 OFFCURVE",
+"578 371 OFFCURVE",
+"578 314 CURVE SMOOTH",
+"578 273 OFFCURVE",
+"568 234 OFFCURVE",
+"549 197 CURVE SMOOTH",
+"530 161 OFFCURVE",
+"512 132 OFFCURVE",
+"495 111 CURVE"
+);
+}
+);
+width = 1000;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0724.loclSYRN;
+lastChange = "2017-09-08 19:39:33 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{441, -100}";
+}
+);
+hints = (
+{
+place = "{68, 75}";
+},
+{
+place = "{353, 65}";
+},
+{
+place = "{628, 75}";
+},
+{
+horizontal = 1;
+place = "{-2, 72}";
+},
+{
+horizontal = 1;
+place = "{319, 75}";
+},
+{
+horizontal = 1;
+place = "{405, 71}";
+},
+{
+horizontal = 1;
+place = "{-136, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"172 -107 LINE",
+"229 -136 LINE",
+"310 16 LINE",
+"354 4 OFFCURVE",
+"401 -2 OFFCURVE",
+"449 -2 CURVE SMOOTH",
+"612 -2 OFFCURVE",
+"703 79 OFFCURVE",
+"703 231 CURVE SMOOTH",
+"703 278 OFFCURVE",
+"687 316 OFFCURVE",
+"655 347 CURVE SMOOTH",
+"624 378 OFFCURVE",
+"586 394 OFFCURVE",
+"542 394 CURVE SMOOTH",
+"502 394 OFFCURVE",
+"462 378 OFFCURVE",
+"422 334 CURVE",
+"418 336 LINE",
+"418 420 OFFCURVE",
+"354 476 OFFCURVE",
+"251 476 CURVE SMOOTH",
+"202 476 OFFCURVE",
+"159 457 OFFCURVE",
+"122 418 CURVE SMOOTH",
+"86 380 OFFCURVE",
+"68 335 OFFCURVE",
+"68 284 CURVE SMOOTH",
+"68 175 OFFCURVE",
+"133 87 OFFCURVE",
+"245 38 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 171 LINE",
+"435 276 OFFCURVE",
+"475 319 OFFCURVE",
+"534 319 CURVE SMOOTH",
+"590 319 OFFCURVE",
+"628 281 OFFCURVE",
+"628 225 CURVE SMOOTH",
+"628 128 OFFCURVE",
+"564 70 OFFCURVE",
+"459 70 CURVE SMOOTH",
+"420 70 OFFCURVE",
+"385 75 OFFCURVE",
+"345 86 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 108 LINE",
+"190 144 OFFCURVE",
+"143 208 OFFCURVE",
+"143 287 CURVE SMOOTH",
+"143 355 OFFCURVE",
+"192 405 OFFCURVE",
+"259 405 CURVE SMOOTH",
+"316 405 OFFCURVE",
+"353 367 OFFCURVE",
+"353 310 CURVE SMOOTH",
+"353 271 OFFCURVE",
+"343 239 OFFCURVE",
+"323 198 CURVE SMOOTH"
+);
+}
+);
+width = 771;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072B.loclSYRN;
+lastChange = "2017-09-08 19:36:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{470, -98}";
+}
+);
+hints = (
+{
+place = "{605, 73}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{340, 74}";
+},
+{
+horizontal = 1;
+place = "{440, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"425 369 LINE",
+"439 361 OFFCURVE",
+"463 354 OFFCURVE",
+"498 349 CURVE SMOOTH",
+"533 344 OFFCURVE",
+"569 341 OFFCURVE",
+"605 340 CURVE",
+"605 164 LINE SMOOTH",
+"605 128 OFFCURVE",
+"609 99 OFFCURVE",
+"618 76 CURVE",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"615 0 LINE",
+"633 46 LINE",
+"635 46 LINE",
+"658 13 OFFCURVE",
+"695 0 OFFCURVE",
+"743 0 CURVE SMOOTH",
+"921 0 LINE",
+"921 76 LINE",
+"749 76 LINE",
+"688 78 OFFCURVE",
+"683 94 OFFCURVE",
+"678 170 CURVE",
+"678 340 LINE",
+"714 341 OFFCURVE",
+"749 344 OFFCURVE",
+"784 349 CURVE SMOOTH",
+"819 354 OFFCURVE",
+"844 361 OFFCURVE",
+"858 369 CURVE",
+"844 440 LINE",
+"816 428 OFFCURVE",
+"747 414 OFFCURVE",
+"642 414 CURVE SMOOTH",
+"535 414 OFFCURVE",
+"467 428 OFFCURVE",
+"439 440 CURVE"
+);
+}
+);
+width = 970;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072C.loclSYRN;
+lastChange = "2017-09-08 19:36:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{573, -79}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 112}";
+},
+{
+horizontal = 1;
+place = "{36, 76}";
+},
+{
+horizontal = 1;
+place = "{-9, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{543, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"595 -9 LINE",
+"650 46 LINE",
+"288 543 LINE",
+"230 540 LINE",
+"199 475 OFFCURVE",
+"164 394 OFFCURVE",
+"125 297 CURVE SMOOTH",
+"87 200 OFFCURVE",
+"68 127 OFFCURVE",
+"68 80 CURVE SMOOTH",
+"68 28 OFFCURVE",
+"94 0 OFFCURVE",
+"137 0 CURVE SMOOTH",
+"152 0 OFFCURVE",
+"173 6 OFFCURVE",
+"199 18 CURVE SMOOTH",
+"226 30 OFFCURVE",
+"250 36 OFFCURVE",
+"271 36 CURVE SMOOTH",
+"314 36 OFFCURVE",
+"336 22 OFFCURVE",
+"349 -2 CURVE",
+"430 0 LINE",
+"413 75 OFFCURVE",
+"359 112 OFFCURVE",
+"268 112 CURVE SMOOTH",
+"233 112 OFFCURVE",
+"187 96 OFFCURVE",
+"148 69 CURVE",
+"145 72 OFFCURVE",
+"144 76 OFFCURVE",
+"144 81 CURVE SMOOTH",
+"143 92 LINE",
+"143 120 OFFCURVE",
+"155 168 OFFCURVE",
+"179 236 CURVE SMOOTH",
+"204 305 OFFCURVE",
+"232 374 OFFCURVE",
+"265 445 CURVE",
+"593 -9 LINE"
+);
+}
+);
+width = 699;
+}
+);
+rightKerningGroup = uni072C;
+},
+{
+color = 7;
+glyphname = uni071B.loclSYRN;
+lastChange = "2017-09-08 19:33:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{433, -98}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-285, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"1056 -3 LINE",
+"1056 76 LINE",
+"746 76 LINE",
+"429 693 LINE",
+"358 659 LINE",
+"659 76 LINE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"698 0 LINE",
+"845 -285 LINE",
+"875 -285 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"785 0 LINE",
+"1002 0 LINE",
+"881 -188 LINE"
+);
+}
+);
+width = 1125;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+color = 7;
+glyphname = uni071C.loclSYRN;
+lastChange = "2017-09-08 19:33:20 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{433, -98}";
+}
+);
+hints = (
+{
+place = "{842, 77}";
+},
+{
+horizontal = 1;
+place = "{-120, 79}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{693, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-300, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"1071 -3 LINE",
+"1071 76 LINE",
+"746 76 LINE",
+"429 693 LINE",
+"358 659 LINE",
+"659 76 LINE",
+"267 76 LINE SMOOTH",
+"175 76 OFFCURVE",
+"127 90 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"698 0 LINE",
+"852 -300 LINE",
+"882 -300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"852 -207 OFFCURVE",
+"828 -174 OFFCURVE",
+"804 -129 CURVE SMOOTH",
+"780 -84 OFFCURVE",
+"768 -41 OFFCURVE",
+"768 0 CURVE",
+"1019 0 LINE",
+"1002 -43 OFFCURVE",
+"978 -89 OFFCURVE",
+"946 -136 CURVE SMOOTH",
+"915 -183 OFFCURVE",
+"891 -214 OFFCURVE",
+"875 -227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"842 -120 LINE",
+"919 -120 LINE",
+"919 -41 LINE",
+"842 -41 LINE"
+);
+}
+);
+width = 1139;
+}
+);
+leftKerningGroup = uni071B;
+},
+{
+color = 7;
+glyphname = uni0718.loclSYRN;
+lastChange = "2017-09-08 19:33:23 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{289, -98}";
+}
+);
+hints = (
+{
+place = "{68, 74}";
+},
+{
+place = "{439, 74}";
+},
+{
+horizontal = 1;
+place = "{-5, 73}";
+},
+{
+horizontal = 1;
+place = "{382, 74}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"513 282 OFFCURVE",
+"493 342 OFFCURVE",
+"454 387 CURVE SMOOTH",
+"415 433 OFFCURVE",
+"362 456 OFFCURVE",
+"295 456 CURVE SMOOTH",
+"226 456 OFFCURVE",
+"171 433 OFFCURVE",
+"130 386 CURVE SMOOTH",
+"89 339 OFFCURVE",
+"68 280 OFFCURVE",
+"68 209 CURVE SMOOTH",
+"68 74 OFFCURVE",
+"148 -5 OFFCURVE",
+"291 -5 CURVE SMOOTH",
+"432 -5 OFFCURVE",
+"513 74 OFFCURVE",
+"513 209 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"439 115 OFFCURVE",
+"390 68 OFFCURVE",
+"291 68 CURVE SMOOTH",
+"187 68 OFFCURVE",
+"142 120 OFFCURVE",
+"142 211 CURVE SMOOTH",
+"142 314 OFFCURVE",
+"198 382 OFFCURVE",
+"291 382 CURVE SMOOTH",
+"384 382 OFFCURVE",
+"439 315 OFFCURVE",
+"439 211 CURVE SMOOTH"
+);
+}
+);
+width = 582;
+}
+);
+rightKerningGroup = uni0718;
+},
+{
+color = 7;
+glyphname = uni071D.loclSYRN;
+lastChange = "2017-09-08 19:33:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{492, -98}";
+}
+);
+hints = (
+{
+place = "{414, 57}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+},
+{
+horizontal = 1;
+place = "{-9, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{228, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"472 132 LINE",
+"474 132 LINE",
+"614 -9 LINE",
+"670 34 LINE",
+"468 228 LINE",
+"417 228 LINE",
+"411 76 LINE",
+"262 76 LINE SMOOTH",
+"174 76 OFFCURVE",
+"129 89 OFFCURVE",
+"94 138 CURVE",
+"49 78 LINE",
+"69 30 OFFCURVE",
+"136 0 OFFCURVE",
+"240 0 CURVE SMOOTH",
+"470 0 LINE"
+);
+}
+);
+width = 734;
+}
+);
+leftKerningGroup = uni071A;
+},
+{
+color = 7;
+glyphname = uni071E.loclSYRN;
+lastChange = "2017-09-08 19:33:29 +0000";
+layers = (
+{
+components = (
+{
+name = uni0717.loclSYRN.Fina;
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 397, -183}";
+},
+{
+name = uni071D.loclSYRN.Init;
+transform = "{1, 0, 0, 1, 791, 0}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 312, 510}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 396, 657}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 480, 510}";
+}
+);
+layerId = UUID0;
+width = 1193;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0719.loclSYRN;
+lastChange = "2017-09-08 19:33:32 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{135, -173}";
+}
+);
+hints = (
+{
+place = "{59, 142}";
+},
+{
+place = "{132, 56}";
+},
+{
+horizontal = 1;
+place = "{-78, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{375, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"130 -63 LINE",
+"185 -78 LINE",
+"191 2 LINE",
+"198 74 OFFCURVE",
+"201 154 OFFCURVE",
+"201 238 CURVE SMOOTH",
+"201 337 OFFCURVE",
+"181 375 OFFCURVE",
+"133 375 CURVE SMOOTH",
+"86 375 OFFCURVE",
+"59 331 OFFCURVE",
+"59 230 CURVE SMOOTH",
+"59 135 OFFCURVE",
+"80 67 OFFCURVE",
+"135 26 CURVE"
+);
+}
+);
+width = 269;
+}
+);
+rightKerningGroup = uni0719;
+},
+{
+color = 5;
+glyphname = uni0660.loclSYRJ;
+lastChange = "2017-09-08 19:41:28 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"161 280 OFFCURVE",
+"123 304 OFFCURVE",
+"94 304 CURVE SMOOTH",
+"67 304 OFFCURVE",
+"29 280 OFFCURVE",
+"29 241 CURVE SMOOTH",
+"29 198 OFFCURVE",
+"65 175 OFFCURVE",
+"97 175 CURVE SMOOTH",
+"129 175 OFFCURVE",
+"161 201 OFFCURVE",
+"161 241 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"161 280 OFFCURVE",
+"123 304 OFFCURVE",
+"94 304 CURVE SMOOTH",
+"67 304 OFFCURVE",
+"29 280 OFFCURVE",
+"29 241 CURVE SMOOTH",
+"29 198 OFFCURVE",
+"65 175 OFFCURVE",
+"97 175 CURVE SMOOTH",
+"129 175 OFFCURVE",
+"161 201 OFFCURVE",
+"161 241 CURVE SMOOTH"
+);
+}
+);
+width = 190;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0660.loclSYRN;
+lastChange = "2017-09-08 19:41:33 +0000";
+layers = (
+{
+hints = (
+{
+place = "{35, 119}";
+},
+{
+horizontal = 1;
+place = "{180, 119}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"35 180 LINE",
+"154 180 LINE",
+"154 299 LINE",
+"35 299 LINE"
+);
+}
+);
+width = 190;
+}
+);
+},
+{
+color = 5;
+glyphname = colon.loclSYRJ;
+lastChange = "2017-09-08 19:41:38 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"83 5 OFFCURVE",
+"107 -14 OFFCURVE",
+"141 -14 CURVE SMOOTH",
+"178 -14 OFFCURVE",
+"201 9 OFFCURVE",
+"201 52 CURVE SMOOTH",
+"201 95 OFFCURVE",
+"178 118 OFFCURVE",
+"141 118 CURVE SMOOTH",
+"104 118 OFFCURVE",
+"83 95 OFFCURVE",
+"83 52 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"83 319 OFFCURVE",
+"107 300 OFFCURVE",
+"141 300 CURVE SMOOTH",
+"178 300 OFFCURVE",
+"201 323 OFFCURVE",
+"201 366 CURVE SMOOTH",
+"201 410 OFFCURVE",
+"181 432 OFFCURVE",
+"141 432 CURVE SMOOTH",
+"102 432 OFFCURVE",
+"83 410 OFFCURVE",
+"83 366 CURVE SMOOTH"
+);
+}
+);
+width = 284;
+}
+);
+},
+{
+color = 5;
+glyphname = exclam.loclSYRJ;
+lastChange = "2017-09-08 19:41:41 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"190 607 LINE",
+"95 607 LINE",
+"117 197 LINE",
+"168 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"89 9 OFFCURVE",
+"111 -8 OFFCURVE",
+"142 -8 CURVE SMOOTH",
+"175 -8 OFFCURVE",
+"195 14 OFFCURVE",
+"195 52 CURVE SMOOTH",
+"195 91 OFFCURVE",
+"176 112 OFFCURVE",
+"142 112 CURVE SMOOTH",
+"107 112 OFFCURVE",
+"89 92 OFFCURVE",
+"89 52 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"190 607 LINE",
+"95 607 LINE",
+"117 197 LINE",
+"168 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"89 9 OFFCURVE",
+"111 -8 OFFCURVE",
+"142 -8 CURVE SMOOTH",
+"175 -8 OFFCURVE",
+"195 14 OFFCURVE",
+"195 52 CURVE SMOOTH",
+"195 91 OFFCURVE",
+"176 112 OFFCURVE",
+"142 112 CURVE SMOOTH",
+"107 112 OFFCURVE",
+"89 92 OFFCURVE",
+"89 52 CURVE SMOOTH"
+);
+}
+);
+width = 284;
+}
+);
+},
+{
+color = 5;
+glyphname = period.loclSYRJ;
+lastChange = "2017-09-08 19:41:45 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"74 5 OFFCURVE",
+"99 -14 OFFCURVE",
+"132 -14 CURVE SMOOTH",
+"169 -14 OFFCURVE",
+"192 9 OFFCURVE",
+"192 52 CURVE SMOOTH",
+"192 95 OFFCURVE",
+"169 118 OFFCURVE",
+"132 118 CURVE SMOOTH",
+"95 118 OFFCURVE",
+"74 95 OFFCURVE",
+"74 52 CURVE SMOOTH"
+);
+}
+);
+width = 266;
+}
+);
+},
+{
+color = 7;
+glyphname = colon.loclSYRN;
+lastChange = "2017-09-08 19:41:48 +0000";
+layers = (
+{
+hints = (
+{
+place = "{89, 107}";
+},
+{
+horizontal = 1;
+place = "{-7, 116}";
+},
+{
+horizontal = 1;
+place = "{307, 116}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"89 -7 LINE",
+"196 -7 LINE",
+"196 109 LINE",
+"89 109 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"89 307 LINE",
+"196 307 LINE",
+"196 423 LINE",
+"89 423 LINE"
+);
+}
+);
+width = 284;
+}
+);
+},
+{
+color = 7;
+glyphname = exclam.loclSYRN;
+lastChange = "2017-09-08 19:41:50 +0000";
+layers = (
+{
+hints = (
+{
+place = "{94, 85}";
+},
+{
+place = "{106, 73}";
+},
+{
+horizontal = 1;
+place = "{-2, 106}";
+},
+{
+horizontal = 1;
+place = "{607, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"190 607 LINE",
+"95 607 LINE",
+"117 197 LINE",
+"168 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"94 -2 LINE",
+"190 -2 LINE",
+"190 104 LINE",
+"94 104 LINE"
+);
+}
+);
+width = 284;
+}
+);
+},
+{
+color = 7;
+glyphname = period.loclSYRN;
+lastChange = "2017-09-08 19:41:52 +0000";
+layers = (
+{
+hints = (
+{
+place = "{80, 107}";
+},
+{
+horizontal = 1;
+place = "{-7, 116}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"80 -7 LINE",
+"187 -7 LINE",
+"187 109 LINE",
+"80 109 LINE"
+);
+}
+);
+width = 266;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0705.loclSYRJ;
+lastChange = "2017-09-08 19:36:17 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, 320}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 296, 320}";
+}
+);
+layerId = UUID0;
+width = 425;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0706.loclSYRJ;
+lastChange = "2017-09-08 19:36:20 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, 154}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 215, -15}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0708.loclSYRJ;
+lastChange = "2017-09-08 19:36:25 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, 373}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 215, 204}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0707.loclSYRJ;
+lastChange = "2017-09-08 19:39:35 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 215, 154}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, -15}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0709.loclSYRJ;
+lastChange = "2017-09-08 19:36:32 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, -15}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 215, -185}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0704.loclSYRJ;
+lastChange = "2017-09-08 19:36:35 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, -15}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, -185}";
+}
+);
+layerId = UUID0;
+width = 256;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0703.loclSYRJ;
+lastChange = "2017-09-08 19:36:37 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, 373}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 127, 203}";
+}
+);
+layerId = UUID0;
+width = 256;
+}
+);
+},
+{
+color = 5;
+glyphname = uni070A.loclSYRJ;
+lastChange = "2017-09-08 19:36:40 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"120 486 LINE",
+"120 425 LINE",
+"459 425 LINE",
+"459 486 LINE",
+"429 486 LINE SMOOTH",
+"405 486 OFFCURVE",
+"386 494 OFFCURVE",
+"386 525 CURVE SMOOTH",
+"386 573 LINE",
+"342 573 LINE",
+"342 525 LINE SMOOTH",
+"342 494 OFFCURVE",
+"320 486 OFFCURVE",
+"296 486 CURVE SMOOTH",
+"283 486 LINE SMOOTH",
+"259 486 OFFCURVE",
+"237 494 OFFCURVE",
+"237 525 CURVE SMOOTH",
+"237 573 LINE",
+"193 573 LINE",
+"193 525 LINE SMOOTH",
+"193 494 OFFCURVE",
+"174 486 OFFCURVE",
+"150 486 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 233 OFFCURVE",
+"260 215 OFFCURVE",
+"290 215 CURVE SMOOTH",
+"317 215 OFFCURVE",
+"342 233 OFFCURVE",
+"342 272 CURVE SMOOTH",
+"342 312 OFFCURVE",
+"317 329 OFFCURVE",
+"290 329 CURVE SMOOTH",
+"260 329 OFFCURVE",
+"238 312 OFFCURVE",
+"238 272 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 7 OFFCURVE",
+"260 -11 OFFCURVE",
+"290 -11 CURVE SMOOTH",
+"317 -11 OFFCURVE",
+"342 7 OFFCURVE",
+"342 46 CURVE SMOOTH",
+"342 85 OFFCURVE",
+"317 103 OFFCURVE",
+"290 103 CURVE SMOOTH",
+"260 103 OFFCURVE",
+"238 85 OFFCURVE",
+"238 46 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"120 486 LINE",
+"120 425 LINE",
+"459 425 LINE",
+"459 486 LINE",
+"429 486 LINE SMOOTH",
+"405 486 OFFCURVE",
+"386 494 OFFCURVE",
+"386 525 CURVE SMOOTH",
+"386 573 LINE",
+"342 573 LINE",
+"342 525 LINE SMOOTH",
+"342 494 OFFCURVE",
+"320 486 OFFCURVE",
+"296 486 CURVE SMOOTH",
+"283 486 LINE SMOOTH",
+"259 486 OFFCURVE",
+"237 494 OFFCURVE",
+"237 525 CURVE SMOOTH",
+"237 573 LINE",
+"193 573 LINE",
+"193 525 LINE SMOOTH",
+"193 494 OFFCURVE",
+"174 486 OFFCURVE",
+"150 486 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 233 OFFCURVE",
+"260 215 OFFCURVE",
+"290 215 CURVE SMOOTH",
+"317 215 OFFCURVE",
+"342 233 OFFCURVE",
+"342 272 CURVE SMOOTH",
+"342 312 OFFCURVE",
+"317 329 OFFCURVE",
+"290 329 CURVE SMOOTH",
+"260 329 OFFCURVE",
+"238 312 OFFCURVE",
+"238 272 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 7 OFFCURVE",
+"260 -11 OFFCURVE",
+"290 -11 CURVE SMOOTH",
+"317 -11 OFFCURVE",
+"342 7 OFFCURVE",
+"342 46 CURVE SMOOTH",
+"342 85 OFFCURVE",
+"317 103 OFFCURVE",
+"290 103 CURVE SMOOTH",
+"260 103 OFFCURVE",
+"238 85 OFFCURVE",
+"238 46 CURVE SMOOTH"
+);
+}
+);
+width = 579;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0702.loclSYRJ;
+lastChange = "2017-09-08 19:36:42 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"78 -97 OFFCURVE",
+"98 -112 OFFCURVE",
+"127 -112 CURVE SMOOTH",
+"160 -112 OFFCURVE",
+"179 -93 OFFCURVE",
+"179 -56 CURVE SMOOTH",
+"179 -19 OFFCURVE",
+"160 0 OFFCURVE",
+"127 0 CURVE SMOOTH",
+"96 0 OFFCURVE",
+"78 -19 OFFCURVE",
+"78 -56 CURVE SMOOTH"
+);
+}
+);
+width = 256;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0701.loclSYRJ;
+lastChange = "2017-09-08 19:36:45 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"78 273 OFFCURVE",
+"98 257 OFFCURVE",
+"127 257 CURVE SMOOTH",
+"160 257 OFFCURVE",
+"179 277 OFFCURVE",
+"179 313 CURVE SMOOTH",
+"179 351 OFFCURVE",
+"160 370 OFFCURVE",
+"127 370 CURVE SMOOTH",
+"96 370 OFFCURVE",
+"78 351 OFFCURVE",
+"78 313 CURVE SMOOTH"
+);
+}
+);
+width = 256;
+}
+);
+},
+{
+color = 5;
+glyphname = uni070D.loclSYRJ;
+lastChange = "2017-09-08 19:36:47 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"354 69 LINE",
+"405 69 LINE",
+"405 323 LINE",
+"648 323 LINE",
+"648 374 LINE",
+"405 374 LINE",
+"405 627 LINE",
+"354 627 LINE",
+"354 374 LINE",
+"110 374 LINE",
+"110 323 LINE",
+"354 323 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 442 OFFCURVE",
+"232 428 OFFCURVE",
+"256 428 CURVE SMOOTH",
+"278 428 OFFCURVE",
+"298 442 OFFCURVE",
+"298 474 CURVE SMOOTH",
+"298 505 OFFCURVE",
+"278 519 OFFCURVE",
+"256 519 CURVE SMOOTH",
+"232 519 OFFCURVE",
+"214 505 OFFCURVE",
+"214 474 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 442 OFFCURVE",
+"479 428 OFFCURVE",
+"502 428 CURVE SMOOTH",
+"524 428 OFFCURVE",
+"544 442 OFFCURVE",
+"544 474 CURVE SMOOTH",
+"544 505 OFFCURVE",
+"524 519 OFFCURVE",
+"502 519 CURVE SMOOTH",
+"479 519 OFFCURVE",
+"460 505 OFFCURVE",
+"460 474 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 192 OFFCURVE",
+"479 178 OFFCURVE",
+"502 178 CURVE SMOOTH",
+"524 178 OFFCURVE",
+"544 192 OFFCURVE",
+"544 224 CURVE SMOOTH",
+"544 255 OFFCURVE",
+"524 269 OFFCURVE",
+"502 269 CURVE SMOOTH",
+"479 269 OFFCURVE",
+"460 255 OFFCURVE",
+"460 224 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 192 OFFCURVE",
+"232 178 OFFCURVE",
+"256 178 CURVE SMOOTH",
+"278 178 OFFCURVE",
+"298 192 OFFCURVE",
+"298 224 CURVE SMOOTH",
+"298 255 OFFCURVE",
+"278 269 OFFCURVE",
+"256 269 CURVE SMOOTH",
+"232 269 OFFCURVE",
+"214 255 OFFCURVE",
+"214 224 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"354 69 LINE",
+"405 69 LINE",
+"405 323 LINE",
+"648 323 LINE",
+"648 374 LINE",
+"405 374 LINE",
+"405 627 LINE",
+"354 627 LINE",
+"354 374 LINE",
+"110 374 LINE",
+"110 323 LINE",
+"354 323 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 442 OFFCURVE",
+"232 428 OFFCURVE",
+"256 428 CURVE SMOOTH",
+"278 428 OFFCURVE",
+"298 442 OFFCURVE",
+"298 474 CURVE SMOOTH",
+"298 505 OFFCURVE",
+"278 519 OFFCURVE",
+"256 519 CURVE SMOOTH",
+"232 519 OFFCURVE",
+"214 505 OFFCURVE",
+"214 474 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 442 OFFCURVE",
+"479 428 OFFCURVE",
+"502 428 CURVE SMOOTH",
+"524 428 OFFCURVE",
+"544 442 OFFCURVE",
+"544 474 CURVE SMOOTH",
+"544 505 OFFCURVE",
+"524 519 OFFCURVE",
+"502 519 CURVE SMOOTH",
+"479 519 OFFCURVE",
+"460 505 OFFCURVE",
+"460 474 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 192 OFFCURVE",
+"479 178 OFFCURVE",
+"502 178 CURVE SMOOTH",
+"524 178 OFFCURVE",
+"544 192 OFFCURVE",
+"544 224 CURVE SMOOTH",
+"544 255 OFFCURVE",
+"524 269 OFFCURVE",
+"502 269 CURVE SMOOTH",
+"479 269 OFFCURVE",
+"460 255 OFFCURVE",
+"460 224 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 192 OFFCURVE",
+"232 178 OFFCURVE",
+"256 178 CURVE SMOOTH",
+"278 178 OFFCURVE",
+"298 192 OFFCURVE",
+"298 224 CURVE SMOOTH",
+"298 255 OFFCURVE",
+"278 269 OFFCURVE",
+"256 269 CURVE SMOOTH",
+"232 269 OFFCURVE",
+"214 255 OFFCURVE",
+"214 224 CURVE SMOOTH"
+);
+}
+);
+width = 758;
+}
+);
+},
+{
+color = 5;
+glyphname = uni070B.loclSYRJ;
+lastChange = "2017-09-08 19:36:50 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"119 586 LINE",
+"804 586 LINE",
+"804 647 LINE",
+"119 647 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"410 410 OFFCURVE",
+"432 392 OFFCURVE",
+"462 392 CURVE SMOOTH",
+"489 392 OFFCURVE",
+"514 410 OFFCURVE",
+"514 449 CURVE SMOOTH",
+"514 489 OFFCURVE",
+"489 506 OFFCURVE",
+"462 506 CURVE SMOOTH",
+"432 506 OFFCURVE",
+"410 489 OFFCURVE",
+"410 449 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"119 586 LINE",
+"804 586 LINE",
+"804 647 LINE",
+"119 647 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"410 410 OFFCURVE",
+"432 392 OFFCURVE",
+"462 392 CURVE SMOOTH",
+"489 392 OFFCURVE",
+"514 410 OFFCURVE",
+"514 449 CURVE SMOOTH",
+"514 489 OFFCURVE",
+"489 506 OFFCURVE",
+"462 506 CURVE SMOOTH",
+"432 506 OFFCURVE",
+"410 489 OFFCURVE",
+"410 449 CURVE SMOOTH"
+);
+}
+);
+width = 923;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0700.loclSYRJ;
+lastChange = "2017-09-08 19:36:52 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"106 132 OFFCURVE",
+"131 113 OFFCURVE",
+"164 113 CURVE SMOOTH",
+"201 113 OFFCURVE",
+"224 136 OFFCURVE",
+"224 179 CURVE SMOOTH",
+"224 222 OFFCURVE",
+"201 245 OFFCURVE",
+"164 245 CURVE SMOOTH",
+"127 245 OFFCURVE",
+"106 222 OFFCURVE",
+"106 179 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"245 273 OFFCURVE",
+"266 257 OFFCURVE",
+"294 257 CURVE SMOOTH",
+"327 257 OFFCURVE",
+"346 277 OFFCURVE",
+"346 313 CURVE SMOOTH",
+"346 351 OFFCURVE",
+"328 370 OFFCURVE",
+"294 370 CURVE SMOOTH",
+"263 370 OFFCURVE",
+"245 351 OFFCURVE",
+"245 313 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 3 OFFCURVE",
+"266 -12 OFFCURVE",
+"294 -12 CURVE SMOOTH",
+"327 -12 OFFCURVE",
+"346 7 OFFCURVE",
+"346 44 CURVE SMOOTH",
+"346 81 OFFCURVE",
+"328 101 OFFCURVE",
+"294 101 CURVE SMOOTH",
+"263 101 OFFCURVE",
+"245 81 OFFCURVE",
+"245 44 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"376 138 OFFCURVE",
+"397 123 OFFCURVE",
+"426 123 CURVE SMOOTH",
+"458 123 OFFCURVE",
+"478 142 OFFCURVE",
+"478 179 CURVE SMOOTH",
+"478 216 OFFCURVE",
+"459 235 OFFCURVE",
+"426 235 CURVE SMOOTH",
+"395 235 OFFCURVE",
+"376 216 OFFCURVE",
+"376 179 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"114 138 OFFCURVE",
+"135 123 OFFCURVE",
+"164 123 CURVE SMOOTH",
+"196 123 OFFCURVE",
+"215 142 OFFCURVE",
+"215 179 CURVE SMOOTH",
+"215 216 OFFCURVE",
+"197 235 OFFCURVE",
+"164 235 CURVE SMOOTH",
+"132 235 OFFCURVE",
+"114 216 OFFCURVE",
+"114 179 CURVE SMOOTH"
+);
+}
+);
+width = 592;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0705.loclSYRN;
+lastChange = "2017-09-08 19:36:54 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, 320}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 296, 320}";
+}
+);
+layerId = UUID0;
+width = 425;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0706.loclSYRN;
+lastChange = "2017-09-08 19:36:57 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, 154}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 215, -15}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0708.loclSYRN;
+lastChange = "2017-09-08 19:37:01 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, 373}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 215, 204}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0707.loclSYRN;
+lastChange = "2017-09-08 19:37:04 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 215, 154}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, -15}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0709.loclSYRN;
+lastChange = "2017-09-08 19:37:06 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, -15}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 215, -185}";
+}
+);
+layerId = UUID0;
+width = 344;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0704.loclSYRN;
+lastChange = "2017-09-08 19:37:10 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, -15}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, -185}";
+}
+);
+layerId = UUID0;
+width = 256;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0703.loclSYRN;
+lastChange = "2017-09-08 19:37:12 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 137, 373}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 137, 203}";
+}
+);
+layerId = UUID0;
+width = 277;
+}
+);
+},
+{
+color = 7;
+glyphname = uni070A.loclSYRN;
+lastChange = "2017-09-08 19:37:15 +0000";
+layers = (
+{
+hints = (
+{
+place = "{193, 44}";
+},
+{
+place = "{246, 88}";
+},
+{
+place = "{342, 44}";
+},
+{
+horizontal = 1;
+place = "{0, 92}";
+},
+{
+horizontal = 1;
+place = "{225, 92}";
+},
+{
+horizontal = 1;
+place = "{425, 61}";
+},
+{
+horizontal = 1;
+place = "{425, 148}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"120 486 LINE",
+"120 425 LINE",
+"459 425 LINE",
+"459 486 LINE",
+"429 486 LINE SMOOTH",
+"400 486 OFFCURVE",
+"386 498 OFFCURVE",
+"386 525 CURVE SMOOTH",
+"386 573 LINE",
+"342 573 LINE",
+"342 525 LINE SMOOTH",
+"342 498 OFFCURVE",
+"327 486 OFFCURVE",
+"296 486 CURVE SMOOTH",
+"283 486 LINE SMOOTH",
+"252 486 OFFCURVE",
+"237 498 OFFCURVE",
+"237 525 CURVE SMOOTH",
+"237 573 LINE",
+"193 573 LINE",
+"193 525 LINE SMOOTH",
+"193 498 OFFCURVE",
+"179 486 OFFCURVE",
+"150 486 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"246 225 LINE",
+"334 225 LINE",
+"334 317 LINE",
+"246 317 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"246 0 LINE",
+"334 0 LINE",
+"334 92 LINE",
+"246 92 LINE"
+);
+}
+);
+width = 579;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0702.loclSYRN;
+lastChange = "2017-09-08 19:37:17 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, -115}";
+}
+);
+layerId = UUID0;
+width = 256;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0701.loclSYRN;
+lastChange = "2017-09-08 19:37:20 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 127, 254}";
+}
+);
+layerId = UUID0;
+width = 256;
+}
+);
+},
+{
+color = 7;
+glyphname = uni070D.loclSYRN;
+lastChange = "2017-09-08 19:37:23 +0000";
+layers = (
+{
+hints = (
+{
+place = "{213, 82}";
+},
+{
+place = "{354, 51}";
+},
+{
+place = "{463, 81}";
+},
+{
+horizontal = 1;
+place = "{180, 85}";
+},
+{
+horizontal = 1;
+place = "{323, 51}";
+},
+{
+horizontal = 1;
+place = "{431, 86}";
+},
+{
+horizontal = 1;
+place = "{69, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{627, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"354 69 LINE",
+"405 69 LINE",
+"405 323 LINE",
+"648 323 LINE",
+"648 374 LINE",
+"405 374 LINE",
+"405 627 LINE",
+"354 627 LINE",
+"354 374 LINE",
+"110 374 LINE",
+"110 323 LINE",
+"354 323 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"463 431 LINE",
+"544 431 LINE",
+"544 517 LINE",
+"463 517 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"213 431 LINE",
+"295 431 LINE",
+"295 517 LINE",
+"213 517 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"463 180 LINE",
+"544 180 LINE",
+"544 265 LINE",
+"463 265 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"213 180 LINE",
+"295 180 LINE",
+"295 265 LINE",
+"213 265 LINE"
+);
+}
+);
+width = 758;
+}
+);
+},
+{
+color = 7;
+glyphname = uni070B.loclSYRN;
+lastChange = "2017-09-08 19:37:26 +0000";
+layers = (
+{
+hints = (
+{
+place = "{417, 89}";
+},
+{
+horizontal = 1;
+place = "{403, 92}";
+},
+{
+horizontal = 1;
+place = "{586, 61}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"119 586 LINE",
+"804 586 LINE",
+"804 647 LINE",
+"119 647 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"417 403 LINE",
+"506 403 LINE",
+"506 495 LINE",
+"417 495 LINE"
+);
+}
+);
+width = 923;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0700.loclSYRN;
+lastChange = "2017-09-08 19:37:29 +0000";
+layers = (
+{
+components = (
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 294, 254}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 294, -15}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 426, 120}";
+},
+{
+name = Dot1p.loclSYRN;
+transform = "{1, 0, 0, 1, 164, 120}";
+}
+);
+layerId = UUID0;
+width = 592;
+}
+);
+},
+{
+color = 5;
+glyphname = uni061B.loclSYRJ;
+lastChange = "2017-09-08 19:42:10 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"187 311 LINE",
+"201 398 OFFCURVE",
+"218 478 OFFCURVE",
+"239 556 CURVE",
+"178 556 LINE",
+"141 475 OFFCURVE",
+"119 400 OFFCURVE",
+"99 322 CURVE",
+"106 311 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"83 5 OFFCURVE",
+"107 -14 OFFCURVE",
+"141 -14 CURVE SMOOTH",
+"178 -14 OFFCURVE",
+"201 9 OFFCURVE",
+"201 52 CURVE SMOOTH",
+"201 95 OFFCURVE",
+"178 118 OFFCURVE",
+"141 118 CURVE SMOOTH",
+"104 118 OFFCURVE",
+"83 95 OFFCURVE",
+"83 52 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"187 311 LINE",
+"201 398 OFFCURVE",
+"218 478 OFFCURVE",
+"239 556 CURVE",
+"178 556 LINE",
+"141 475 OFFCURVE",
+"119 400 OFFCURVE",
+"99 322 CURVE",
+"106 311 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"83 5 OFFCURVE",
+"107 -14 OFFCURVE",
+"141 -14 CURVE SMOOTH",
+"178 -14 OFFCURVE",
+"201 9 OFFCURVE",
+"201 52 CURVE SMOOTH",
+"201 95 OFFCURVE",
+"178 118 OFFCURVE",
+"141 118 CURVE SMOOTH",
+"104 118 OFFCURVE",
+"83 95 OFFCURVE",
+"83 52 CURVE SMOOTH"
+);
+}
+);
+width = 284;
+}
+);
+},
+{
+color = 7;
+glyphname = uni061B.loclSYRN;
+lastChange = "2017-09-08 19:42:14 +0000";
+layers = (
+{
+hints = (
+{
+place = "{89, 107}";
+},
+{
+horizontal = 1;
+place = "{-7, 116}";
+},
+{
+horizontal = 1;
+place = "{556, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"187 311 LINE",
+"202 398 OFFCURVE",
+"218 477 OFFCURVE",
+"239 556 CURVE",
+"178 556 LINE",
+"141 475 OFFCURVE",
+"119 399 OFFCURVE",
+"99 322 CURVE",
+"106 311 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"89 -7 LINE",
+"196 -7 LINE",
+"196 109 LINE",
+"89 109 LINE"
+);
+}
+);
+width = 284;
+}
+);
+},
+{
+color = 5;
+glyphname = uni061F.loclSYRJ;
+lastChange = "2017-09-08 19:42:16 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"262 197 LINE",
+"262 223 LINE SMOOTH",
+"262 283 OFFCURVE",
+"233 321 OFFCURVE",
+"187 356 CURVE SMOOTH",
+"144 388 OFFCURVE",
+"108 417 OFFCURVE",
+"108 464 CURVE SMOOTH",
+"108 512 OFFCURVE",
+"147 546 OFFCURVE",
+"212 546 CURVE SMOOTH",
+"257 546 OFFCURVE",
+"297 535 OFFCURVE",
+"336 516 CURVE",
+"365 577 LINE",
+"312 604 OFFCURVE",
+"262 617 OFFCURVE",
+"209 617 CURVE SMOOTH",
+"107 617 OFFCURVE",
+"32 555 OFFCURVE",
+"32 461 CURVE SMOOTH",
+"32 389 OFFCURVE",
+"76 354 OFFCURVE",
+"128 314 CURVE",
+"168 283 OFFCURVE",
+"197 260 OFFCURVE",
+"197 213 CURVE SMOOTH",
+"197 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 92 OFFCURVE",
+"262 112 OFFCURVE",
+"227 112 CURVE SMOOTH",
+"193 112 OFFCURVE",
+"174 91 OFFCURVE",
+"174 52 CURVE SMOOTH",
+"174 14 OFFCURVE",
+"194 -8 OFFCURVE",
+"227 -8 CURVE SMOOTH",
+"258 -8 OFFCURVE",
+"280 9 OFFCURVE",
+"280 52 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 197 LINE",
+"262 223 LINE SMOOTH",
+"262 283 OFFCURVE",
+"233 321 OFFCURVE",
+"187 356 CURVE SMOOTH",
+"144 388 OFFCURVE",
+"108 417 OFFCURVE",
+"108 464 CURVE SMOOTH",
+"108 512 OFFCURVE",
+"147 546 OFFCURVE",
+"212 546 CURVE SMOOTH",
+"257 546 OFFCURVE",
+"297 535 OFFCURVE",
+"336 516 CURVE",
+"365 577 LINE",
+"312 604 OFFCURVE",
+"262 617 OFFCURVE",
+"209 617 CURVE SMOOTH",
+"107 617 OFFCURVE",
+"32 555 OFFCURVE",
+"32 461 CURVE SMOOTH",
+"32 389 OFFCURVE",
+"76 354 OFFCURVE",
+"128 314 CURVE",
+"168 283 OFFCURVE",
+"197 260 OFFCURVE",
+"197 213 CURVE SMOOTH",
+"197 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 92 OFFCURVE",
+"262 112 OFFCURVE",
+"227 112 CURVE SMOOTH",
+"193 112 OFFCURVE",
+"174 91 OFFCURVE",
+"174 52 CURVE SMOOTH",
+"174 14 OFFCURVE",
+"194 -8 OFFCURVE",
+"227 -8 CURVE SMOOTH",
+"258 -8 OFFCURVE",
+"280 9 OFFCURVE",
+"280 52 CURVE SMOOTH"
+);
+}
+);
+width = 379;
+}
+);
+},
+{
+color = 7;
+glyphname = uni061F.loclSYRN;
+lastChange = "2017-09-08 19:42:20 +0000";
+layers = (
+{
+hints = (
+{
+place = "{32, 76}";
+},
+{
+place = "{179, 96}";
+},
+{
+horizontal = 1;
+place = "{-2, 106}";
+},
+{
+horizontal = 1;
+place = "{546, 71}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"262 197 LINE",
+"262 223 LINE SMOOTH",
+"262 278 OFFCURVE",
+"239 318 OFFCURVE",
+"184 358 CURVE SMOOTH",
+"129 399 OFFCURVE",
+"108 428 OFFCURVE",
+"108 464 CURVE SMOOTH",
+"108 512 OFFCURVE",
+"149 546 OFFCURVE",
+"212 546 CURVE SMOOTH",
+"257 546 OFFCURVE",
+"297 535 OFFCURVE",
+"336 516 CURVE",
+"365 577 LINE",
+"312 604 OFFCURVE",
+"262 617 OFFCURVE",
+"209 617 CURVE SMOOTH",
+"157 617 OFFCURVE",
+"114 602 OFFCURVE",
+"81 573 CURVE SMOOTH",
+"48 544 OFFCURVE",
+"32 506 OFFCURVE",
+"32 461 CURVE SMOOTH",
+"32 396 OFFCURVE",
+"66 357 OFFCURVE",
+"141 304 CURVE SMOOTH",
+"178 278 OFFCURVE",
+"197 248 OFFCURVE",
+"197 213 CURVE SMOOTH",
+"197 197 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"179 -2 LINE",
+"275 -2 LINE",
+"275 104 LINE",
+"179 104 LINE"
+);
+}
+);
+width = 379;
+}
+);
+},
+{
+glyphname = .notdef;
+lastChange = "2017-09-07 21:15:43 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"94 0 LINE",
+"505 0 LINE",
+"505 714 LINE",
+"94 714 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"145 663 LINE",
+"454 663 LINE",
+"454 51 LINE",
+"145 51 LINE"
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+color = 7;
+glyphname = minus;
+lastChange = "2017-09-08 17:23:52 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{271, 65}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"509 271 LINE",
+"509 336 LINE",
+"63 336 LINE",
+"63 271 LINE"
+);
+}
+);
+width = 573;
+}
+);
+unicode = 2212;
+},
+{
+color = 5;
+glyphname = uni066A.loclSYRJ;
+lastChange = "2017-09-08 19:42:23 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"366 586 LINE",
+"63 0 LINE",
+"137 0 LINE",
+"439 586 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"187 564 OFFCURVE",
+"152 586 OFFCURVE",
+"126 586 CURVE SMOOTH",
+"102 586 OFFCURVE",
+"68 564 OFFCURVE",
+"68 529 CURVE SMOOTH",
+"68 490 OFFCURVE",
+"101 470 OFFCURVE",
+"129 470 CURVE SMOOTH",
+"158 470 OFFCURVE",
+"187 493 OFFCURVE",
+"187 529 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"429 84 OFFCURVE",
+"394 106 OFFCURVE",
+"369 106 CURVE SMOOTH",
+"344 106 OFFCURVE",
+"310 84 OFFCURVE",
+"310 49 CURVE SMOOTH",
+"310 11 OFFCURVE",
+"343 -10 OFFCURVE",
+"372 -10 CURVE SMOOTH",
+"400 -10 OFFCURVE",
+"429 14 OFFCURVE",
+"429 49 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"366 586 LINE",
+"63 0 LINE",
+"137 0 LINE",
+"439 586 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"187 564 OFFCURVE",
+"152 586 OFFCURVE",
+"126 586 CURVE SMOOTH",
+"102 586 OFFCURVE",
+"68 564 OFFCURVE",
+"68 529 CURVE SMOOTH",
+"68 490 OFFCURVE",
+"101 470 OFFCURVE",
+"129 470 CURVE SMOOTH",
+"158 470 OFFCURVE",
+"187 493 OFFCURVE",
+"187 529 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"429 84 OFFCURVE",
+"394 106 OFFCURVE",
+"369 106 CURVE SMOOTH",
+"344 106 OFFCURVE",
+"310 84 OFFCURVE",
+"310 49 CURVE SMOOTH",
+"310 11 OFFCURVE",
+"343 -10 OFFCURVE",
+"372 -10 CURVE SMOOTH",
+"400 -10 OFFCURVE",
+"429 14 OFFCURVE",
+"429 49 CURVE SMOOTH"
+);
+}
+);
+width = 478;
+}
+);
+},
+{
+color = 7;
+glyphname = uni066A.loclSYRN;
+lastChange = "2017-09-08 19:42:26 +0000";
+layers = (
+{
+hints = (
+{
+place = "{78, 99}";
+},
+{
+place = "{320, 99}";
+},
+{
+horizontal = 1;
+place = "{0, 96}";
+},
+{
+horizontal = 1;
+place = "{480, 96}";
+},
+{
+horizontal = 1;
+place = "{586, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"366 586 LINE",
+"63 0 LINE",
+"137 0 LINE",
+"439 586 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"78 480 LINE",
+"177 480 LINE",
+"177 576 LINE",
+"78 576 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"320 0 LINE",
+"419 0 LINE",
+"419 96 LINE",
+"320 96 LINE"
+);
+}
+);
+width = 478;
+}
+);
+},
+{
+color = 7;
+glyphname = uni030A.loclSYRN.alt;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = uni030A.loclSYRN;
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0325.loclSYRN.alt;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = uni0325.loclSYRN;
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0308.loclSYRJ;
+lastChange = "2017-09-08 19:42:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 542}";
+},
+{
+name = mka;
+position = "{2, 720}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-78 586 OFFCURVE",
+"-74 573 OFFCURVE",
+"-56 573 CURVE SMOOTH",
+"-34 573 OFFCURVE",
+"-32 586 OFFCURVE",
+"-32 601 CURVE SMOOTH",
+"-32 615 OFFCURVE",
+"-34 629 OFFCURVE",
+"-56 629 CURVE SMOOTH",
+"-74 629 OFFCURVE",
+"-78 615 OFFCURVE",
+"-78 601 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"29 586 OFFCURVE",
+"33 573 OFFCURVE",
+"51 573 CURVE SMOOTH",
+"73 573 OFFCURVE",
+"75 586 OFFCURVE",
+"75 601 CURVE SMOOTH",
+"75 615 OFFCURVE",
+"73 629 OFFCURVE",
+"51 629 CURVE SMOOTH",
+"33 629 OFFCURVE",
+"29 615 OFFCURVE",
+"29 601 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-136 560 OFFCURVE",
+"-115 544 OFFCURVE",
+"-86 544 CURVE SMOOTH",
+"-54 544 OFFCURVE",
+"-35 564 OFFCURVE",
+"-35 601 CURVE SMOOTH",
+"-35 638 OFFCURVE",
+"-53 657 OFFCURVE",
+"-86 657 CURVE SMOOTH",
+"-118 657 OFFCURVE",
+"-136 638 OFFCURVE",
+"-136 601 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"33 560 OFFCURVE",
+"53 544 OFFCURVE",
+"82 544 CURVE SMOOTH",
+"115 544 OFFCURVE",
+"134 564 OFFCURVE",
+"134 601 CURVE SMOOTH",
+"134 638 OFFCURVE",
+"115 657 OFFCURVE",
+"82 657 CURVE SMOOTH",
+"51 657 OFFCURVE",
+"33 638 OFFCURVE",
+"33 601 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0307.loclSYRJ;
+lastChange = "2017-09-08 19:37:32 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 542}";
+},
+{
+name = mka;
+position = "{4, 708}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, -1, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni030A.loclSYRJ;
+lastChange = "2017-09-08 19:44:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _QU;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"64 653 OFFCURVE",
+"37 675 OFFCURVE",
+"0 675 CURVE SMOOTH",
+"-35 675 OFFCURVE",
+"-64 651 OFFCURVE",
+"-64 610 CURVE SMOOTH",
+"-64 570 OFFCURVE",
+"-37 547 OFFCURVE",
+"0 547 CURVE SMOOTH",
+"35 547 OFFCURVE",
+"64 572 OFFCURVE",
+"64 613 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-33 633 OFFCURVE",
+"-19 646 OFFCURVE",
+"0 646 CURVE SMOOTH",
+"18 646 OFFCURVE",
+"32 633 OFFCURVE",
+"32 611 CURVE SMOOTH",
+"32 590 OFFCURVE",
+"19 577 OFFCURVE",
+"0 577 CURVE SMOOTH",
+"-19 577 OFFCURVE",
+"-33 590 OFFCURVE",
+"-33 611 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"64 653 OFFCURVE",
+"37 675 OFFCURVE",
+"0 675 CURVE SMOOTH",
+"-35 675 OFFCURVE",
+"-64 651 OFFCURVE",
+"-64 610 CURVE SMOOTH",
+"-64 570 OFFCURVE",
+"-37 547 OFFCURVE",
+"0 547 CURVE SMOOTH",
+"35 547 OFFCURVE",
+"64 572 OFFCURVE",
+"64 613 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-33 633 OFFCURVE",
+"-19 646 OFFCURVE",
+"0 646 CURVE SMOOTH",
+"18 646 OFFCURVE",
+"32 633 OFFCURVE",
+"32 611 CURVE SMOOTH",
+"32 590 OFFCURVE",
+"19 577 OFFCURVE",
+"0 577 CURVE SMOOTH",
+"-19 577 OFFCURVE",
+"-33 590 OFFCURVE",
+"-33 611 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0304.loclSYRJ;
+lastChange = "2017-09-08 19:45:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 542}";
+},
+{
+name = mka;
+position = "{2, 677}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-127 550 LINE",
+"127 550 LINE",
+"127 596 LINE",
+"-127 596 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-127 550 LINE",
+"127 550 LINE",
+"127 596 LINE",
+"-127 596 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0320.loclSYRJ;
+lastChange = "2017-09-08 19:45:03 +0000";
+layers = (
+{
+components = (
+{
+name = uni0331;
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0323.loclSYRJ;
+lastChange = "2017-09-08 19:45:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = mkb;
+position = "{0, -170}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 0, -118}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0324.loclSYRJ;
+lastChange = "2017-09-08 19:45:07 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = mkb;
+position = "{-4, -179}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, -86, -115}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 82, -115}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0325.loclSYRJ;
+lastChange = "2017-09-08 19:45:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _RU;
+position = "{0, 0}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-64 -112 OFFCURVE",
+"-37 -134 OFFCURVE",
+"0 -134 CURVE SMOOTH",
+"35 -134 OFFCURVE",
+"64 -109 OFFCURVE",
+"64 -69 CURVE SMOOTH",
+"64 -28 OFFCURVE",
+"37 -6 OFFCURVE",
+"0 -6 CURVE SMOOTH",
+"-35 -6 OFFCURVE",
+"-64 -31 OFFCURVE",
+"-64 -71 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"33 -91 OFFCURVE",
+"19 -104 OFFCURVE",
+"0 -104 CURVE SMOOTH",
+"-18 -104 OFFCURVE",
+"-32 -91 OFFCURVE",
+"-32 -70 CURVE SMOOTH",
+"-32 -48 OFFCURVE",
+"-19 -36 OFFCURVE",
+"0 -36 CURVE SMOOTH",
+"19 -36 OFFCURVE",
+"33 -48 OFFCURVE",
+"33 -70 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-64 -112 OFFCURVE",
+"-37 -134 OFFCURVE",
+"0 -134 CURVE SMOOTH",
+"35 -134 OFFCURVE",
+"64 -109 OFFCURVE",
+"64 -69 CURVE SMOOTH",
+"64 -28 OFFCURVE",
+"37 -6 OFFCURVE",
+"0 -6 CURVE SMOOTH",
+"-35 -6 OFFCURVE",
+"-64 -31 OFFCURVE",
+"-64 -71 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"33 -91 OFFCURVE",
+"19 -104 OFFCURVE",
+"0 -104 CURVE SMOOTH",
+"-18 -104 OFFCURVE",
+"-32 -91 OFFCURVE",
+"-32 -70 CURVE SMOOTH",
+"-32 -48 OFFCURVE",
+"-19 -36 OFFCURVE",
+"0 -36 CURVE SMOOTH",
+"19 -36 OFFCURVE",
+"33 -48 OFFCURVE",
+"33 -70 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0308.loclSYRN;
+lastChange = "2017-09-08 19:45:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, -86, 542}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 82, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0307.loclSYRN;
+lastChange = "2017-09-08 19:37:34 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, -1, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni030A.loclSYRN;
+lastChange = "2017-09-08 19:45:15 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+place = "{-53, 106}";
+},
+{
+horizontal = 1;
+place = "{558, 106}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-53 558 LINE",
+"53 558 LINE",
+"53 664 LINE",
+"-53 664 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-25 637 LINE",
+"24 637 LINE",
+"24 584 LINE",
+"-25 584 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0304.loclSYRN;
+lastChange = "2017-09-08 19:45:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{550, 43}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-127 550 LINE",
+"127 550 LINE",
+"127 593 LINE",
+"-127 593 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0320.loclSYRN;
+lastChange = "2017-09-08 19:45:19 +0000";
+layers = (
+{
+components = (
+{
+name = uni0331;
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0323.loclSYRN;
+lastChange = "2017-09-08 19:45:27 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 0, -118}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0324.loclSYRN;
+lastChange = "2017-09-08 19:45:28 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, -86, -115}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 82, -115}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0325.loclSYRN;
+lastChange = "2017-09-08 19:45:31 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+hints = (
+{
+place = "{-53, 106}";
+},
+{
+horizontal = 1;
+place = "{-123, 105}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-53 -123 LINE",
+"53 -123 LINE",
+"53 -18 LINE",
+"-53 -18 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-25 -44 LINE",
+"24 -44 LINE",
+"24 -97 LINE",
+"-25 -97 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0732.loclSYRJ.above;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 542}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot2slant.loclSYRJ;
+transform = "{1, 0, 0, 1, 10, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0732.loclSYRN.above;
+lastChange = "2017-09-07 21:20:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, 10, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0741.loclSYRN.alt;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, -15, 556}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0742.loclSYRN.alt;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, -15, -97}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0735.loclSYRN.alt;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{-196, 792}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{726, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{542, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"95 715 OFFCURVE",
+"87 726 OFFCURVE",
+"72 726 CURVE SMOOTH",
+"59 726 OFFCURVE",
+"42 718 OFFCURVE",
+"21 701 CURVE SMOOTH",
+"0 685 OFFCURVE",
+"-10 671 OFFCURVE",
+"-10 659 CURVE SMOOTH",
+"-10 647 OFFCURVE",
+"-2 636 OFFCURVE",
+"14 636 CURVE SMOOTH",
+"27 636 OFFCURVE",
+"44 644 OFFCURVE",
+"64 661 CURVE SMOOTH",
+"85 678 OFFCURVE",
+"95 692 OFFCURVE",
+"95 704 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 621 OFFCURVE",
+"134 632 OFFCURVE",
+"119 632 CURVE SMOOTH",
+"106 632 OFFCURVE",
+"89 624 OFFCURVE",
+"68 607 CURVE SMOOTH",
+"47 591 OFFCURVE",
+"37 577 OFFCURVE",
+"37 564 CURVE SMOOTH",
+"37 553 OFFCURVE",
+"45 542 OFFCURVE",
+"61 542 CURVE SMOOTH",
+"74 542 OFFCURVE",
+"91 550 OFFCURVE",
+"111 566 CURVE SMOOTH",
+"132 583 OFFCURVE",
+"142 597 OFFCURVE",
+"142 610 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0735.loclSYRN.altB;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{-196, 792}";
+}
+);
+components = (
+{
+name = uni0735.loclSYRN.alt;
+transform = "{1, 0, 0, 1, -61, 0}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0735.loclSYRN.altC;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{-229, 755}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{726, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{541, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"12 714 OFFCURVE",
+"5 726 OFFCURVE",
+"-10 726 CURVE SMOOTH",
+"-23 726 OFFCURVE",
+"-38 717 OFFCURVE",
+"-57 698 CURVE SMOOTH",
+"-76 679 OFFCURVE",
+"-86 664 OFFCURVE",
+"-86 651 CURVE SMOOTH",
+"-86 640 OFFCURVE",
+"-78 628 OFFCURVE",
+"-63 628 CURVE SMOOTH",
+"-50 628 OFFCURVE",
+"-35 638 OFFCURVE",
+"-16 657 CURVE SMOOTH",
+"3 676 OFFCURVE",
+"12 692 OFFCURVE",
+"12 703 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"71 628 OFFCURVE",
+"64 639 OFFCURVE",
+"49 639 CURVE SMOOTH",
+"36 639 OFFCURVE",
+"20 630 OFFCURVE",
+"1 611 CURVE SMOOTH",
+"-18 592 OFFCURVE",
+"-27 577 OFFCURVE",
+"-27 564 CURVE SMOOTH",
+"-27 553 OFFCURVE",
+"-20 541 OFFCURVE",
+"-4 541 CURVE SMOOTH",
+"9 541 OFFCURVE",
+"25 551 OFFCURVE",
+"43 570 CURVE SMOOTH",
+"62 589 OFFCURVE",
+"71 605 OFFCURVE",
+"71 616 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0732.loclSYRJ.below;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -1}";
+}
+);
+components = (
+{
+name = Dot2slant.loclSYRJ;
+transform = "{1, 0, 0, 1, -9, -130}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0732.loclSYRN.below;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, -9, -121}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0711.loclSYRJ;
+lastChange = "2017-09-08 19:33:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 543}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-29 793 LINE",
+"-11 778 OFFCURVE",
+"-3 761 OFFCURVE",
+"-3 743 CURVE SMOOTH",
+"-3 728 OFFCURVE",
+"-6 713 OFFCURVE",
+"-17 687 CURVE SMOOTH",
+"-28 660 OFFCURVE",
+"-35 632 OFFCURVE",
+"-35 608 CURVE SMOOTH",
+"-35 586 OFFCURVE",
+"-30 566 OFFCURVE",
+"-20 547 CURVE",
+"13 562 LINE",
+"4 587 OFFCURVE",
+"3 597 OFFCURVE",
+"3 610 CURVE SMOOTH",
+"3 626 OFFCURVE",
+"4 641 OFFCURVE",
+"16 674 CURVE SMOOTH",
+"29 711 OFFCURVE",
+"34 726 OFFCURVE",
+"34 748 CURVE SMOOTH",
+"34 775 OFFCURVE",
+"25 795 OFFCURVE",
+"-2 818 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni074A.loclSYRJ;
+lastChange = "2017-09-08 19:37:36 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 544}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-12 542 LINE",
+"12 542 LINE",
+"12 655 LINE",
+"121 655 LINE",
+"121 679 LINE",
+"12 679 LINE",
+"12 792 LINE",
+"-12 792 LINE",
+"-12 679 LINE",
+"-122 679 LINE",
+"-122 655 LINE",
+"-12 655 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-74 709 OFFCURVE",
+"-67 703 OFFCURVE",
+"-56 703 CURVE SMOOTH",
+"-45 703 OFFCURVE",
+"-37 709 OFFCURVE",
+"-37 723 CURVE SMOOTH",
+"-37 738 OFFCURVE",
+"-45 744 OFFCURVE",
+"-56 744 CURVE SMOOTH",
+"-67 744 OFFCURVE",
+"-74 738 OFFCURVE",
+"-74 723 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 709 OFFCURVE",
+"44 703 OFFCURVE",
+"56 703 CURVE SMOOTH",
+"65 703 OFFCURVE",
+"74 709 OFFCURVE",
+"74 723 CURVE SMOOTH",
+"74 738 OFFCURVE",
+"65 744 OFFCURVE",
+"56 744 CURVE SMOOTH",
+"44 744 OFFCURVE",
+"36 738 OFFCURVE",
+"36 723 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 597 OFFCURVE",
+"44 590 OFFCURVE",
+"56 590 CURVE SMOOTH",
+"65 590 OFFCURVE",
+"74 597 OFFCURVE",
+"74 611 CURVE SMOOTH",
+"74 625 OFFCURVE",
+"65 631 OFFCURVE",
+"56 631 CURVE SMOOTH",
+"44 631 OFFCURVE",
+"36 625 OFFCURVE",
+"36 611 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-74 597 OFFCURVE",
+"-67 590 OFFCURVE",
+"-56 590 CURVE SMOOTH",
+"-45 590 OFFCURVE",
+"-37 597 OFFCURVE",
+"-37 611 CURVE SMOOTH",
+"-37 625 OFFCURVE",
+"-45 631 OFFCURVE",
+"-56 631 CURVE SMOOTH",
+"-67 631 OFFCURVE",
+"-74 625 OFFCURVE",
+"-74 611 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-12 542 LINE",
+"12 542 LINE",
+"12 655 LINE",
+"121 655 LINE",
+"121 679 LINE",
+"12 679 LINE",
+"12 792 LINE",
+"-12 792 LINE",
+"-12 679 LINE",
+"-122 679 LINE",
+"-122 655 LINE",
+"-12 655 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-74 709 OFFCURVE",
+"-67 703 OFFCURVE",
+"-56 703 CURVE SMOOTH",
+"-45 703 OFFCURVE",
+"-37 709 OFFCURVE",
+"-37 723 CURVE SMOOTH",
+"-37 738 OFFCURVE",
+"-45 744 OFFCURVE",
+"-56 744 CURVE SMOOTH",
+"-67 744 OFFCURVE",
+"-74 738 OFFCURVE",
+"-74 723 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 709 OFFCURVE",
+"44 703 OFFCURVE",
+"56 703 CURVE SMOOTH",
+"65 703 OFFCURVE",
+"74 709 OFFCURVE",
+"74 723 CURVE SMOOTH",
+"74 738 OFFCURVE",
+"65 744 OFFCURVE",
+"56 744 CURVE SMOOTH",
+"44 744 OFFCURVE",
+"36 738 OFFCURVE",
+"36 723 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"36 597 OFFCURVE",
+"44 590 OFFCURVE",
+"56 590 CURVE SMOOTH",
+"65 590 OFFCURVE",
+"74 597 OFFCURVE",
+"74 611 CURVE SMOOTH",
+"74 625 OFFCURVE",
+"65 631 OFFCURVE",
+"56 631 CURVE SMOOTH",
+"44 631 OFFCURVE",
+"36 625 OFFCURVE",
+"36 611 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-74 597 OFFCURVE",
+"-67 590 OFFCURVE",
+"-56 590 CURVE SMOOTH",
+"-45 590 OFFCURVE",
+"-37 597 OFFCURVE",
+"-37 611 CURVE SMOOTH",
+"-37 625 OFFCURVE",
+"-45 631 OFFCURVE",
+"-56 631 CURVE SMOOTH",
+"-67 631 OFFCURVE",
+"-74 625 OFFCURVE",
+"-74 611 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni073D.loclSYRJ;
+lastChange = "2017-09-08 19:37:39 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 544}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"22 687 LINE",
+"70 741 LINE",
+"42 762 LINE",
+"-104 598 LINE",
+"-77 576 LINE",
+"-2 660 LINE",
+"77 573 LINE",
+"104 599 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-31 552 OFFCURVE",
+"-19 542 OFFCURVE",
+"-1 542 CURVE SMOOTH",
+"15 542 OFFCURVE",
+"29 552 OFFCURVE",
+"29 576 CURVE SMOOTH",
+"29 599 OFFCURVE",
+"15 608 OFFCURVE",
+"-1 608 CURVE SMOOTH",
+"-19 608 OFFCURVE",
+"-31 599 OFFCURVE",
+"-31 576 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"22 687 LINE",
+"70 741 LINE",
+"42 762 LINE",
+"-104 598 LINE",
+"-77 576 LINE",
+"-2 660 LINE",
+"77 573 LINE",
+"104 599 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-31 552 OFFCURVE",
+"-19 542 OFFCURVE",
+"-1 542 CURVE SMOOTH",
+"15 542 OFFCURVE",
+"29 552 OFFCURVE",
+"29 576 CURVE SMOOTH",
+"29 599 OFFCURVE",
+"15 608 OFFCURVE",
+"-1 608 CURVE SMOOTH",
+"-19 608 OFFCURVE",
+"-31 599 OFFCURVE",
+"-31 576 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni073E.loclSYRJ;
+lastChange = "2017-09-08 19:37:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -3}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-23 -146 LINE",
+"-70 -199 LINE",
+"-42 -221 LINE",
+"104 -57 LINE",
+"78 -35 LINE",
+"2 -118 LINE",
+"-77 -32 LINE",
+"-104 -57 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"31 -11 OFFCURVE",
+"19 0 OFFCURVE",
+"1 0 CURVE SMOOTH",
+"-15 0 OFFCURVE",
+"-29 -11 OFFCURVE",
+"-29 -34 CURVE SMOOTH",
+"-29 -57 OFFCURVE",
+"-15 -67 OFFCURVE",
+"1 -67 CURVE SMOOTH",
+"19 -67 OFFCURVE",
+"31 -57 OFFCURVE",
+"31 -34 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-23 -146 LINE",
+"-70 -199 LINE",
+"-42 -221 LINE",
+"104 -57 LINE",
+"78 -35 LINE",
+"2 -118 LINE",
+"-77 -32 LINE",
+"-104 -57 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"31 -11 OFFCURVE",
+"19 0 OFFCURVE",
+"1 0 CURVE SMOOTH",
+"-15 0 OFFCURVE",
+"-29 -11 OFFCURVE",
+"-29 -34 CURVE SMOOTH",
+"-29 -57 OFFCURVE",
+"-15 -67 OFFCURVE",
+"1 -67 CURVE SMOOTH",
+"19 -67 OFFCURVE",
+"31 -57 OFFCURVE",
+"31 -34 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0740.loclSYRJ;
+lastChange = "2017-09-08 19:37:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+position = "{0, 542}";
+},
+{
+name = mka;
+position = "{0, 544}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, -138, 316}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni073C.loclSYRJ;
+lastChange = "2017-09-08 19:37:46 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -3}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-33 -69 OFFCURVE",
+"-37 -82 OFFCURVE",
+"-37 -94 CURVE SMOOTH",
+"-37 -110 OFFCURVE",
+"-31 -122 OFFCURVE",
+"-14 -122 CURVE SMOOTH",
+"3 -122 OFFCURVE",
+"15 -104 OFFCURVE",
+"26 -77 CURVE",
+"32 -60 OFFCURVE",
+"37 -47 OFFCURVE",
+"37 -35 CURVE SMOOTH",
+"37 -19 OFFCURVE",
+"31 -7 OFFCURVE",
+"14 -7 CURVE SMOOTH",
+"-3 -7 OFFCURVE",
+"-16 -25 OFFCURVE",
+"-27 -52 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0747.loclSYRJ;
+lastChange = "2017-09-08 19:37:48 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 545}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-113 554 LINE",
+"-84 524 LINE",
+"102 679 LINE",
+"74 709 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-113 554 LINE",
+"-84 524 LINE",
+"102 679 LINE",
+"74 709 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0748.loclSYRJ;
+lastChange = "2017-09-08 19:37:50 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -3}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"73 -168 LINE",
+"102 -138 LINE",
+"-84 18 LINE",
+"-113 -13 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"73 -168 LINE",
+"102 -138 LINE",
+"-84 18 LINE",
+"-113 -13 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0730.loclSYRJ;
+lastChange = "2017-09-08 19:37:52 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 544}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"61 724 LINE",
+"-87 736 LINE",
+"-89 585 LINE",
+"-119 559 LINE",
+"-95 533 LINE",
+"112 723 LINE",
+"88 749 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"26 692 LINE",
+"-56 617 LINE",
+"-53 697 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"61 724 LINE",
+"-87 736 LINE",
+"-89 585 LINE",
+"-119 559 LINE",
+"-95 533 LINE",
+"112 723 LINE",
+"88 749 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"26 692 LINE",
+"-56 617 LINE",
+"-53 697 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0731.loclSYRJ;
+lastChange = "2017-09-08 19:37:54 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -2}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-61 -183 LINE",
+"87 -194 LINE",
+"89 -43 LINE",
+"119 -17 LINE",
+"94 9 LINE",
+"-112 -182 LINE",
+"-88 -208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-26 -150 LINE",
+"56 -75 LINE",
+"53 -155 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-61 -183 LINE",
+"87 -194 LINE",
+"89 -43 LINE",
+"119 -17 LINE",
+"94 9 LINE",
+"-112 -182 LINE",
+"-88 -208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-26 -150 LINE",
+"56 -75 LINE",
+"53 -155 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0732.loclSYRJ;
+lastChange = "2017-09-08 19:37:56 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-22 602 OFFCURVE",
+"-26 589 OFFCURVE",
+"-26 577 CURVE SMOOTH",
+"-26 561 OFFCURVE",
+"-20 549 OFFCURVE",
+"-3 549 CURVE SMOOTH",
+"14 549 OFFCURVE",
+"27 567 OFFCURVE",
+"37 594 CURVE SMOOTH",
+"43 610 OFFCURVE",
+"48 624 OFFCURVE",
+"48 636 CURVE SMOOTH",
+"48 652 OFFCURVE",
+"42 664 OFFCURVE",
+"25 664 CURVE SMOOTH",
+"8 664 OFFCURVE",
+"-6 646 OFFCURVE",
+"-16 619 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-42 -69 OFFCURVE",
+"-46 -82 OFFCURVE",
+"-46 -94 CURVE SMOOTH",
+"-46 -110 OFFCURVE",
+"-40 -122 OFFCURVE",
+"-23 -122 CURVE SMOOTH",
+"-6 -122 OFFCURVE",
+"7 -104 OFFCURVE",
+"17 -77 CURVE SMOOTH",
+"23 -61 OFFCURVE",
+"28 -47 OFFCURVE",
+"28 -35 CURVE SMOOTH",
+"28 -19 OFFCURVE",
+"22 -7 OFFCURVE",
+"5 -7 CURVE SMOOTH",
+"-12 -7 OFFCURVE",
+"-26 -25 OFFCURVE",
+"-36 -52 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0741.loclSYRJ;
+lastChange = "2017-09-08 19:37:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _QU;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, -27, 551}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0742.loclSYRJ;
+lastChange = "2017-09-08 19:38:00 +0000";
+layers = (
+{
+anchors = (
+{
+name = _RU;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 0, -103}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni073F.loclSYRJ;
+lastChange = "2017-09-08 19:38:02 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 545}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-33 603 OFFCURVE",
+"-37 590 OFFCURVE",
+"-37 578 CURVE SMOOTH",
+"-37 562 OFFCURVE",
+"-31 550 OFFCURVE",
+"-14 550 CURVE SMOOTH",
+"3 550 OFFCURVE",
+"16 568 OFFCURVE",
+"26 595 CURVE SMOOTH",
+"32 611 OFFCURVE",
+"37 625 OFFCURVE",
+"37 637 CURVE SMOOTH",
+"37 653 OFFCURVE",
+"31 665 OFFCURVE",
+"14 665 CURVE SMOOTH",
+"-3 665 OFFCURVE",
+"-16 647 OFFCURVE",
+"-27 620 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0745.loclSYRJ;
+lastChange = "2017-09-08 19:38:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 545}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 69, 542}";
+},
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 0, 666}";
+},
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, -68, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0746.loclSYRJ;
+lastChange = "2017-09-08 19:38:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -3}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 69, -82}";
+},
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 0, -206}";
+},
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, -68, -82}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0743.loclSYRJ;
+lastChange = "2017-09-08 19:38:08 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 545}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 0, 542}";
+},
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 0, 666}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0744.loclSYRJ;
+lastChange = "2017-09-08 19:38:10 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -3}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 0, -206}";
+},
+{
+name = Dot3.loclSYRJ;
+transform = "{1, 0, 0, 1, 0, -82}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0739.loclSYRJ;
+lastChange = "2017-09-08 19:38:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -4}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-97 -132 OFFCURVE",
+"-101 -145 OFFCURVE",
+"-101 -157 CURVE SMOOTH",
+"-101 -173 OFFCURVE",
+"-95 -185 OFFCURVE",
+"-78 -185 CURVE SMOOTH",
+"-61 -185 OFFCURVE",
+"-49 -167 OFFCURVE",
+"-38 -140 CURVE",
+"-32 -123 OFFCURVE",
+"-27 -110 OFFCURVE",
+"-27 -98 CURVE SMOOTH",
+"-27 -82 OFFCURVE",
+"-33 -70 OFFCURVE",
+"-50 -70 CURVE SMOOTH",
+"-67 -70 OFFCURVE",
+"-80 -88 OFFCURVE",
+"-91 -115 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"32 -69 OFFCURVE",
+"28 -82 OFFCURVE",
+"28 -94 CURVE SMOOTH",
+"28 -110 OFFCURVE",
+"34 -122 OFFCURVE",
+"51 -122 CURVE SMOOTH",
+"68 -122 OFFCURVE",
+"80 -104 OFFCURVE",
+"91 -77 CURVE",
+"97 -60 OFFCURVE",
+"102 -47 OFFCURVE",
+"102 -35 CURVE SMOOTH",
+"102 -19 OFFCURVE",
+"96 -7 OFFCURVE",
+"79 -7 CURVE SMOOTH",
+"62 -7 OFFCURVE",
+"49 -25 OFFCURVE",
+"38 -52 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0738.loclSYRJ;
+lastChange = "2017-09-08 19:38:14 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -3}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-97 -69 OFFCURVE",
+"-101 -82 OFFCURVE",
+"-101 -94 CURVE SMOOTH",
+"-101 -110 OFFCURVE",
+"-95 -122 OFFCURVE",
+"-78 -122 CURVE SMOOTH",
+"-61 -122 OFFCURVE",
+"-49 -104 OFFCURVE",
+"-38 -77 CURVE",
+"-32 -60 OFFCURVE",
+"-27 -47 OFFCURVE",
+"-27 -35 CURVE SMOOTH",
+"-27 -19 OFFCURVE",
+"-33 -7 OFFCURVE",
+"-50 -7 CURVE SMOOTH",
+"-67 -7 OFFCURVE",
+"-80 -25 OFFCURVE",
+"-91 -52 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"32 -69 OFFCURVE",
+"28 -82 OFFCURVE",
+"28 -94 CURVE SMOOTH",
+"28 -110 OFFCURVE",
+"34 -122 OFFCURVE",
+"51 -122 CURVE SMOOTH",
+"68 -122 OFFCURVE",
+"80 -104 OFFCURVE",
+"91 -77 CURVE",
+"97 -60 OFFCURVE",
+"102 -47 OFFCURVE",
+"102 -35 CURVE SMOOTH",
+"102 -19 OFFCURVE",
+"96 -7 OFFCURVE",
+"79 -7 CURVE SMOOTH",
+"62 -7 OFFCURVE",
+"49 -25 OFFCURVE",
+"38 -52 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0733.loclSYRJ;
+lastChange = "2017-09-08 19:38:17 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 544}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-60 639 OFFCURVE",
+"-54 617 OFFCURVE",
+"-42 591 CURVE",
+"-54 582 OFFCURVE",
+"-69 572 OFFCURVE",
+"-87 559 CURVE",
+"-66 531 LINE",
+"-8 571 OFFCURVE",
+"20 592 OFFCURVE",
+"43 617 CURVE",
+"72 646 OFFCURVE",
+"78 672 OFFCURVE",
+"78 691 CURVE SMOOTH",
+"78 726 OFFCURVE",
+"56 753 OFFCURVE",
+"15 753 CURVE SMOOTH",
+"-34 753 OFFCURVE",
+"-60 713 OFFCURVE",
+"-60 665 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"9 632 OFFCURVE",
+"0 624 OFFCURVE",
+"-11 615 CURVE",
+"-19 628 OFFCURVE",
+"-24 646 OFFCURVE",
+"-24 665 CURVE SMOOTH",
+"-24 686 OFFCURVE",
+"-17 717 OFFCURVE",
+"13 717 CURVE SMOOTH",
+"30 717 OFFCURVE",
+"41 705 OFFCURVE",
+"41 687 CURVE SMOOTH",
+"41 674 OFFCURVE",
+"34 658 OFFCURVE",
+"18 641 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-60 639 OFFCURVE",
+"-54 617 OFFCURVE",
+"-42 591 CURVE",
+"-54 582 OFFCURVE",
+"-69 572 OFFCURVE",
+"-87 559 CURVE",
+"-66 531 LINE",
+"-8 571 OFFCURVE",
+"19 592 OFFCURVE",
+"43 617 CURVE SMOOTH",
+"71 647 OFFCURVE",
+"78 672 OFFCURVE",
+"78 691 CURVE SMOOTH",
+"78 726 OFFCURVE",
+"56 753 OFFCURVE",
+"15 753 CURVE SMOOTH",
+"-34 753 OFFCURVE",
+"-60 713 OFFCURVE",
+"-60 665 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"9 632 OFFCURVE",
+"0 624 OFFCURVE",
+"-11 615 CURVE",
+"-19 628 OFFCURVE",
+"-24 646 OFFCURVE",
+"-24 665 CURVE SMOOTH",
+"-24 686 OFFCURVE",
+"-17 717 OFFCURVE",
+"13 717 CURVE SMOOTH",
+"30 717 OFFCURVE",
+"41 705 OFFCURVE",
+"41 687 CURVE SMOOTH",
+"41 674 OFFCURVE",
+"34 658 OFFCURVE",
+"18 641 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0734.loclSYRJ;
+lastChange = "2017-09-08 19:38:19 +0000";
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+position = "{0, 0}";
+},
+{
+name = _mkb;
+position = "{0, -4}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"61 -100 OFFCURVE",
+"55 -78 OFFCURVE",
+"43 -52 CURVE",
+"55 -42 OFFCURVE",
+"70 -32 OFFCURVE",
+"88 -20 CURVE",
+"67 9 LINE",
+"8 -32 OFFCURVE",
+"-19 -53 OFFCURVE",
+"-42 -78 CURVE",
+"-71 -107 OFFCURVE",
+"-78 -132 OFFCURVE",
+"-78 -152 CURVE SMOOTH",
+"-78 -187 OFFCURVE",
+"-55 -214 OFFCURVE",
+"-14 -214 CURVE SMOOTH",
+"35 -214 OFFCURVE",
+"61 -175 OFFCURVE",
+"61 -125 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-8 -93 OFFCURVE",
+"0 -84 OFFCURVE",
+"12 -75 CURVE",
+"20 -89 OFFCURVE",
+"25 -106 OFFCURVE",
+"25 -125 CURVE SMOOTH",
+"25 -146 OFFCURVE",
+"18 -177 OFFCURVE",
+"-12 -177 CURVE SMOOTH",
+"-29 -177 OFFCURVE",
+"-40 -166 OFFCURVE",
+"-40 -148 CURVE SMOOTH",
+"-40 -135 OFFCURVE",
+"-34 -119 OFFCURVE",
+"-17 -102 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"61 -100 OFFCURVE",
+"55 -78 OFFCURVE",
+"43 -52 CURVE",
+"55 -42 OFFCURVE",
+"70 -32 OFFCURVE",
+"88 -20 CURVE",
+"67 9 LINE",
+"8 -32 OFFCURVE",
+"-19 -53 OFFCURVE",
+"-42 -78 CURVE",
+"-71 -107 OFFCURVE",
+"-78 -132 OFFCURVE",
+"-78 -152 CURVE SMOOTH",
+"-78 -187 OFFCURVE",
+"-55 -214 OFFCURVE",
+"-14 -214 CURVE SMOOTH",
+"35 -214 OFFCURVE",
+"61 -175 OFFCURVE",
+"61 -125 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-8 -93 OFFCURVE",
+"0 -84 OFFCURVE",
+"12 -75 CURVE",
+"20 -89 OFFCURVE",
+"25 -106 OFFCURVE",
+"25 -125 CURVE SMOOTH",
+"25 -146 OFFCURVE",
+"18 -177 OFFCURVE",
+"-12 -177 CURVE SMOOTH",
+"-29 -177 OFFCURVE",
+"-40 -166 OFFCURVE",
+"-40 -148 CURVE SMOOTH",
+"-40 -135 OFFCURVE",
+"-34 -119 OFFCURVE",
+"-17 -102 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni0735.loclSYRJ;
+lastChange = "2017-09-08 19:38:22 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 544}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-17 604 OFFCURVE",
+"-29 585 OFFCURVE",
+"-29 568 CURVE SMOOTH",
+"-29 555 OFFCURVE",
+"-21 545 OFFCURVE",
+"-6 545 CURVE SMOOTH",
+"8 545 OFFCURVE",
+"22 558 OFFCURVE",
+"38 579 CURVE SMOOTH",
+"48 592 OFFCURVE",
+"61 611 OFFCURVE",
+"61 627 CURVE SMOOTH",
+"61 639 OFFCURVE",
+"52 650 OFFCURVE",
+"38 650 CURVE SMOOTH",
+"23 650 OFFCURVE",
+"9 638 OFFCURVE",
+"-7 617 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-45 724 OFFCURVE",
+"-59 705 OFFCURVE",
+"-59 688 CURVE SMOOTH",
+"-59 675 OFFCURVE",
+"-51 666 OFFCURVE",
+"-36 666 CURVE SMOOTH",
+"-21 666 OFFCURVE",
+"-7 678 OFFCURVE",
+"9 699 CURVE SMOOTH",
+"19 712 OFFCURVE",
+"32 731 OFFCURVE",
+"32 747 CURVE SMOOTH",
+"32 759 OFFCURVE",
+"23 770 OFFCURVE",
+"9 770 CURVE SMOOTH",
+"-6 770 OFFCURVE",
+"-20 758 OFFCURVE",
+"-36 737 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-17 604 OFFCURVE",
+"-29 585 OFFCURVE",
+"-29 568 CURVE SMOOTH",
+"-29 555 OFFCURVE",
+"-21 545 OFFCURVE",
+"-6 545 CURVE SMOOTH",
+"8 545 OFFCURVE",
+"22 558 OFFCURVE",
+"38 579 CURVE SMOOTH",
+"48 592 OFFCURVE",
+"61 611 OFFCURVE",
+"61 627 CURVE SMOOTH",
+"61 639 OFFCURVE",
+"52 650 OFFCURVE",
+"38 650 CURVE SMOOTH",
+"23 650 OFFCURVE",
+"9 638 OFFCURVE",
+"-7 617 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-45 725 OFFCURVE",
+"-59 705 OFFCURVE",
+"-59 688 CURVE SMOOTH",
+"-59 675 OFFCURVE",
+"-51 666 OFFCURVE",
+"-36 666 CURVE SMOOTH",
+"-21 666 OFFCURVE",
+"-7 678 OFFCURVE",
+"9 699 CURVE SMOOTH",
+"19 712 OFFCURVE",
+"32 731 OFFCURVE",
+"32 747 CURVE SMOOTH",
+"32 759 OFFCURVE",
+"23 770 OFFCURVE",
+"9 770 CURVE SMOOTH",
+"-6 770 OFFCURVE",
+"-20 758 OFFCURVE",
+"-36 737 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0711.loclSYRN;
+lastChange = "2017-09-08 19:33:39 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+place = "{0, 35}";
+},
+{
+horizontal = 1;
+place = "{483, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{742, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-59 483 LINE",
+"51 483 LINE",
+"51 516 LINE",
+"23 516 LINE SMOOTH",
+"11 516 OFFCURVE",
+"-2 516 OFFCURVE",
+"-16 515 CURVE",
+"-16 518 LINE",
+"23 569 OFFCURVE",
+"35 616 OFFCURVE",
+"35 659 CURVE SMOOTH",
+"35 714 OFFCURVE",
+"16 739 OFFCURVE",
+"-24 742 CURVE",
+"-41 708 LINE",
+"-9 695 LINE",
+"-2 687 OFFCURVE",
+"0 670 OFFCURVE",
+"0 655 CURVE SMOOTH",
+"0 612 OFFCURVE",
+"-18 558 OFFCURVE",
+"-58 509 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni074A.loclSYRN;
+lastChange = "2017-09-08 19:38:25 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+place = "{-78, 37}";
+},
+{
+place = "{-12, 24}";
+},
+{
+place = "{40, 37}";
+},
+{
+horizontal = 1;
+place = "{589, 38}";
+},
+{
+horizontal = 1;
+place = "{655, 24}";
+},
+{
+horizontal = 1;
+place = "{707, 38}";
+},
+{
+horizontal = 1;
+place = "{542, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{792, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-12 542 LINE",
+"12 542 LINE",
+"12 655 LINE",
+"121 655 LINE",
+"121 679 LINE",
+"12 679 LINE",
+"12 792 LINE",
+"-12 792 LINE",
+"-12 679 LINE",
+"-122 679 LINE",
+"-122 655 LINE",
+"-12 655 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"40 707 LINE",
+"77 707 LINE",
+"77 745 LINE",
+"40 745 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-78 707 LINE",
+"-41 707 LINE",
+"-41 745 LINE",
+"-78 745 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-78 589 LINE",
+"-41 589 LINE",
+"-41 627 LINE",
+"-78 627 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"40 589 LINE",
+"77 589 LINE",
+"77 627 LINE",
+"40 627 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni073D.loclSYRN;
+lastChange = "2017-09-08 19:38:27 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{762, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{542, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"22 687 LINE",
+"70 741 LINE",
+"42 762 LINE",
+"-104 598 LINE",
+"-77 576 LINE",
+"-2 660 LINE",
+"77 573 LINE",
+"104 599 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-26 542 LINE",
+"23 542 LINE",
+"23 596 LINE",
+"-26 596 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni073E.loclSYRN;
+lastChange = "2017-09-08 19:38:30 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{-221, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{0, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-23 -146 LINE",
+"-70 -199 LINE",
+"-42 -221 LINE",
+"104 -57 LINE",
+"78 -35 LINE",
+"2 -118 LINE",
+"-77 -32 LINE",
+"-104 -57 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"26 0 LINE",
+"-23 0 LINE",
+"-23 -55 LINE",
+"26 -55 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0740.loclSYRN;
+lastChange = "2017-09-08 19:38:32 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, -86, -115}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 82, -115}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni073C.loclSYRN;
+lastChange = "2017-09-08 19:38:35 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, 0, -130}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0747.loclSYRN;
+lastChange = "2017-09-08 19:38:38 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{543, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{642, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-124 583 LINE",
+"-111 543 LINE",
+"124 604 LINE",
+"111 642 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0748.loclSYRN;
+lastChange = "2017-09-08 19:38:39 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{-2, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-101, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"124 -42 LINE",
+"111 -2 LINE",
+"-124 -62 LINE",
+"-111 -101 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0730.loclSYRN;
+lastChange = "2017-09-08 19:38:41 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+place = "{-88, 33}";
+},
+{
+horizontal = 1;
+place = "{533, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{749, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"61 724 LINE",
+"-87 736 LINE",
+"-89 585 LINE",
+"-119 559 LINE",
+"-95 533 LINE",
+"112 723 LINE",
+"88 749 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-42 628 LINE",
+"-54 616 LINE",
+"-57 616 LINE",
+"-53 697 LINE",
+"26 692 LINE",
+"26 690 LINE",
+"8 674 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0731.loclSYRN;
+lastChange = "2017-09-08 19:38:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+hints = (
+{
+place = "{54, 34}";
+},
+{
+horizontal = 1;
+place = "{-188, 35}";
+},
+{
+horizontal = 1;
+place = "{9, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{-208, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-61 -183 LINE",
+"87 -194 LINE",
+"89 -43 LINE",
+"118 -17 LINE",
+"94 9 LINE",
+"-112 -182 LINE",
+"-88 -208 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"42 -86 LINE",
+"54 -74 LINE",
+"56 -75 LINE",
+"53 -155 LINE",
+"-27 -151 LINE",
+"-27 -148 LINE",
+"-8 -133 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0732.loclSYRN;
+lastChange = "2017-09-08 19:38:46 +0000";
+layers = (
+{
+components = (
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, 11, 541}";
+},
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, -9, -121}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0741.loclSYRN;
+lastChange = "2017-09-08 19:38:49 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, -15, 556}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0742.loclSYRN;
+lastChange = "2017-09-08 19:38:51 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, -15, -97}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni073F.loclSYRN;
+lastChange = "2017-09-08 19:38:53 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, 0, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0745.loclSYRN;
+lastChange = "2017-09-08 19:38:56 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, 69, 542}";
+},
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, 0, 666}";
+},
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, -68, 542}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0746.loclSYRN;
+lastChange = "2017-09-08 19:38:58 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, 69, -82}";
+},
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, 0, -206}";
+},
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, -68, -82}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0743.loclSYRN;
+lastChange = "2017-09-08 19:39:01 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, 0, 542}";
+},
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, 0, 666}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0744.loclSYRN;
+lastChange = "2017-09-08 19:39:04 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, 0, -206}";
+},
+{
+name = Dot3.loclSYRN;
+transform = "{1, 0, 0, 1, 0, -82}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0739.loclSYRN;
+lastChange = "2017-09-08 19:39:06 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, -50, -179}";
+},
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, 57, -106}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0738.loclSYRN;
+lastChange = "2017-09-08 19:39:09 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+components = (
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, -54, -121}";
+},
+{
+name = Dot2slant.loclSYRN;
+transform = "{1, 0, 0, 1, 55, -121}";
+}
+);
+layerId = UUID0;
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0733.loclSYRN;
+lastChange = "2017-09-08 19:39:11 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+place = "{-60, 36}";
+},
+{
+place = "{41, 37}";
+},
+{
+horizontal = 1;
+place = "{717, 36}";
+},
+{
+horizontal = 1;
+place = "{531, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"78 726 OFFCURVE",
+"55 753 OFFCURVE",
+"15 753 CURVE SMOOTH",
+"-33 753 OFFCURVE",
+"-60 714 OFFCURVE",
+"-60 665 CURVE SMOOTH",
+"-60 638 OFFCURVE",
+"-55 618 OFFCURVE",
+"-43 591 CURVE",
+"-87 559 LINE",
+"-66 531 LINE",
+"-28 558 LINE SMOOTH",
+"15 588 OFFCURVE",
+"44 613 OFFCURVE",
+"57 632 CURVE SMOOTH",
+"71 651 OFFCURVE",
+"78 671 OFFCURVE",
+"78 691 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"-13 614 LINE",
+"-20 627 OFFCURVE",
+"-24 645 OFFCURVE",
+"-24 665 CURVE SMOOTH",
+"-24 694 OFFCURVE",
+"-11 717 OFFCURVE",
+"13 717 CURVE SMOOTH",
+"29 717 OFFCURVE",
+"41 706 OFFCURVE",
+"41 687 CURVE SMOOTH",
+"41 662 OFFCURVE",
+"24 641 OFFCURVE",
+"-11 614 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0734.loclSYRN;
+lastChange = "2017-09-08 19:39:13 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 0}";
+}
+);
+hints = (
+{
+place = "{-78, 38}";
+},
+{
+place = "{25, 36}";
+},
+{
+horizontal = 1;
+place = "{-214, 36}";
+},
+{
+horizontal = 1;
+place = "{8, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-78 -188 OFFCURVE",
+"-55 -214 OFFCURVE",
+"-14 -214 CURVE SMOOTH",
+"33 -214 OFFCURVE",
+"61 -177 OFFCURVE",
+"61 -126 CURVE SMOOTH",
+"61 -99 OFFCURVE",
+"55 -78 OFFCURVE",
+"43 -53 CURVE",
+"87 -21 LINE",
+"67 8 LINE",
+"29 -19 LINE SMOOTH",
+"-58 -79 OFFCURVE",
+"-78 -113 OFFCURVE",
+"-78 -152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"13 -75 LINE",
+"21 -88 OFFCURVE",
+"25 -107 OFFCURVE",
+"25 -126 CURVE SMOOTH",
+"25 -157 OFFCURVE",
+"11 -178 OFFCURVE",
+"-12 -178 CURVE SMOOTH",
+"-29 -178 OFFCURVE",
+"-40 -167 OFFCURVE",
+"-40 -148 CURVE SMOOTH",
+"-40 -123 OFFCURVE",
+"-24 -102 OFFCURVE",
+"11 -75 CURVE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni0735.loclSYRN;
+lastChange = "2017-09-08 19:39:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mark0;
+position = "{0, 542}";
+}
+);
+hints = (
+{
+horizontal = 1;
+place = "{545, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{768, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"61 639 OFFCURVE",
+"53 650 OFFCURVE",
+"38 650 CURVE SMOOTH",
+"25 650 OFFCURVE",
+"11 639 OFFCURVE",
+"-5 618 CURVE SMOOTH",
+"-21 597 OFFCURVE",
+"-29 581 OFFCURVE",
+"-29 568 CURVE SMOOTH",
+"-29 556 OFFCURVE",
+"-22 545 OFFCURVE",
+"-6 545 CURVE SMOOTH",
+"7 545 OFFCURVE",
+"21 555 OFFCURVE",
+"37 576 CURVE SMOOTH",
+"53 597 OFFCURVE",
+"61 614 OFFCURVE",
+"61 627 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"32 757 OFFCURVE",
+"24 768 OFFCURVE",
+"9 768 CURVE SMOOTH",
+"-4 768 OFFCURVE",
+"-19 757 OFFCURVE",
+"-35 736 CURVE SMOOTH",
+"-51 715 OFFCURVE",
+"-59 699 OFFCURVE",
+"-59 686 CURVE SMOOTH",
+"-59 673 OFFCURVE",
+"-51 663 OFFCURVE",
+"-36 663 CURVE SMOOTH",
+"-23 663 OFFCURVE",
+"-9 673 OFFCURVE",
+"7 694 CURVE SMOOTH",
+"24 715 OFFCURVE",
+"32 732 OFFCURVE",
+"32 745 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = Wasla.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 543}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-90 598 OFFCURVE",
+"-113 569 OFFCURVE",
+"-127 550 CURVE",
+"-100 533 LINE",
+"-88 546 OFFCURVE",
+"-76 562 OFFCURVE",
+"-71 567 CURVE",
+"-47 556 OFFCURVE",
+"-17 549 OFFCURVE",
+"15 549 CURVE SMOOTH",
+"96 549 OFFCURVE",
+"118 588 OFFCURVE",
+"118 621 CURVE SMOOTH",
+"118 658 OFFCURVE",
+"87 679 OFFCURVE",
+"60 679 CURVE SMOOTH",
+"31 679 OFFCURVE",
+"2 667 OFFCURVE",
+"-39 595 CURVE",
+"-53 599 OFFCURVE",
+"-65 603 OFFCURVE",
+"-78 608 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"72 643 OFFCURVE",
+"83 632 OFFCURVE",
+"83 617 CURVE SMOOTH",
+"83 606 OFFCURVE",
+"73 587 OFFCURVE",
+"25 587 CURVE SMOOTH",
+"15 587 OFFCURVE",
+"5 587 OFFCURVE",
+"-3 588 CURVE",
+"16 622 OFFCURVE",
+"34 643 OFFCURVE",
+"56 643 CURVE SMOOTH"
+);
+}
+);
+};
+hints = (
+{
+horizontal = 1;
+place = "{549, 38}";
+},
+{
+horizontal = 1;
+place = "{643, 36}";
+},
+{
+horizontal = 1;
+place = "{533, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-90 598 OFFCURVE",
+"-113 569 OFFCURVE",
+"-127 550 CURVE",
+"-100 533 LINE",
+"-88 546 OFFCURVE",
+"-76 562 OFFCURVE",
+"-71 567 CURVE",
+"-47 556 OFFCURVE",
+"-17 549 OFFCURVE",
+"15 549 CURVE SMOOTH",
+"96 549 OFFCURVE",
+"118 588 OFFCURVE",
+"118 621 CURVE SMOOTH",
+"118 658 OFFCURVE",
+"87 679 OFFCURVE",
+"60 679 CURVE SMOOTH",
+"31 679 OFFCURVE",
+"2 667 OFFCURVE",
+"-39 595 CURVE",
+"-53 599 OFFCURVE",
+"-65 603 OFFCURVE",
+"-78 608 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"72 643 OFFCURVE",
+"83 632 OFFCURVE",
+"83 617 CURVE SMOOTH",
+"83 606 OFFCURVE",
+"73 587 OFFCURVE",
+"25 587 CURVE SMOOTH",
+"15 587 OFFCURVE",
+"5 587 OFFCURVE",
+"-3 588 CURVE",
+"16 622 OFFCURVE",
+"34 643 OFFCURVE",
+"56 643 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = uni072Auni0308.loclSYRN.Isol;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{259, -98}";
+}
+);
+components = (
+{
+name = uni0716.loclSYRN;
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 328, 505}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 144, 505}";
+}
+);
+layerId = UUID0;
+width = 521;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = uni072Auni0308.loclSYRN.Fina;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+anchors = (
+{
+name = mark0;
+position = "{259, -98}";
+}
+);
+components = (
+{
+name = uni0716.loclSYRN.Fina;
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 144, 505}";
+},
+{
+name = Dot1.loclSYRN;
+transform = "{1, 0, 0, 1, 328, 505}";
+}
+);
+layerId = UUID0;
+width = 518;
+}
+);
+rightKerningGroup = uni0715;
+},
+{
+color = 7;
+glyphname = Dot1.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+place = "{-40, 82}";
+},
+{
+horizontal = 1;
+place = "{17, 85}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-40 17 LINE",
+"42 17 LINE",
+"42 102 LINE",
+"-40 102 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = Dot2slant.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+place = "{-32, 63}";
+},
+{
+horizontal = 1;
+place = "{6, 119}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"31 109 OFFCURVE",
+"25 125 OFFCURVE",
+"8 125 CURVE SMOOTH",
+"-7 125 OFFCURVE",
+"-17 115 OFFCURVE",
+"-23 94 CURVE SMOOTH",
+"-29 73 OFFCURVE",
+"-32 56 OFFCURVE",
+"-32 42 CURVE SMOOTH",
+"-32 22 OFFCURVE",
+"-25 6 OFFCURVE",
+"-9 6 CURVE SMOOTH",
+"14 6 OFFCURVE",
+"31 41 OFFCURVE",
+"31 89 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = Dot3.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{8, 21}";
+target = up;
+type = BottomGhost;
+},
+{
+horizontal = 1;
+place = "{76, -20}";
+target = down;
+type = TopGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-32 8 LINE",
+"32 8 LINE",
+"32 76 LINE",
+"-32 76 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = Dot1p.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+place = "{-43, 88}";
+},
+{
+horizontal = 1;
+place = "{13, 92}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-43 13 LINE",
+"45 13 LINE",
+"45 105 LINE",
+"-43 105 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = Stretch.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+place = "{-39, 115}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"76 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"76 0 LINE"
+);
+}
+);
+width = 76;
+}
+);
+},
+{
+color = 7;
+glyphname = Stretch2.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+place = "{-39, 175}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"136 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"136 0 LINE"
+);
+}
+);
+width = 136;
+}
+);
+},
+{
+color = 7;
+glyphname = Stretch3.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+place = "{-39, 70}";
+},
+{
+horizontal = 1;
+place = "{76, -20}";
+target = down;
+type = TopGhost;
+},
+{
+horizontal = 1;
+place = "{0, 21}";
+target = up;
+type = BottomGhost;
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"31 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"31 0 LINE"
+);
+}
+);
+width = 31;
+}
+);
+},
+{
+color = 7;
+glyphname = Stretch5.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+place = "{-39, 149}";
+},
+{
+horizontal = 1;
+place = "{0, 76}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"110 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"110 0 LINE"
+);
+}
+);
+width = 110;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM4in.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-215 815 LINE",
+"20 815 LINE",
+"20 850 LINE",
+"-215 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM8in.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-410 815 LINE",
+"20 815 LINE",
+"20 850 LINE",
+"-410 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM4out.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-20 815 LINE",
+"215 815 LINE",
+"215 850 LINE",
+"-20 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM12out.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-20 815 LINE",
+"605 815 LINE",
+"605 850 LINE",
+"-20 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM18out.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-20 815 LINE",
+"898 815 LINE",
+"898 850 LINE",
+"-20 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM4xin.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-215 815 LINE",
+"-68 815 LINE",
+"-68 850 LINE",
+"-215 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM8xin.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-410 815 LINE",
+"-68 815 LINE",
+"-68 850 LINE",
+"-410 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM4xout.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"59 815 LINE",
+"215 815 LINE",
+"215 850 LINE",
+"59 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM12xout.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"59 815 LINE",
+"605 815 LINE",
+"605 850 LINE",
+"59 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 7;
+glyphname = SAM18xout.loclSYRN;
+lastChange = "2017-09-07 21:20:12 +0000";
+layers = (
+{
+hints = (
+{
+horizontal = 1;
+place = "{815, 35}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"59 815 LINE",
+"898 815 LINE",
+"898 850 LINE",
+"59 850 LINE"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = Wasla.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = _mka;
+position = "{0, 543}";
+},
+{
+name = _top;
+position = "{0, 542}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-90 598 OFFCURVE",
+"-113 569 OFFCURVE",
+"-127 550 CURVE",
+"-100 533 LINE",
+"-88 546 OFFCURVE",
+"-76 562 OFFCURVE",
+"-71 567 CURVE",
+"-47 556 OFFCURVE",
+"-17 549 OFFCURVE",
+"15 549 CURVE SMOOTH",
+"96 549 OFFCURVE",
+"118 588 OFFCURVE",
+"118 621 CURVE SMOOTH",
+"118 658 OFFCURVE",
+"87 679 OFFCURVE",
+"60 679 CURVE SMOOTH",
+"31 679 OFFCURVE",
+"2 667 OFFCURVE",
+"-39 595 CURVE",
+"-53 599 OFFCURVE",
+"-65 603 OFFCURVE",
+"-78 608 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"72 643 OFFCURVE",
+"83 632 OFFCURVE",
+"83 617 CURVE SMOOTH",
+"83 606 OFFCURVE",
+"73 587 OFFCURVE",
+"25 587 CURVE SMOOTH",
+"15 587 OFFCURVE",
+"5 587 OFFCURVE",
+"-3 588 CURVE",
+"16 622 OFFCURVE",
+"34 643 OFFCURVE",
+"56 643 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-90 598 OFFCURVE",
+"-113 569 OFFCURVE",
+"-127 550 CURVE",
+"-100 533 LINE",
+"-88 546 OFFCURVE",
+"-76 562 OFFCURVE",
+"-71 567 CURVE",
+"-47 556 OFFCURVE",
+"-17 549 OFFCURVE",
+"15 549 CURVE SMOOTH",
+"96 549 OFFCURVE",
+"118 588 OFFCURVE",
+"118 621 CURVE SMOOTH",
+"118 658 OFFCURVE",
+"87 679 OFFCURVE",
+"60 679 CURVE SMOOTH",
+"31 679 OFFCURVE",
+"2 667 OFFCURVE",
+"-39 595 CURVE",
+"-53 599 OFFCURVE",
+"-65 603 OFFCURVE",
+"-78 608 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"72 643 OFFCURVE",
+"83 632 OFFCURVE",
+"83 617 CURVE SMOOTH",
+"83 606 OFFCURVE",
+"73 587 OFFCURVE",
+"25 587 CURVE SMOOTH",
+"15 587 OFFCURVE",
+"5 587 OFFCURVE",
+"-3 588 CURVE",
+"16 622 OFFCURVE",
+"34 643 OFFCURVE",
+"56 643 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072Auni0308.loclSYRJ.Isol;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{365, 529}";
+},
+{
+name = RU;
+position = "{295, -112}";
+},
+{
+name = bottom;
+position = "{155, -216}";
+},
+{
+name = top;
+position = "{193, 553}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"52 382 OFFCURVE",
+"72 366 OFFCURVE",
+"101 366 CURVE SMOOTH",
+"134 366 OFFCURVE",
+"153 386 OFFCURVE",
+"153 422 CURVE SMOOTH",
+"153 459 OFFCURVE",
+"134 479 OFFCURVE",
+"101 479 CURVE SMOOTH",
+"70 479 OFFCURVE",
+"52 459 OFFCURVE",
+"52 422 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 382 OFFCURVE",
+"241 366 OFFCURVE",
+"270 366 CURVE SMOOTH",
+"303 366 OFFCURVE",
+"322 386 OFFCURVE",
+"322 422 CURVE SMOOTH",
+"322 459 OFFCURVE",
+"303 479 OFFCURVE",
+"270 479 CURVE SMOOTH",
+"239 479 OFFCURVE",
+"221 459 OFFCURVE",
+"221 422 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"306 237 OFFCURVE",
+"252 284 OFFCURVE",
+"187 284 CURVE SMOOTH",
+"112 284 OFFCURVE",
+"68 210 OFFCURVE",
+"68 158 CURVE SMOOTH",
+"68 97 OFFCURVE",
+"108 62 OFFCURVE",
+"141 38 CURVE SMOOTH",
+"157 27 OFFCURVE",
+"171 16 OFFCURVE",
+"173 4 CURVE",
+"149 -27 OFFCURVE",
+"115 -58 OFFCURVE",
+"84 -87 CURVE",
+"135 -130 LINE",
+"218 -62 OFFCURVE",
+"306 37 OFFCURVE",
+"306 145 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = uni0716.loclSYRJ;
+},
+{
+name = Dot11.loclSYRJ;
+transform = "{1, 0, 0, 1, 101, 363}";
+},
+{
+name = Dot11.loclSYRJ;
+transform = "{1, 0, 0, 1, 270, 363}";
+}
+);
+layerId = UUID0;
+width = 365;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072Auni0308.loclSYRJ.Fina;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{322, 429}";
+},
+{
+name = RU;
+position = "{258, -112}";
+},
+{
+name = bottom;
+position = "{133, -247}";
+},
+{
+name = top;
+position = "{156, 450}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"310 279 OFFCURVE",
+"331 264 OFFCURVE",
+"360 264 CURVE SMOOTH",
+"392 264 OFFCURVE",
+"411 283 OFFCURVE",
+"411 320 CURVE SMOOTH",
+"411 357 OFFCURVE",
+"393 376 OFFCURVE",
+"360 376 CURVE SMOOTH",
+"328 376 OFFCURVE",
+"310 357 OFFCURVE",
+"310 320 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 279 OFFCURVE",
+"500 264 OFFCURVE",
+"529 264 CURVE SMOOTH",
+"561 264 OFFCURVE",
+"580 283 OFFCURVE",
+"580 320 CURVE SMOOTH",
+"580 357 OFFCURVE",
+"562 376 OFFCURVE",
+"529 376 CURVE SMOOTH",
+"497 376 OFFCURVE",
+"479 357 OFFCURVE",
+"479 320 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"409 -162 LINE",
+"462 -119 OFFCURVE",
+"508 -63 OFFCURVE",
+"531 3 CURVE",
+"561 0 OFFCURVE",
+"592 0 OFFCURVE",
+"619 0 CURVE",
+"619 76 LINE",
+"570 76 OFFCURVE",
+"547 84 OFFCURVE",
+"518 127 CURVE SMOOTH",
+"495 160 OFFCURVE",
+"469 179 OFFCURVE",
+"430 179 CURVE SMOOTH",
+"385 179 OFFCURVE",
+"351 142 OFFCURVE",
+"351 101 CURVE SMOOTH",
+"351 71 OFFCURVE",
+"360 51 OFFCURVE",
+"383 29 CURVE SMOOTH",
+"401 12 OFFCURVE",
+"421 -4 OFFCURVE",
+"425 -21 CURVE",
+"425 -42 OFFCURVE",
+"398 -83 OFFCURVE",
+"366 -116 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"115 305 OFFCURVE",
+"135 289 OFFCURVE",
+"164 289 CURVE SMOOTH",
+"197 289 OFFCURVE",
+"216 308 OFFCURVE",
+"216 345 CURVE SMOOTH",
+"216 382 OFFCURVE",
+"197 402 OFFCURVE",
+"164 402 CURVE SMOOTH",
+"133 402 OFFCURVE",
+"115 382 OFFCURVE",
+"115 345 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"81 162 OFFCURVE",
+"81 114 CURVE SMOOTH",
+"81 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"271 0 OFFCURVE",
+"280 0 CURVE",
+"280 76 LINE",
+"271 76 OFFCURVE",
+"251 77 OFFCURVE",
+"237 83 CURVE",
+"238 92 OFFCURVE",
+"238 96 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = uni0716.loclSYRJ.Fina;
+},
+{
+name = Dot11.loclSYRJ;
+transform = "{1, 0, 0, 1, 77, 286}";
+},
+{
+name = Dot11.loclSYRJ;
+transform = "{1, 0, 0, 1, 246, 286}";
+}
+);
+layerId = UUID0;
+width = 283;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072Auni0308.loclSYRJ.IsolQR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{400, 491}";
+},
+{
+name = RU;
+position = "{303, -77}";
+},
+{
+name = bottom;
+position = "{169, -302}";
+},
+{
+name = top;
+position = "{177, 584}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"115 280 OFFCURVE",
+"76 205 OFFCURVE",
+"76 153 CURVE SMOOTH",
+"76 104 OFFCURVE",
+"100 72 OFFCURVE",
+"149 32 CURVE SMOOTH",
+"176 10 LINE",
+"156 -21 OFFCURVE",
+"132 -57 OFFCURVE",
+"101 -89 CURVE",
+"148 -130 LINE",
+"223 -53 OFFCURVE",
+"306 42 OFFCURVE",
+"306 135 CURVE SMOOTH",
+"306 212 OFFCURVE",
+"262 280 OFFCURVE",
+"190 280 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"52 382 OFFCURVE",
+"72 366 OFFCURVE",
+"101 366 CURVE SMOOTH",
+"134 366 OFFCURVE",
+"153 385 OFFCURVE",
+"153 422 CURVE SMOOTH",
+"153 459 OFFCURVE",
+"134 479 OFFCURVE",
+"101 479 CURVE SMOOTH",
+"70 479 OFFCURVE",
+"52 459 OFFCURVE",
+"52 422 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 382 OFFCURVE",
+"241 366 OFFCURVE",
+"270 366 CURVE SMOOTH",
+"303 366 OFFCURVE",
+"322 385 OFFCURVE",
+"322 422 CURVE SMOOTH",
+"322 459 OFFCURVE",
+"303 479 OFFCURVE",
+"270 479 CURVE SMOOTH",
+"239 479 OFFCURVE",
+"221 459 OFFCURVE",
+"221 422 CURVE SMOOTH"
+);
+}
+);
+};
+components = (
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 101, 363}";
+},
+{
+name = Dot1.loclSYRJ;
+transform = "{1, 0, 0, 1, 270, 363}";
+},
+{
+name = uni0716.loclSYRJ.QR;
+}
+);
+layerId = UUID0;
+width = 441;
+}
+);
+},
+{
+color = 5;
+glyphname = uni072Auni0308.loclSYRJ.FinaQR;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+anchors = (
+{
+name = QU;
+position = "{392, 387}";
+},
+{
+name = RU;
+position = "{286, -114}";
+},
+{
+name = bottom;
+position = "{159, -279}";
+},
+{
+name = top;
+position = "{157, 481}";
+}
+);
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"1215 279 OFFCURVE",
+"1236 264 OFFCURVE",
+"1265 264 CURVE SMOOTH",
+"1297 264 OFFCURVE",
+"1316 283 OFFCURVE",
+"1316 320 CURVE SMOOTH",
+"1316 357 OFFCURVE",
+"1298 376 OFFCURVE",
+"1265 376 CURVE SMOOTH",
+"1233 376 OFFCURVE",
+"1215 357 OFFCURVE",
+"1215 320 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1384 279 OFFCURVE",
+"1405 264 OFFCURVE",
+"1434 264 CURVE SMOOTH",
+"1466 264 OFFCURVE",
+"1485 283 OFFCURVE",
+"1485 320 CURVE SMOOTH",
+"1485 357 OFFCURVE",
+"1467 376 OFFCURVE",
+"1434 376 CURVE SMOOTH",
+"1402 376 OFFCURVE",
+"1384 357 OFFCURVE",
+"1384 320 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"1314 -162 LINE",
+"1367 -119 OFFCURVE",
+"1413 -63 OFFCURVE",
+"1436 3 CURVE",
+"1466 0 OFFCURVE",
+"1522 0 OFFCURVE",
+"1549 0 CURVE SMOOTH",
+"1713 0 LINE",
+"1713 76 LINE",
+"1549 76 LINE SMOOTH",
+"1473 76 OFFCURVE",
+"1452 84 OFFCURVE",
+"1423 127 CURVE SMOOTH",
+"1400 160 OFFCURVE",
+"1374 179 OFFCURVE",
+"1335 179 CURVE SMOOTH",
+"1290 179 OFFCURVE",
+"1256 142 OFFCURVE",
+"1256 101 CURVE SMOOTH",
+"1256 71 OFFCURVE",
+"1265 51 OFFCURVE",
+"1288 29 CURVE SMOOTH",
+"1306 12 OFFCURVE",
+"1326 -4 OFFCURVE",
+"1330 -21 CURVE",
+"1330 -42 OFFCURVE",
+"1303 -83 OFFCURVE",
+"1271 -116 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1314 -162 LINE",
+"1367 -119 OFFCURVE",
+"1413 -63 OFFCURVE",
+"1436 3 CURVE",
+"1466 0 OFFCURVE",
+"1522 0 OFFCURVE",
+"1549 0 CURVE SMOOTH",
+"1713 0 LINE",
+"1713 76 LINE",
+"1549 76 LINE SMOOTH",
+"1473 76 OFFCURVE",
+"1452 84 OFFCURVE",
+"1423 127 CURVE SMOOTH",
+"1400 160 OFFCURVE",
+"1374 179 OFFCURVE",
+"1335 179 CURVE SMOOTH",
+"1290 179 OFFCURVE",
+"1256 142 OFFCURVE",
+"1256 101 CURVE SMOOTH",
+"1256 71 OFFCURVE",
+"1265 51 OFFCURVE",
+"1288 29 CURVE SMOOTH",
+"1306 12 OFFCURVE",
+"1326 -4 OFFCURVE",
+"1330 -21 CURVE",
+"1330 -42 OFFCURVE",
+"1303 -83 OFFCURVE",
+"1271 -116 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"1328 -145 LINE",
+"1373 -100 OFFCURVE",
+"1401 -42 OFFCURVE",
+"1416 5 CURVE",
+"1445 2 OFFCURVE",
+"1515 0 OFFCURVE",
+"1542 0 CURVE SMOOTH",
+"1713 0 LINE",
+"1713 76 LINE",
+"1547 76 LINE SMOOTH",
+"1454 76 OFFCURVE",
+"1447 79 OFFCURVE",
+"1417 124 CURVE SMOOTH",
+"1392 162 OFFCURVE",
+"1372 178 OFFCURVE",
+"1334 178 CURVE SMOOTH",
+"1292 178 OFFCURVE",
+"1261 141 OFFCURVE",
+"1261 100 CURVE SMOOTH",
+"1261 48 OFFCURVE",
+"1300 27 OFFCURVE",
+"1341 10 CURVE",
+"1340 -12 OFFCURVE",
+"1315 -67 OFFCURVE",
+"1284 -109 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"811 192 OFFCURVE",
+"780 153 OFFCURVE",
+"780 110 CURVE SMOOTH",
+"780 55 OFFCURVE",
+"818 30 OFFCURVE",
+"859 12 CURVE",
+"858 -11 OFFCURVE",
+"833 -67 OFFCURVE",
+"802 -109 CURVE",
+"846 -145 LINE",
+"891 -100 OFFCURVE",
+"919 -41 OFFCURVE",
+"934 6 CURVE",
+"958 3 OFFCURVE",
+"1033 0 OFFCURVE",
+"1060 0 CURVE SMOOTH",
+"1135 0 LINE",
+"1135 76 LINE",
+"1065 76 LINE SMOOTH",
+"1037 76 OFFCURVE",
+"960 78 OFFCURVE",
+"948 85 CURVE",
+"946 95 OFFCURVE",
+"943 106 OFFCURVE",
+"940 115 CURVE SMOOTH",
+"919 176 OFFCURVE",
+"886 192 OFFCURVE",
+"853 192 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"885 135 OFFCURVE",
+"895 113 OFFCURVE",
+"895 82 CURVE SMOOTH",
+"895 76 OFFCURVE",
+"895 66 OFFCURVE",
+"893 55 CURVE",
+"862 57 OFFCURVE",
+"830 65 OFFCURVE",
+"830 100 CURVE SMOOTH",
+"830 121 OFFCURVE",
+"843 135 OFFCURVE",
+"860 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"811 192 OFFCURVE",
+"780 153 OFFCURVE",
+"780 110 CURVE SMOOTH",
+"780 55 OFFCURVE",
+"818 30 OFFCURVE",
+"859 12 CURVE",
+"858 -11 OFFCURVE",
+"833 -67 OFFCURVE",
+"802 -109 CURVE",
+"846 -145 LINE",
+"891 -100 OFFCURVE",
+"919 -41 OFFCURVE",
+"934 6 CURVE",
+"958 3 OFFCURVE",
+"1033 0 OFFCURVE",
+"1060 0 CURVE SMOOTH",
+"1135 0 LINE",
+"1135 76 LINE",
+"1065 76 LINE SMOOTH",
+"1037 76 OFFCURVE",
+"960 78 OFFCURVE",
+"948 85 CURVE",
+"946 95 OFFCURVE",
+"943 106 OFFCURVE",
+"940 115 CURVE SMOOTH",
+"919 176 OFFCURVE",
+"886 192 OFFCURVE",
+"853 192 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"885 135 OFFCURVE",
+"895 113 OFFCURVE",
+"895 82 CURVE SMOOTH",
+"895 76 OFFCURVE",
+"895 66 OFFCURVE",
+"893 55 CURVE",
+"862 57 OFFCURVE",
+"830 65 OFFCURVE",
+"830 100 CURVE SMOOTH",
+"830 121 OFFCURVE",
+"843 135 OFFCURVE",
+"860 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"811 192 OFFCURVE",
+"780 153 OFFCURVE",
+"780 110 CURVE SMOOTH",
+"780 55 OFFCURVE",
+"818 30 OFFCURVE",
+"859 12 CURVE",
+"858 -11 OFFCURVE",
+"833 -67 OFFCURVE",
+"802 -109 CURVE",
+"846 -145 LINE",
+"891 -100 OFFCURVE",
+"919 -41 OFFCURVE",
+"934 6 CURVE",
+"958 3 OFFCURVE",
+"1033 0 OFFCURVE",
+"1060 0 CURVE SMOOTH",
+"1225 0 LINE",
+"1225 76 LINE",
+"1065 76 LINE SMOOTH",
+"1037 76 OFFCURVE",
+"960 78 OFFCURVE",
+"948 85 CURVE",
+"946 95 OFFCURVE",
+"943 106 OFFCURVE",
+"940 115 CURVE SMOOTH",
+"919 176 OFFCURVE",
+"886 192 OFFCURVE",
+"853 192 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"885 135 OFFCURVE",
+"895 113 OFFCURVE",
+"895 82 CURVE SMOOTH",
+"895 76 OFFCURVE",
+"895 66 OFFCURVE",
+"893 55 CURVE",
+"862 57 OFFCURVE",
+"830 65 OFFCURVE",
+"830 100 CURVE SMOOTH",
+"830 121 OFFCURVE",
+"843 135 OFFCURVE",
+"860 135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"727 279 OFFCURVE",
+"748 264 OFFCURVE",
+"777 264 CURVE SMOOTH",
+"809 264 OFFCURVE",
+"828 283 OFFCURVE",
+"828 320 CURVE SMOOTH",
+"828 357 OFFCURVE",
+"810 376 OFFCURVE",
+"777 376 CURVE SMOOTH",
+"745 376 OFFCURVE",
+"727 357 OFFCURVE",
+"727 320 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"896 279 OFFCURVE",
+"917 264 OFFCURVE",
+"946 264 CURVE SMOOTH",
+"978 264 OFFCURVE",
+"997 283 OFFCURVE",
+"997 320 CURVE SMOOTH",
+"997 357 OFFCURVE",
+"979 376 OFFCURVE",
+"946 376 CURVE SMOOTH",
+"914 376 OFFCURVE",
+"896 357 OFFCURVE",
+"896 320 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"811 192 OFFCURVE",
+"780 153 OFFCURVE",
+"780 110 CURVE SMOOTH",
+"780 55 OFFCURVE",
+"818 30 OFFCURVE",
+"859 12 CURVE",
+"858 -11 OFFCURVE",
+"833 -67 OFFCURVE",
+"802 -109 CURVE",
+"846 -145 LINE",
+"891 -100 OFFCURVE",
+"919 -41 OFFCURVE",
+"934 6 CURVE",
+"958 3 OFFCURVE",
+"1033 0 OFFCURVE",
+"1060 0 CURVE SMOOTH",
+"1225 0 LINE",
+"1225 76 LINE",
+"1065 76 LINE SMOOTH",
+"1037 76 OFFCURVE",
+"960 78 OFFCURVE",
+"948 85 CURVE",
+"946 95 OFFCURVE",
+"943 106 OFFCURVE",
+"940 115 CURVE SMOOTH",
+"919 176 OFFCURVE",
+"886 192 OFFCURVE",
+"853 192 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"815 203 OFFCURVE",
+"780 162 OFFCURVE",
+"780 114 CURVE SMOOTH",
+"780 68 OFFCURVE",
+"801 39 OFFCURVE",
+"846 14 CURVE",
+"841 -11 OFFCURVE",
+"815 -62 OFFCURVE",
+"781 -102 CURVE",
+"825 -139 LINE",
+"867 -99 OFFCURVE",
+"902 -41 OFFCURVE",
+"921 4 CURVE",
+"944 1 OFFCURVE",
+"974 0 OFFCURVE",
+"983 0 CURVE SMOOTH",
+"1225 0 LINE",
+"1225 76 LINE",
+"983 76 LINE SMOOTH",
+"974 76 OFFCURVE",
+"953 77 OFFCURVE",
+"939 83 CURVE",
+"939 88 OFFCURVE",
+"940 94 OFFCURVE",
+"940 100 CURVE SMOOTH",
+"940 158 OFFCURVE",
+"912 203 OFFCURVE",
+"859 203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"81 162 OFFCURVE",
+"81 114 CURVE SMOOTH",
+"81 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"271 0 OFFCURVE",
+"280 0 CURVE",
+"280 76 LINE",
+"271 76 OFFCURVE",
+"251 77 OFFCURVE",
+"237 83 CURVE",
+"238 92 OFFCURVE",
+"238 96 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"28 305 OFFCURVE",
+"48 289 OFFCURVE",
+"77 289 CURVE SMOOTH",
+"110 289 OFFCURVE",
+"129 308 OFFCURVE",
+"129 345 CURVE SMOOTH",
+"129 382 OFFCURVE",
+"110 402 OFFCURVE",
+"77 402 CURVE SMOOTH",
+"46 402 OFFCURVE",
+"28 382 OFFCURVE",
+"28 345 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 305 OFFCURVE",
+"217 289 OFFCURVE",
+"246 289 CURVE SMOOTH",
+"279 289 OFFCURVE",
+"298 308 OFFCURVE",
+"298 345 CURVE SMOOTH",
+"298 382 OFFCURVE",
+"279 402 OFFCURVE",
+"246 402 CURVE SMOOTH",
+"215 402 OFFCURVE",
+"197 382 OFFCURVE",
+"197 345 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"117 203 OFFCURVE",
+"81 162 OFFCURVE",
+"81 114 CURVE SMOOTH",
+"81 68 OFFCURVE",
+"103 39 OFFCURVE",
+"147 14 CURVE",
+"142 -11 OFFCURVE",
+"114 -60 OFFCURVE",
+"84 -102 CURVE",
+"126 -138 LINE",
+"166 -98 OFFCURVE",
+"201 -41 OFFCURVE",
+"220 4 CURVE",
+"242 1 OFFCURVE",
+"272 0 OFFCURVE",
+"280 0 CURVE SMOOTH",
+"525 0 LINE",
+"525 76 LINE",
+"279 76 LINE SMOOTH",
+"271 76 OFFCURVE",
+"250 77 OFFCURVE",
+"237 83 CURVE",
+"238 92 OFFCURVE",
+"238 97 OFFCURVE",
+"238 100 CURVE SMOOTH",
+"238 158 OFFCURVE",
+"211 203 OFFCURVE",
+"160 203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"28 304 OFFCURVE",
+"49 289 OFFCURVE",
+"78 289 CURVE SMOOTH",
+"110 289 OFFCURVE",
+"129 308 OFFCURVE",
+"129 345 CURVE SMOOTH",
+"129 382 OFFCURVE",
+"110 402 OFFCURVE",
+"77 402 CURVE SMOOTH",
+"45 402 OFFCURVE",
+"28 382 OFFCURVE",
+"28 345 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 304 OFFCURVE",
+"218 289 OFFCURVE",
+"247 289 CURVE SMOOTH",
+"279 289 OFFCURVE",
+"298 308 OFFCURVE",
+"298 345 CURVE SMOOTH",
+"298 382 OFFCURVE",
+"279 402 OFFCURVE",
+"246 402 CURVE SMOOTH",
+"214 402 OFFCURVE",
+"197 382 OFFCURVE",
+"197 345 CURVE SMOOTH"
+);
+}
+);
+width = 525;
+}
+);
+},
+{
+color = 5;
+glyphname = Dot1.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-49 19 OFFCURVE",
+"-29 3 OFFCURVE",
+"0 3 CURVE SMOOTH",
+"33 3 OFFCURVE",
+"52 22 OFFCURVE",
+"52 59 CURVE SMOOTH",
+"52 96 OFFCURVE",
+"33 116 OFFCURVE",
+"0 116 CURVE SMOOTH",
+"-31 116 OFFCURVE",
+"-49 96 OFFCURVE",
+"-49 59 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = Dot2slant.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"-33 61 OFFCURVE",
+"-37 48 OFFCURVE",
+"-37 36 CURVE SMOOTH",
+"-37 20 OFFCURVE",
+"-31 8 OFFCURVE",
+"-14 8 CURVE SMOOTH",
+"3 8 OFFCURVE",
+"15 26 OFFCURVE",
+"26 53 CURVE",
+"32 70 OFFCURVE",
+"37 83 OFFCURVE",
+"37 95 CURVE SMOOTH",
+"37 111 OFFCURVE",
+"31 123 OFFCURVE",
+"14 123 CURVE SMOOTH",
+"-3 123 OFFCURVE",
+"-16 105 OFFCURVE",
+"-27 78 CURVE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-33 61 OFFCURVE",
+"-37 48 OFFCURVE",
+"-37 36 CURVE SMOOTH",
+"-37 20 OFFCURVE",
+"-31 8 OFFCURVE",
+"-14 8 CURVE SMOOTH",
+"3 8 OFFCURVE",
+"16 26 OFFCURVE",
+"26 53 CURVE SMOOTH",
+"32 69 OFFCURVE",
+"37 83 OFFCURVE",
+"37 95 CURVE SMOOTH",
+"37 111 OFFCURVE",
+"31 123 OFFCURVE",
+"14 123 CURVE SMOOTH",
+"-3 123 OFFCURVE",
+"-17 105 OFFCURVE",
+"-27 78 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = Dot3.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-38 13 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"20 0 OFFCURVE",
+"37 13 OFFCURVE",
+"37 42 CURVE SMOOTH",
+"37 70 OFFCURVE",
+"20 83 OFFCURVE",
+"0 83 CURVE SMOOTH",
+"-21 83 OFFCURVE",
+"-38 70 OFFCURVE",
+"-38 42 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = DotEncl.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"212 -163 OFFCURVE",
+"228 -177 OFFCURVE",
+"250 -177 CURVE SMOOTH",
+"270 -177 OFFCURVE",
+"287 -163 OFFCURVE",
+"287 -136 CURVE SMOOTH",
+"287 -109 OFFCURVE",
+"270 -95 OFFCURVE",
+"250 -95 CURVE SMOOTH",
+"228 -95 OFFCURVE",
+"212 -109 OFFCURVE",
+"212 -136 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = Stretch.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"98 0 LINE"
+);
+}
+);
+width = 98;
+}
+);
+},
+{
+color = 5;
+glyphname = Stretch2.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"171 76 LINE",
+"0 76 LINE SMOOTH",
+"-21 76 OFFCURVE",
+"-39 61 OFFCURVE",
+"-39 38 CURVE SMOOTH",
+"-39 14 OFFCURVE",
+"-21 0 OFFCURVE",
+"0 0 CURVE SMOOTH",
+"171 0 LINE"
+);
+}
+);
+width = 171;
+}
+);
+},
+{
+color = 5;
+glyphname = Dot11.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-49 19 OFFCURVE",
+"-29 3 OFFCURVE",
+"0 3 CURVE SMOOTH",
+"33 3 OFFCURVE",
+"52 22 OFFCURVE",
+"52 59 CURVE SMOOTH",
+"52 96 OFFCURVE",
+"33 116 OFFCURVE",
+"0 116 CURVE SMOOTH",
+"-31 116 OFFCURVE",
+"-49 96 OFFCURVE",
+"-49 59 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+color = 5;
+glyphname = Dot111.loclSYRJ;
+lastChange = "2017-09-08 15:50:18 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-49 19 OFFCURVE",
+"-29 3 OFFCURVE",
+"0 3 CURVE SMOOTH",
+"33 3 OFFCURVE",
+"52 22 OFFCURVE",
+"52 59 CURVE SMOOTH",
+"52 96 OFFCURVE",
+"33 116 OFFCURVE",
+"0 116 CURVE SMOOTH",
+"-31 116 OFFCURVE",
+"-49 96 OFFCURVE",
+"-49 59 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+}
+);
+instances = (
+{
+instanceInterpolations = {
+UUID0 = 1;
+};
+name = Regular;
+}
+);
+kerning = {
+UUID0 = {
+"@MMK_L_uni0710" = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+"@MMK_L_uni0715" = {
+"@MMK_R_uni0702" = -73;
+"@MMK_R_uni0713" = -232;
+"@MMK_R_uni071B" = -134;
+"@MMK_R_uni0720" = -24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = -107;
+"@MMK_R_uni072B" = -83;
+"@MMK_R_uni074F" = 83;
+uni061B = 107;
+uni0704 = -73;
+uni0706 = -73;
+uni0709 = -73;
+uni0713.Init = -232;
+uni0713.InitLong = -232;
+uni0714 = -232;
+uni0714.Init = -232;
+uni0714.InitLong = -232;
+uni0718 = -24;
+uni071B.Init = -134;
+uni071B.InitLongG = -134;
+uni071C = -134;
+uni071C.Init = -134;
+uni071C.InitLongG = -134;
+uni071D = -32;
+uni071F = -73;
+uni071F.Init = -59;
+uni0720.Init = -24;
+uni0720.InitB = -24;
+uni0721 = 27;
+uni0721.Init = 27;
+uni0722 = -112;
+uni0722.InitB = 24;
+uni0725.Init = -107;
+uni0728 = -85;
+uni0729 = 17;
+uni0729.Init = 17;
+uni072B.Init = -83;
+uni072C = -37;
+uni072E = -232;
+uni072E.Init = -232;
+uni072E.InitLong = -232;
+uni074F.Init = 83;
+};
+"@MMK_L_uni0717" = {
+"@MMK_R_uni0710" = -85;
+"@MMK_R_uni0713" = -37;
+"@MMK_R_uni0725" = 24;
+uni0710.Fina2 = -85;
+uni0710.Fina3 = -85;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0725.Init = 24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+"@MMK_L_uni0718" = {
+"@MMK_R_uni0702" = -54;
+"@MMK_R_uni0710" = -85;
+"@MMK_R_uni0713" = -49;
+"@MMK_R_uni0725" = 24;
+uni0704 = -54;
+uni0706 = -54;
+uni0709 = -54;
+uni0710.Fina2 = -85;
+uni0710.Fina3 = -85;
+uni0713.Init = -49;
+uni0713.InitLong = -49;
+uni0714 = -49;
+uni0714.Init = -49;
+uni0714.InitLong = -49;
+uni0722 = -49;
+uni0725.Init = 24;
+uni072E = -49;
+uni072E.Init = -49;
+uni072E.InitLong = -49;
+};
+"@MMK_L_uni0719" = {
+uni0722 = 176;
+uni0728 = -34;
+};
+"@MMK_L_uni0728" = {
+"@MMK_R_uni0710" = -59;
+"@MMK_R_uni0713" = 107;
+"@MMK_R_uni071B" = 146;
+"@MMK_R_uni0720" = 24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = 78;
+"@MMK_R_uni0727" = 83;
+uni0710.Fina2 = -59;
+uni0710.Fina3 = -59;
+uni0713.Init = 107;
+uni0713.InitLong = 107;
+uni0714 = 107;
+uni0714.Init = 107;
+uni0714.InitLong = 107;
+uni0715 = 15;
+uni0716 = 15;
+uni0718 = 41;
+uni0719 = 41;
+uni071A = 39;
+uni071A.Init = 39;
+uni071B.Init = 146;
+uni071B.InitLongG = 146;
+uni071C = 146;
+uni071C.Init = 146;
+uni071C.InitLongG = 146;
+uni071D = 39;
+uni071F = 29;
+uni071F.Init = 37;
+uni0720.Init = 24;
+uni0720.InitB = 24;
+uni0722 = -49;
+uni0722.InitB = 24;
+uni0725.Init = 78;
+uni0726 = 39;
+uni0726.Init = 39;
+uni0727.Init = 83;
+uni0728 = 229;
+uni072A = 15;
+uni072Auni0308.Isol = 15;
+uni072C = 24;
+uni072E = 107;
+uni072E.Init = 107;
+uni072E.InitLong = 107;
+uni072F = 15;
+uni074D = 102;
+};
+"@MMK_L_uni072C" = {
+"@MMK_R_uni0710" = -34;
+"@MMK_R_uni0713" = -20;
+"@MMK_R_uni071B" = 34;
+"@MMK_R_uni0725" = 34;
+uni0710.Fina2 = -34;
+uni0710.Fina3 = -34;
+uni0713.Init = -20;
+uni0713.InitLong = -20;
+uni0714 = -20;
+uni0714.Init = -20;
+uni0714.InitLong = -20;
+uni071B.Init = 34;
+uni071B.InitLongG = 34;
+uni071C = 34;
+uni071C.Init = 34;
+uni071C.InitLongG = 34;
+uni0722 = 49;
+uni0725.Init = 34;
+uni072E = -20;
+uni072E.Init = -20;
+uni072E.InitLong = -20;
+};
+"@MMK_L_uni072F" = {
+"@MMK_R_uni0713" = 37;
+"@MMK_R_uni0725" = 27;
+"@MMK_R_uni0727" = 61;
+"@MMK_R_uni074F" = 76;
+uni0713.Init = 37;
+uni0713.InitLong = 37;
+uni0714 = 37;
+uni0714.Init = 37;
+uni0714.InitLong = 37;
+uni0722 = 400;
+uni0725.Init = 27;
+uni0727.Init = 61;
+uni072E = 37;
+uni072E.Init = 37;
+uni072E.InitLong = 37;
+uni074F.Init = 76;
+};
+"@MMK_L_uni074D" = {
+"@MMK_R_uni0710" = -61;
+"@MMK_R_uni0713" = 146;
+uni0710.Fina2 = -61;
+uni0710.Fina3 = -61;
+uni0713.Init = 146;
+uni0713.InitLong = 146;
+uni0714 = 146;
+uni0714.Init = 146;
+uni0714.InitLong = 146;
+uni0722 = 366;
+uni0728 = -34;
+uni072E = 146;
+uni072E.Init = 146;
+uni072E.InitLong = 146;
+};
+asterisk = {
+uni0662 = 44;
+uni0663 = 44;
+uni0664 = -10;
+uni0665 = 34;
+uni0666 = 29;
+uni0667 = 59;
+uni0668 = -24;
+};
+backslash = {
+uni0660 = -49;
+uni0661 = -20;
+uni0663 = 39;
+uni0664 = -34;
+uni0665 = -44;
+uni0667 = 24;
+uni0668 = -39;
+};
+degree = {
+uni0661 = -29;
+uni0662 = 15;
+uni0663 = 15;
+uni0664 = -44;
+uni0667 = 39;
+uni0668 = -54;
+};
+equal = {
+uni0660 = 39;
+uni0665 = 34;
+uni0666 = 15;
+};
+hyphen = {
+uni0660 = 59;
+uni0662 = -49;
+uni0663 = -49;
+uni0665 = 54;
+uni0666 = 34;
+uni0669 = 39;
+};
+period = {
+uni0662 = -63;
+uni0663 = -63;
+uni0664 = 20;
+uni0667 = -102;
+uni0668 = 39;
+uni0669 = 29;
+};
+plus = {
+uni0660 = 39;
+uni0661 = -10;
+uni0662 = -59;
+uni0663 = -54;
+uni0665 = 29;
+uni0667 = -10;
+uni0668 = -15;
+};
+slash = {
+uni0661 = -39;
+uni0662 = -127;
+uni0663 = -122;
+uni0665 = -63;
+uni0666 = -10;
+uni0667 = -73;
+uni0668 = 29;
+};
+uni060C = {
+uni0662 = -83;
+uni0663 = -83;
+uni0664 = 24;
+uni0667 = -63;
+uni0668 = 39;
+};
+uni0621 = {
+"@MMK_R_uni0713" = 49;
+"@MMK_R_uni071B" = 59;
+"@MMK_R_uni0725" = 59;
+"@MMK_R_uni072B" = 49;
+uni0713.Init = 49;
+uni0713.InitLong = 49;
+uni0714 = 49;
+uni0714.Init = 49;
+uni0714.InitLong = 49;
+uni071B.Init = 59;
+uni071B.InitLongG = 59;
+uni071C = 59;
+uni071C.Init = 59;
+uni071C.InitLongG = 59;
+uni0722 = 122;
+uni0725.Init = 59;
+uni072B.Init = 49;
+uni072C = 39;
+uni072E = 49;
+uni072E.Init = 49;
+uni072E.InitLong = 49;
+};
+uni0660 = {
+backslash = 34;
+equal = 34;
+hyphen = 63;
+period = 20;
+plus = 39;
+slash = -29;
+uni060C = 63;
+uni0660 = 54;
+uni0662 = -44;
+uni0663 = -29;
+uni0665 = 44;
+uni0667 = -34;
+uni0669 = 10;
+uni066A = 63;
+uni066B = 39;
+uni066C = -59;
+};
+uni0661 = {
+slash = -34;
+uni0661 = -20;
+uni066C = -15;
+};
+uni0662 = {
+equal = 34;
+hyphen = 34;
+period = -20;
+plus = 20;
+slash = 20;
+uni0660 = 15;
+uni0662 = 44;
+uni0663 = 39;
+uni0664 = 24;
+uni0665 = 24;
+uni0666 = 24;
+uni0667 = 49;
+uni0668 = 20;
+uni0669 = 20;
+uni066A = 39;
+};
+uni0663 = {
+equal = 34;
+hyphen = 34;
+period = -20;
+plus = 20;
+slash = 20;
+uni0660 = 15;
+uni0662 = 44;
+uni0663 = 59;
+uni0665 = 15;
+uni0667 = 63;
+uni0668 = 20;
+uni0669 = 20;
+uni066A = 29;
+};
+uni0664 = {
+backslash = 34;
+equal = 34;
+hyphen = 24;
+slash = -29;
+uni060C = 20;
+uni0664 = 20;
+uni0665 = 29;
+uni0666 = 20;
+uni0667 = 24;
+uni0668 = 34;
+uni066C = -20;
+};
+uni0665 = {
+backslash = 15;
+equal = 34;
+hyphen = 54;
+plus = 29;
+slash = -78;
+uni060C = 39;
+uni0660 = 34;
+uni0662 = -44;
+uni0663 = -39;
+uni0665 = 29;
+uni0666 = 15;
+uni0667 = -5;
+uni0668 = 15;
+uni0669 = 15;
+uni066C = -54;
+};
+uni0666 = {
+backslash = -59;
+hyphen = -34;
+period = -102;
+plus = -39;
+slash = 24;
+uni060C = -39;
+uni0660 = -54;
+uni0662 = 63;
+uni0663 = 59;
+uni0664 = -20;
+uni0665 = -15;
+uni0666 = 24;
+uni0667 = 73;
+uni0668 = -39;
+uni066A = 54;
+uni066B = -54;
+uni066C = 24;
+};
+uni0667 = {
+equal = 15;
+period = -63;
+slash = 20;
+uni0662 = 63;
+uni0663 = 59;
+uni0665 = 10;
+uni0666 = 29;
+uni0667 = 83;
+uni066A = 54;
+uni066B = -59;
+uni066C = 24;
+};
+uni0668 = {
+backslash = 83;
+equal = 15;
+period = 20;
+plus = -15;
+slash = -73;
+uni060C = 39;
+uni0662 = -59;
+uni0663 = -63;
+uni0664 = 54;
+uni0665 = 15;
+uni0666 = 39;
+uni0667 = -24;
+uni0668 = 83;
+uni0669 = 24;
+uni066A = 44;
+uni066B = 34;
+uni066C = -102;
+};
+uni0669 = {
+backslash = -15;
+equal = 49;
+hyphen = 44;
+period = -107;
+plus = 24;
+slash = -20;
+uni0660 = 15;
+uni0662 = 20;
+uni0663 = 44;
+uni0664 = -24;
+uni0665 = 44;
+uni0666 = 20;
+uni0667 = 39;
+uni0668 = -15;
+uni0669 = 20;
+uni066A = 29;
+uni066B = -73;
+};
+uni066A = {
+uni0660 = 44;
+uni0661 = -34;
+uni0662 = 15;
+uni0663 = 29;
+uni0664 = 44;
+uni0667 = 24;
+uni0668 = 54;
+};
+uni066B = {
+uni0661 = -20;
+uni0662 = -63;
+uni0663 = -63;
+uni0664 = 34;
+uni0667 = -98;
+uni0668 = 34;
+uni0669 = 20;
+};
+uni066C = {
+uni0661 = -39;
+uni0663 = 20;
+uni0664 = -24;
+uni0667 = 34;
+uni0668 = -29;
+};
+uni0710.Fina1 = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0710.Fina1wideX = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0710.Fina1wideY = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0710.Fina2 = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0710.Fina3 = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0710.Medi2 = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0710.Medi2wideX = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0710.Medi2wideY = {
+"@MMK_R_uni0710" = -56;
+"@MMK_R_uni0713" = -37;
+uni0710.Fina2 = -56;
+uni0710.Fina3 = -56;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0728 = -24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0715.Fina = {
+"@MMK_R_uni0702" = -73;
+"@MMK_R_uni0713" = -232;
+"@MMK_R_uni071B" = -134;
+"@MMK_R_uni0720" = -24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = -107;
+"@MMK_R_uni072B" = -83;
+"@MMK_R_uni074F" = 83;
+uni061B = 107;
+uni0704 = -73;
+uni0706 = -73;
+uni0709 = -73;
+uni0713.Init = -232;
+uni0713.InitLong = -232;
+uni0714 = -232;
+uni0714.Init = -232;
+uni0714.InitLong = -232;
+uni0718 = -24;
+uni071B.Init = -134;
+uni071B.InitLongG = -134;
+uni071C = -134;
+uni071C.Init = -134;
+uni071C.InitLongG = -134;
+uni071D = -32;
+uni071F = -73;
+uni071F.Init = -59;
+uni0720.Init = -24;
+uni0720.InitB = -24;
+uni0721 = 27;
+uni0721.Init = 27;
+uni0722 = -112;
+uni0722.InitB = 24;
+uni0725.Init = -107;
+uni0728 = -85;
+uni0729 = 17;
+uni0729.Init = 17;
+uni072B.Init = -83;
+uni072C = -37;
+uni072E = -232;
+uni072E.Init = -232;
+uni072E.InitLong = -232;
+uni074F.Init = 83;
+};
+uni0715.loclSYRJ = {
+uni0710.loclSYRJ = -37;
+uni071B.loclSYRJ = -24;
+uni071B.loclSYRJ.Init = -24;
+uni071C.loclSYRJ = -24;
+uni071C.loclSYRJ.Init = -24;
+uni0722.loclSYRJ = 107;
+};
+uni0715.loclSYRJ.Fina = {
+uni0710.loclSYRJ = -37;
+uni071B.loclSYRJ = -24;
+uni071B.loclSYRJ.Init = -24;
+uni071C.loclSYRJ = -24;
+uni071C.loclSYRJ.Init = -24;
+uni0722.loclSYRJ = 107;
+};
+uni0716 = {
+"@MMK_R_uni0702" = -73;
+"@MMK_R_uni0713" = -232;
+"@MMK_R_uni071B" = -134;
+"@MMK_R_uni0720" = -24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = -107;
+"@MMK_R_uni072B" = -83;
+"@MMK_R_uni074F" = 83;
+uni061B = 107;
+uni0704 = -73;
+uni0706 = -73;
+uni0709 = -73;
+uni0713.Init = -232;
+uni0713.InitLong = -232;
+uni0714 = -232;
+uni0714.Init = -232;
+uni0714.InitLong = -232;
+uni0718 = -24;
+uni071B.Init = -134;
+uni071B.InitLongG = -134;
+uni071C = -134;
+uni071C.Init = -134;
+uni071C.InitLongG = -134;
+uni071D = -32;
+uni071F = -73;
+uni071F.Init = -59;
+uni0720.Init = -24;
+uni0720.InitB = -24;
+uni0721 = 27;
+uni0721.Init = 27;
+uni0722 = -112;
+uni0722.InitB = 24;
+uni0725.Init = -107;
+uni0728 = -85;
+uni0729 = 17;
+uni0729.Init = 17;
+uni072B.Init = -83;
+uni072C = -37;
+uni072E = -232;
+uni072E.Init = -232;
+uni072E.InitLong = -232;
+uni074F.Init = 83;
+};
+uni0716.Fina = {
+"@MMK_R_uni0702" = -73;
+"@MMK_R_uni0713" = -232;
+"@MMK_R_uni071B" = -134;
+"@MMK_R_uni0720" = -24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = -107;
+"@MMK_R_uni072B" = -83;
+"@MMK_R_uni074F" = 83;
+uni061B = 107;
+uni0704 = -73;
+uni0706 = -73;
+uni0709 = -73;
+uni0713.Init = -232;
+uni0713.InitLong = -232;
+uni0714 = -232;
+uni0714.Init = -232;
+uni0714.InitLong = -232;
+uni0718 = -24;
+uni071B.Init = -134;
+uni071B.InitLongG = -134;
+uni071C = -134;
+uni071C.Init = -134;
+uni071C.InitLongG = -134;
+uni071D = -32;
+uni071F = -73;
+uni071F.Init = -59;
+uni0720.Init = -24;
+uni0720.InitB = -24;
+uni0721 = 27;
+uni0721.Init = 27;
+uni0722 = -112;
+uni0722.InitB = 24;
+uni0725.Init = -107;
+uni0728 = -85;
+uni0729 = 17;
+uni0729.Init = 17;
+uni072B.Init = -83;
+uni072C = -37;
+uni072E = -232;
+uni072E.Init = -232;
+uni072E.InitLong = -232;
+uni074F.Init = 83;
+};
+uni0717.Fina = {
+"@MMK_R_uni0710" = -85;
+"@MMK_R_uni0713" = -37;
+"@MMK_R_uni0725" = 24;
+uni0710.Fina2 = -85;
+uni0710.Fina3 = -85;
+uni0713.Init = -37;
+uni0713.InitLong = -37;
+uni0714 = -37;
+uni0714.Init = -37;
+uni0714.InitLong = -37;
+uni0725.Init = 24;
+uni072E = -37;
+uni072E.Init = -37;
+uni072E.InitLong = -37;
+};
+uni0718.Fina = {
+"@MMK_R_uni0702" = -54;
+"@MMK_R_uni0710" = -85;
+"@MMK_R_uni0713" = -49;
+"@MMK_R_uni0725" = 24;
+uni0704 = -54;
+uni0706 = -54;
+uni0709 = -54;
+uni0710.Fina2 = -85;
+uni0710.Fina3 = -85;
+uni0713.Init = -49;
+uni0713.InitLong = -49;
+uni0714 = -49;
+uni0714.Init = -49;
+uni0714.InitLong = -49;
+uni0722 = -49;
+uni0725.Init = 24;
+uni072E = -49;
+uni072E.Init = -49;
+uni072E.InitLong = -49;
+};
+uni0719.Fina = {
+uni0722 = 176;
+uni0728 = -34;
+};
+uni071D = {
+bracketleft = 98;
+};
+uni0721 = {
+"@MMK_R_uni0702" = -110;
+uni0704 = -110;
+uni0706 = -110;
+uni0709 = -110;
+};
+uni0721.Fina = {
+"@MMK_R_uni0702" = -110;
+uni0704 = -110;
+uni0706 = -110;
+uni0709 = -110;
+};
+uni0722 = {
+"@MMK_R_uni0702" = 37;
+bracketleft = 61;
+uni0704 = 37;
+uni0706 = 37;
+uni0709 = 37;
+};
+uni0722.Fina = {
+"@MMK_R_uni0702" = 37;
+bracketleft = 61;
+uni0704 = 37;
+uni0706 = 37;
+uni0709 = 37;
+};
+uni0728.Fina = {
+"@MMK_R_uni0710" = -59;
+"@MMK_R_uni0713" = 107;
+"@MMK_R_uni071B" = 146;
+"@MMK_R_uni0720" = 24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = 78;
+"@MMK_R_uni0727" = 83;
+uni0710.Fina2 = -59;
+uni0710.Fina3 = -59;
+uni0713.Init = 107;
+uni0713.InitLong = 107;
+uni0714 = 107;
+uni0714.Init = 107;
+uni0714.InitLong = 107;
+uni0715 = 15;
+uni0716 = 15;
+uni0718 = 41;
+uni0719 = 41;
+uni071A = 39;
+uni071A.Init = 39;
+uni071B.Init = 146;
+uni071B.InitLongG = 146;
+uni071C = 146;
+uni071C.Init = 146;
+uni071C.InitLongG = 146;
+uni071D = 39;
+uni071F = 29;
+uni071F.Init = 37;
+uni0720.Init = 24;
+uni0720.InitB = 24;
+uni0722 = -49;
+uni0722.InitB = 24;
+uni0725.Init = 78;
+uni0726 = 39;
+uni0726.Init = 39;
+uni0727.Init = 83;
+uni0728 = 229;
+uni072A = 15;
+uni072Auni0308.Isol = 15;
+uni072C = 24;
+uni072E = 107;
+uni072E.Init = 107;
+uni072E.InitLong = 107;
+uni072F = 15;
+uni074D = 102;
+};
+uni072A = {
+"@MMK_R_uni0702" = -73;
+"@MMK_R_uni0713" = -232;
+"@MMK_R_uni071B" = -134;
+"@MMK_R_uni0720" = -24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = -107;
+"@MMK_R_uni072B" = -83;
+"@MMK_R_uni074F" = 83;
+uni061B = 107;
+uni0704 = -73;
+uni0706 = -73;
+uni0709 = -73;
+uni0713.Init = -232;
+uni0713.InitLong = -232;
+uni0714 = -232;
+uni0714.Init = -232;
+uni0714.InitLong = -232;
+uni0718 = -24;
+uni071B.Init = -134;
+uni071B.InitLongG = -134;
+uni071C = -134;
+uni071C.Init = -134;
+uni071C.InitLongG = -134;
+uni071D = -32;
+uni071F = -73;
+uni071F.Init = -59;
+uni0720.Init = -24;
+uni0720.InitB = -24;
+uni0721 = 27;
+uni0721.Init = 27;
+uni0722 = -112;
+uni0722.InitB = 24;
+uni0725.Init = -107;
+uni0728 = -85;
+uni0729 = 17;
+uni0729.Init = 17;
+uni072B.Init = -83;
+uni072C = -37;
+uni072E = -232;
+uni072E.Init = -232;
+uni072E.InitLong = -232;
+uni074F.Init = 83;
+};
+uni072A.Fina = {
+"@MMK_R_uni0702" = -73;
+"@MMK_R_uni0713" = -232;
+"@MMK_R_uni071B" = -134;
+"@MMK_R_uni0720" = -24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = -107;
+"@MMK_R_uni072B" = -83;
+"@MMK_R_uni074F" = 83;
+uni061B = 107;
+uni0704 = -73;
+uni0706 = -73;
+uni0709 = -73;
+uni0713.Init = -232;
+uni0713.InitLong = -232;
+uni0714 = -232;
+uni0714.Init = -232;
+uni0714.InitLong = -232;
+uni0718 = -24;
+uni071B.Init = -134;
+uni071B.InitLongG = -134;
+uni071C = -134;
+uni071C.Init = -134;
+uni071C.InitLongG = -134;
+uni071D = -32;
+uni071F = -73;
+uni071F.Init = -59;
+uni0720.Init = -24;
+uni0720.InitB = -24;
+uni0721 = 27;
+uni0721.Init = 27;
+uni0722 = -112;
+uni0722.InitB = 24;
+uni0725.Init = -107;
+uni0728 = -85;
+uni0729 = 17;
+uni0729.Init = 17;
+uni072B.Init = -83;
+uni072C = -37;
+uni072E = -232;
+uni072E.Init = -232;
+uni072E.InitLong = -232;
+uni074F.Init = 83;
+};
+uni072Auni0308.Fina = {
+"@MMK_R_uni0702" = -73;
+"@MMK_R_uni0713" = -232;
+"@MMK_R_uni071B" = -134;
+"@MMK_R_uni0720" = -24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = -107;
+"@MMK_R_uni072B" = -83;
+"@MMK_R_uni074F" = 83;
+uni061B = 107;
+uni0704 = -73;
+uni0706 = -73;
+uni0709 = -73;
+uni0713.Init = -232;
+uni0713.InitLong = -232;
+uni0714 = -232;
+uni0714.Init = -232;
+uni0714.InitLong = -232;
+uni0718 = -24;
+uni071B.Init = -134;
+uni071B.InitLongG = -134;
+uni071C = -134;
+uni071C.Init = -134;
+uni071C.InitLongG = -134;
+uni071D = -32;
+uni071F = -73;
+uni071F.Init = -59;
+uni0720.Init = -24;
+uni0720.InitB = -24;
+uni0721 = 27;
+uni0721.Init = 27;
+uni0722 = -112;
+uni0722.InitB = 24;
+uni0725.Init = -107;
+uni0728 = -85;
+uni0729 = 17;
+uni0729.Init = 17;
+uni072B.Init = -83;
+uni072C = -37;
+uni072E = -232;
+uni072E.Init = -232;
+uni072E.InitLong = -232;
+uni074F.Init = 83;
+};
+uni072Auni0308.Isol = {
+"@MMK_R_uni0702" = -73;
+"@MMK_R_uni0713" = -232;
+"@MMK_R_uni071B" = -134;
+"@MMK_R_uni0720" = -24;
+"@MMK_R_uni0722.Init" = 24;
+"@MMK_R_uni0725" = -107;
+"@MMK_R_uni072B" = -83;
+"@MMK_R_uni074F" = 83;
+uni061B = 107;
+uni0704 = -73;
+uni0706 = -73;
+uni0709 = -73;
+uni0713.Init = -232;
+uni0713.InitLong = -232;
+uni0714 = -232;
+uni0714.Init = -232;
+uni0714.InitLong = -232;
+uni0718 = -24;
+uni071B.Init = -134;
+uni071B.InitLongG = -134;
+uni071C = -134;
+uni071C.Init = -134;
+uni071C.InitLongG = -134;
+uni071D = -32;
+uni071F = -73;
+uni071F.Init = -59;
+uni0720.Init = -24;
+uni0720.InitB = -24;
+uni0721 = 27;
+uni0721.Init = 27;
+uni0722 = -112;
+uni0722.InitB = 24;
+uni0725.Init = -107;
+uni0728 = -85;
+uni0729 = 17;
+uni0729.Init = 17;
+uni072B.Init = -83;
+uni072C = -37;
+uni072E = -232;
+uni072E.Init = -232;
+uni072E.InitLong = -232;
+uni074F.Init = 83;
+};
+uni072C.Fina = {
+"@MMK_R_uni0710" = -34;
+"@MMK_R_uni0713" = -20;
+"@MMK_R_uni071B" = 34;
+"@MMK_R_uni0725" = 34;
+uni0710.Fina2 = -34;
+uni0710.Fina3 = -34;
+uni0713.Init = -20;
+uni0713.InitLong = -20;
+uni0714 = -20;
+uni0714.Init = -20;
+uni0714.InitLong = -20;
+uni071B.Init = 34;
+uni071B.InitLongG = 34;
+uni071C = 34;
+uni071C.Init = 34;
+uni071C.InitLongG = 34;
+uni0722 = 49;
+uni0725.Init = 34;
+uni072E = -20;
+uni072E.Init = -20;
+uni072E.InitLong = -20;
+};
+uni072F.Fina = {
+"@MMK_R_uni0713" = 37;
+"@MMK_R_uni0725" = 27;
+"@MMK_R_uni0727" = 61;
+"@MMK_R_uni074F" = 76;
+uni0713.Init = 37;
+uni0713.InitLong = 37;
+uni0714 = 37;
+uni0714.Init = 37;
+uni0714.InitLong = 37;
+uni0722 = 400;
+uni0725.Init = 27;
+uni0727.Init = 61;
+uni072E = 37;
+uni072E.Init = 37;
+uni072E.InitLong = 37;
+uni074F.Init = 76;
+};
+uni074D.Fina = {
+"@MMK_R_uni0710" = -61;
+"@MMK_R_uni0713" = 146;
+uni0710.Fina2 = -61;
+uni0710.Fina3 = -61;
+uni0713.Init = 146;
+uni0713.InitLong = 146;
+uni0714 = 146;
+uni0714.Init = 146;
+uni0714.InitLong = 146;
+uni0722 = 366;
+uni0728 = -34;
+uni072E = 146;
+uni072E.Init = 146;
+uni072E.InitLong = 146;
+};
+};
+};
+keyboardIncrement = 0;
+manufacturer = "Monotype Imaging Inc.";
+manufacturerURL = "http://code.google.com/p/noto/";
+unitsPerEm = 1000;
+versionMajor = 0;
+versionMinor = 900;
+}


### PR DESCRIPTION
This file contains all of Estrangela, Eastern and Western Syriac in a
single font. Applications can choose the preferred style by requesting
the corresponding OpenType language system. We’ll need this for
re-packaging Noto Sans into a single pan-Unicode font file.

The OpenType language system tags for Syriac have been registered with
Microsoft and became part of the OpenType 1.8 specification; HarfBuzz
recognizes the BCP47 script codes for Syriac and converts them to the
correct OpenType language system codes.

The font design is probably not the final version, but I’d like to
add the current version to the source repository so that
applications and operating systems can be tested early.