### PR TITLE
NotoSansCanadianAboriginal: use long familyName, add styleMapFamilyName

### DIFF
--- a/src/NotoSansCanadianAboriginal/NotoSansCanadianAboriginal-MM.glyphs
+++ b/src/NotoSansCanadianAboriginal/NotoSansCanadianAboriginal-MM.glyphs
@@ -85441,7 +85441,7 @@ value = (
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig Thin";
+value = "Noto Sans CanAborig Th";
 }
 );
 interpolationWeight = 26;
@@ -85478,7 +85478,7 @@ value = 200;
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig ExtLt";
+value = "Noto Sans CanAborig XLt";
 }
 );
 interpolationWeight = 39;
@@ -85516,7 +85516,7 @@ value = 300;
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig Light";
+value = "Noto Sans CanAborig Lt";
 }
 );
 interpolationWeight = 58;
@@ -85590,7 +85590,7 @@ value = 500;
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig Med";
+value = "Noto Sans CanAborig Md";
 }
 );
 interpolationWeight = 108;
@@ -85628,7 +85628,7 @@ value = 600;
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig SemBd";
+value = "Noto Sans CanAborig SmBd";
 }
 );
 interpolationWeight = 128;
@@ -85705,7 +85705,7 @@ value = "536";
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig ExtBd";
+value = "Noto Sans CanAborig XBd";
 }
 );
 interpolationWeight = 169;
@@ -85743,7 +85743,7 @@ value = "536";
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig Blk";
+value = "Noto Sans CanAborig Bk";
 }
 );
 interpolationWeight = 190;

--- a/src/NotoSansCanadianAboriginal/NotoSansCanadianAboriginal-MM.glyphs
+++ b/src/NotoSansCanadianAboriginal/NotoSansCanadianAboriginal-MM.glyphs
@@ -85478,7 +85478,7 @@ value = 200;
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig ExtraLight";
+value = "Noto Sans CanAborig ExtLt";
 }
 );
 interpolationWeight = 39;
@@ -85590,7 +85590,7 @@ value = 500;
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig Medium";
+value = "Noto Sans CanAborig Med";
 }
 );
 interpolationWeight = 108;
@@ -85628,7 +85628,7 @@ value = 600;
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig SemiBold";
+value = "Noto Sans CanAborig SemBd";
 }
 );
 interpolationWeight = 128;
@@ -85705,7 +85705,7 @@ value = "536";
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig ExtraBold";
+value = "Noto Sans CanAborig ExtBd";
 }
 );
 interpolationWeight = 169;
@@ -85743,7 +85743,7 @@ value = "536";
 },
 {
 name = styleMapFamilyName;
-value = "Noto Sans CanAborig Black";
+value = "Noto Sans CanAborig Blk";
 }
 );
 interpolationWeight = 190;

--- a/src/NotoSansCanadianAboriginal/NotoSansCanadianAboriginal-MM.glyphs
+++ b/src/NotoSansCanadianAboriginal/NotoSansCanadianAboriginal-MM.glyphs
@@ -811,7 +811,7 @@ date = "2017-11-19 13:14:29 +0000";
 designer = "Monotype Design Team";
 designerURL = "http://www.monotype.com/studio";
 disablesNiceNames = 1;
-familyName = "Noto Sans CanAborig";
+familyName = "Noto Sans Canadian Aboriginal";
 fontMaster = (
 {
 alignmentZones = (
@@ -85440,20 +85440,8 @@ value = (
 );
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = preferredSubfamilyName;
-value = Thin;
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-Thin";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-Thin";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig Thin";
 }
 );
 interpolationWeight = 26;
@@ -85489,20 +85477,8 @@ name = weightClass;
 value = 200;
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = preferredSubfamilyName;
-value = ExtraLight;
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-ExtraLight";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-ExtraLight";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig ExtraLight";
 }
 );
 interpolationWeight = 39;
@@ -85539,20 +85515,8 @@ name = weightClass;
 value = 300;
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = preferredSubfamilyName;
-value = Light;
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-Light";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-Light";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig Light";
 }
 );
 interpolationWeight = 58;
@@ -85589,16 +85553,8 @@ name = weightClass;
 value = 400;
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-Regular";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-Regular";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig";
 }
 );
 interpolationWeight = 90;
@@ -85633,20 +85589,8 @@ name = weightClass;
 value = 500;
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = preferredSubfamilyName;
-value = Medium;
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-Medium";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-Medium";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig Medium";
 }
 );
 interpolationWeight = 108;
@@ -85683,20 +85627,8 @@ name = weightClass;
 value = 600;
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = preferredSubfamilyName;
-value = SemiBold;
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-SemiBold";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-SemiBold";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig SemiBold";
 }
 );
 interpolationWeight = 128;
@@ -85733,16 +85665,8 @@ name = xHeight;
 value = "536";
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-Bold";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-Bold";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig";
 }
 );
 interpolationWeight = 151;
@@ -85780,20 +85704,8 @@ name = xHeight;
 value = "536";
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = preferredSubfamilyName;
-value = ExtraBold;
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-ExtraBold";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-ExtraBold";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig ExtraBold";
 }
 );
 interpolationWeight = 169;
@@ -85830,20 +85742,8 @@ name = xHeight;
 value = "536";
 },
 {
-name = preferredFamilyName;
-value = "Noto Sans Canadian Aboriginal";
-},
-{
-name = preferredSubfamilyName;
-value = Black;
-},
-{
-name = fileName;
-value = "NotoSansCanadianAboriginal-Black";
-},
-{
-name = postscriptFontName;
-value = "NotoSansCanadianAboriginal-Black";
+name = styleMapFamilyName;
+value = "Noto Sans CanAborig Black";
 }
 );
 interpolationWeight = 190;


### PR DESCRIPTION
... for the short "Noto Sans CanAborig".

Same as https://github.com/googlei18n/noto-source/commit/bc5f10d976e71c8d5eb0b48ec9a14bc1b31fa626

Fixes #107