### PR TITLE
fix familyName of NotoSans Old North Arabian and Sora Sompeng

### DIFF
--- a/src/NotoSansOldNorthArabian-MM.glyphs
+++ b/src/NotoSansOldNorthArabian-MM.glyphs
@@ -96,7 +96,7 @@ date = "2018-02-12 23:22:07 +0000";
 designer = "Monotype Design Team";
 designerURL = "http://www.monotype.com/studio";
 disablesAutomaticAlignment = 1;
-familyName = "Noto Sans OldNorArab";
+familyName = "Noto Sans Old North Arabian";
 fontMaster = (
 {
 alignmentZones = (
@@ -2437,16 +2437,8 @@ name = xHeight;
 value = "536";
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Old North Arabian";
-},
-{
-name = fileName;
-value = "NotoSansOldNorthArabian-Regular";
-},
-{
-name = postscriptFontName;
-value = "NotoSansOldNorthArabian-Regular";
+name = styleMapFamilyName;
+value = "Noto Sans OldNorArab";
 }
 );
 instanceInterpolations = {

--- a/src/NotoSansSoraSompeng-MM.glyphs
+++ b/src/NotoSansSoraSompeng-MM.glyphs
@@ -103,7 +103,7 @@ designer = "Monotype Design Team";
 designerURL = "http://www.monotype.com/studio";
 disablesAutomaticAlignment = 1;
 disablesNiceNames = 1;
-familyName = "Noto Sans SoraSomp";
+familyName = "Noto Sans Sora Sompeng";
 fontMaster = (
 {
 alignmentZones = (
@@ -2907,16 +2907,8 @@ name = xHeight;
 value = "536";
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Sora Sompeng";
-},
-{
-name = fileName;
-value = "NotoSansSoraSompeng-Regular";
-},
-{
-name = postscriptFontName;
-value = "NotoSansSoraSompeng-Regular";
+name = styleMapFamilyName;
+value = "Noto Sans SoraSomp";
 }
 );
 instanceInterpolations = {


### PR DESCRIPTION
These source files are the only two for which the `familyName` attribute uses a shortened form that doesn't match the respective file name.

This patch sets the `familyName` to the long (preferred) name, and sets the `styleMapFamilyName` to the short name.

It also removes the `preferredFamilyName`, `fileName` and `postscriptFontName` custom parameters since they are now redundant, as they are the same as the default values.

Fixes #107